### PR TITLE
Fix for Segmentation fault on processing exit #1

### DIFF
--- a/src/metafs/mim/meta_io_manager.cpp
+++ b/src/metafs/mim/meta_io_manager.cpp
@@ -119,7 +119,7 @@ MetaIoMgr::Close(void)
 void
 MetaIoMgr::Finalize(void)
 {
-    if (finalized == false)
+    if (IsModuleReady() && (finalized == false))
     {
         ioScheduler->ClearHandlerThread(); // exit mioHandler thread
         ioScheduler->ExitThread();         // exit scheduler thread


### PR DESCRIPTION
Defect Analysis Result: Double resource release during exit. 
