### PR TITLE
[AWIBOF-6010] coverity bug fixed

### DIFF
--- a/src/metafs/mai/metafs_io_api.cpp
+++ b/src/metafs/mai/metafs_io_api.cpp
@@ -47,7 +47,8 @@ MetaFsIoApi::MetaFsIoApi(void)
   isNormal(false),
   ioMgr(nullptr),
   ctrlMgr(nullptr),
-  telemetryPublisher(nullptr)
+  telemetryPublisher(nullptr),
+  concurrentMetaFsTimeInterval(nullptr)
 {
 }
 


### PR DESCRIPTION
Added initialization value for concurrentMetaFsTimeInterval