### PR TITLE
[AWIBOF-6140] upgrade package bugfix

### DIFF
--- a/package/src/DEBIAN/postinst
+++ b/package/src/DEBIAN/postinst
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# libtcmalloc linking
-ln -sf /usr/local/lib/libtcmalloc.so.4.5.3 /usr/local/lib/libtcmalloc.so.4
-ln -sf /usr/local/lib/libtcmalloc.so.4 /usr/local/lib/libtcmalloc.so
-
 # Register CLI man page
 mv /etc/poseidonos-cli* /usr/share/man/man3/
 makewhatis

--- a/package/src/DEBIAN/postrm
+++ b/package/src/DEBIAN/postrm
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# remove pos user library and config files
-rm -rf /usr/local/lib/spdk/
-rm -rf /usr/local/lib/libtcmalloc*
-rm -rf /usr/local/etc/
-rm -rf /etc/pos/
-rm -rf /var/log/pos/


### PR DESCRIPTION
apt install poseidonos.deb 만 해서 upgrade 하려는 시나리오에서 postrm 스크립트로 인한 spdk lib 삭제 버그 수정