### PR TITLE
Add execution of setup script on initiators

### DIFF
--- a/benchmark/2_fio_perf_test/2_1_fio_benchmark_200g.sh
+++ b/benchmark/2_fio_perf_test/2_1_fio_benchmark_200g.sh
@@ -29,6 +29,12 @@ sshpass -p "${INIT_1_PW}" scp ${INIT1_FIO_SCRIPT_FILE} ${INIT1_PARSE_RESULT_FILE
 sshpass -p "${INIT_2_PW}" scp ${INIT2_FIO_SCRIPT_FILE} ${INIT2_PARSE_RESULT_FILE} ${INIT_2_ID}@${INIT_2_IP}:${INIT2_FIO_SCRIPT_DIR}/
 
 echo
+echo "setup_env"
+sshpass -p "${INIT_1_PW}" ssh ${INIT_1_ID}@${INIT_1_IP} "cd ${INIT1_FIO_SCRIPT_DIR}; echo ${INIT_1_PW} | sudo -S nohup ${INIT1_FIO_SCRIPT_DIR}/script/setup_env.sh > /dev/null 2>&1 &"
+sshpass -p "${INIT_2_PW}" ssh ${INIT_2_ID}@${INIT_2_IP} "cd ${INIT2_FIO_SCRIPT_DIR}; echo ${INIT_2_PW} | sudo -S nohup ${INIT2_FIO_SCRIPT_DIR}/script/setup_env.sh > /dev/null 2>&1"
+sleep 2
+
+echo
 echo "seq_write for "$TOT_TIME "sec"
 sshpass -p "${INIT_1_PW}" ssh ${INIT_1_ID}@${INIT_1_IP} "cd ${INIT1_FIO_SCRIPT_DIR}; echo ${INIT_1_PW} | sudo -S nohup ${INIT1_FIO_SCRIPT_DIR}/${INIT1_FIO_SCRIPT_FILE} -w 0 -b 128k -q 4 -o 1 -c ${INIT1_VOL_CNT} -a ${RAMP_TIME} -r ${IO_RUN_TIME} -e ${INIT1_FIO_ENGINE} -i ${TARGET_IP_1} > /dev/null 2>&1 &"
 sshpass -p "${INIT_2_PW}" ssh ${INIT_2_ID}@${INIT_2_IP} "cd ${INIT2_FIO_SCRIPT_DIR}; echo ${INIT_1_PW} | sudo -S nohup ${INIT2_FIO_SCRIPT_DIR}/${INIT2_FIO_SCRIPT_FILE} -w 0 -b 128k -q 4 -o 2 -c ${INIT2_VOL_CNT} -a ${RAMP_TIME} -r ${IO_RUN_TIME} -e ${INIT2_FIO_ENGINE} -i ${TARGET_IP_2} > /dev/null 2>&1"


### PR DESCRIPTION
Modify script to run setup_env.sh on both initiators to make sure user-mode fio run normally right after.