### PR TITLE
[AWIBOF-6146] Set TRACE to the default log level for major sink

### DIFF
--- a/src/cli/cli_server.cpp
+++ b/src/cli/cli_server.cpp
@@ -280,7 +280,7 @@ EnableReuseAddr(int sockfd)
             "fd:{}, optval:{}, rc:{}", sockfd, optval, rc);
         return rc;
     }
-    POS_TRACE_INFO(EID(CLI_REUSE_ADDR_ENABLED),
+    POS_TRACE_DEBUG(EID(CLI_REUSE_ADDR_ENABLED),
         "fd:{}, optval:{}, rc:{}", sockfd, optval, rc);
     return 0;
 }
@@ -448,7 +448,7 @@ CLIServer()
                 }
                 else if (cli_fd >= 0)
                 {
-                    POS_TRACE_TRACE(EID(CLI_CLIENT_ACCEPTED), "fd:{}, client_ip:{}, client_port:{}",
+                    POS_TRACE_DEBUG(EID(CLI_CLIENT_ACCEPTED), "fd:{}, client_ip:{}, client_port:{}",
                         cli_fd, inet_ntoa(cli_addr.sin_addr), ntohs(cli_addr.sin_port));
 
                     sock_pool_t* clnt = AddClient(cli_fd);

--- a/src/logger/logger.cpp
+++ b/src/logger/logger.cpp
@@ -93,7 +93,7 @@ Logger::Logger(void)
 
     console_sink->set_level(spdlog::level::trace);
     minor_sink->set_level(spdlog::level::debug);
-    major_sink->set_level(spdlog::level::warn);
+    major_sink->set_level(spdlog::level::trace);
 
     // Console log is always displayed in plain text form
     console_sink->set_pattern(BuildPattern(false));

--- a/tool/cli/script/build_cli.sh
+++ b/tool/cli/script/build_cli.sh
@@ -13,7 +13,7 @@ GOPATH=$(${GO} env | grep GOPATH | awk -F"\"" '{print $2}')
 GOROOT=$(${GO} env | grep GOROOT | awk -F"\"" '{print $2}')
 export PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
 
-mkdir api
+mkdir -p api
 protoc --go_out=api --go_opt=paths=source_relative \
     --go-grpc_out=api --go-grpc_opt=paths=source_relative \
     -I $ROOT_DIR/../../proto cli.proto
@@ -26,7 +26,7 @@ mv ./cli bin/poseidonos-cli
 # Build CLI markdown and manpage documents
 cd docs
 rm markdown manpage -rf
-mkdir markdown manpage
+mkdir -p markdown manpage
 ${GO} build -o ../bin/gen_md gen_md.go
 ${GO} build -o ../bin/gen_man gen_man.go
 chmod +x ../bin/gen_md ../bin/gen_man


### PR DESCRIPTION
Set TRACE log level to the default log level for major sink.

Change the levels of some events from INFO to DEBUG.

Add -p flag to mkdir to prevent error message when the directory exists.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>