### PR TITLE
[AWIBOF-6059] Remove ISegmentCtx implementation in ContextManager

### DIFF
--- a/src/allocator/context_manager/context_manager.h
+++ b/src/allocator/context_manager/context_manager.h
@@ -60,7 +60,7 @@ const int NO_REBUILD_TARGET_USER_SEGMENT = 0;
 
 class ContextIoManager;
 
-class ContextManager : public IContextManager, public ISegmentCtx
+class ContextManager : public IContextManager
 {
 public:
     ContextManager(void) = default;
@@ -87,10 +87,6 @@ public:
     virtual int GetGcThreshold(GcMode mode);
     virtual uint64_t GetStoredContextVersion(int owner);
 
-    virtual void ValidateBlks(VirtualBlks blks) override;
-    virtual void InvalidateBlks(VirtualBlks blks, bool isForced) override;
-    virtual void UpdateOccupiedStripeCount(StripeId lsid) override;
-
     virtual int SetNextSsdLsid(void);
     virtual char* GetContextSectionAddr(int owner, int section);
     virtual int GetContextSectionSize(int owner, int section);
@@ -99,7 +95,7 @@ public:
 
     // TODO (huijeong.kim) remove mixed use of SegmentCtx and ISegmentCtx
     virtual SegmentCtx* GetSegmentCtx(void) { return segmentCtx; }
-    virtual ISegmentCtx* GetISegmentCtx(void) { return this; }
+    virtual ISegmentCtx* GetISegmentCtx(void) { return segmentCtx; }
     virtual AllocatorCtx* GetAllocatorCtx(void) { return allocatorCtx; }
     virtual ContextReplayer* GetContextReplayer(void) { return contextReplayer; }
     virtual GcCtx* GetGcCtx(void) { return gcCtx; }
@@ -107,7 +103,6 @@ public:
 
     virtual BlockAllocationStatus* GetAllocationStatus(void) { return blockAllocStatus; }
 
-    virtual uint32_t GetArrayId(void);
 private:
     void _ResetSegmentStates(void);
 

--- a/src/allocator/context_manager/context_replayer.cpp
+++ b/src/allocator/context_manager/context_replayer.cpp
@@ -109,8 +109,7 @@ void
 ContextReplayer::ReplayStripeFlushed(StripeId userLsid)
 {
     // increase occupied stripe count
-    SegmentId segId = userLsid / addrInfo->GetstripesPerSegment();
-    segmentCtx->IncreaseOccupiedStripeCount(segId);
+    segmentCtx->UpdateOccupiedStripeCount(userLsid);
 }
 
 void

--- a/src/allocator/context_manager/gc_ctx/gc_ctx.cpp
+++ b/src/allocator/context_manager/gc_ctx/gc_ctx.cpp
@@ -72,7 +72,13 @@ GcCtx::SetUrgentThreshold(int inputThreshold)
 }
 
 GcMode
-GcCtx::GetCurrentGcMode(int numFreeSegments)
+GcCtx::GetCurrentGcMode(void)
+{
+    return curGcMode;
+}
+
+GcMode
+GcCtx::UpdateCurrentGcMode(int numFreeSegments)
 {
     pos::GcMode newGcMode = curGcMode;
 

--- a/src/allocator/context_manager/gc_ctx/gc_ctx.h
+++ b/src/allocator/context_manager/gc_ctx/gc_ctx.h
@@ -48,7 +48,8 @@ public:
     int GetUrgentThreshold(void);
     void SetNormalGcThreshold(int inputThreshold);
     void SetUrgentThreshold(int inputThreshold);
-    virtual GcMode GetCurrentGcMode(int numFreeSegments);
+    virtual GcMode GetCurrentGcMode(void);
+    virtual GcMode UpdateCurrentGcMode(int numFreeSegments);
 
     static const int DEFAULT_GC_THRESHOLD = 20;
     static const int DEFAULT_URGENT_THRESHOLD = 5;

--- a/src/allocator/i_context_manager.h
+++ b/src/allocator/i_context_manager.h
@@ -45,7 +45,6 @@ class IContextManager
 {
 public:
     virtual int FlushContexts(EventSmartPtr callback, bool sync) = 0;
-    virtual void UpdateOccupiedStripeCount(StripeId lsid) = 0;
     virtual uint64_t GetStoredContextVersion(int owner) = 0;
 
     virtual SegmentId AllocateFreeSegment(void) = 0;
@@ -59,7 +58,6 @@ public:
 
     virtual SegmentCtx* GetSegmentCtx(void) = 0;
     virtual GcCtx* GetGcCtx(void) = 0;
-    virtual uint32_t GetArrayId(void) = 0;
 };
 
 } // namespace pos

--- a/src/allocator/i_segment_ctx.h
+++ b/src/allocator/i_segment_ctx.h
@@ -40,8 +40,8 @@ class ISegmentCtx
 {
 public:
     virtual void ValidateBlks(VirtualBlks blks) = 0;
-    virtual void InvalidateBlks(VirtualBlks blks, bool isForced) = 0;
-    virtual void UpdateOccupiedStripeCount(StripeId lsid) = 0;
+    virtual bool InvalidateBlks(VirtualBlks blks, bool isForced) = 0;
+    virtual bool UpdateOccupiedStripeCount(StripeId lsid) = 0;
 };
 
 } // namespace pos

--- a/src/cli/array_info_command.cpp
+++ b/src/cli/array_info_command.cpp
@@ -153,7 +153,6 @@ ArrayInfoCommand::_GetGCMode(IGCInfo* gc, string arrayName)
     }
 
     IContextManager* iContextManager = AllocatorServiceSingleton::Instance()->GetIContextManager(arrayName);
-    SegmentCtx* segmentCtx = iContextManager->GetSegmentCtx();
     GcCtx* gcCtx = iContextManager->GetGcCtx();
 
     ComponentsInfo* info = ArrayMgr()->GetInfo(arrayName);
@@ -164,10 +163,7 @@ ArrayInfoCommand::_GetGCMode(IGCInfo* gc, string arrayName)
         return "N/A";
     }
 
-    uint32_t arrayId = iContextManager->GetArrayId();
-    segmentCtx->UpdateGcFreeSegment(arrayId);
-    int numOfFreeSegments = segmentCtx->GetNumOfFreeSegment();
-    GcMode gcMode = gcCtx->GetCurrentGcMode(numOfFreeSegments);
+    GcMode gcMode = gcCtx->GetCurrentGcMode();
 
     std::string strGCMode;
 

--- a/src/gc/copier.cpp
+++ b/src/gc/copier.cpp
@@ -177,10 +177,7 @@ Copier::_CompareThresholdState(void)
     SegmentCtx* segmentCtx = iContextManager->GetSegmentCtx();
     GcCtx* gcCtx = iContextManager->GetGcCtx();
 
-    uint32_t arrayId = iContextManager->GetArrayId();
-    segmentCtx->UpdateGcFreeSegment(arrayId);
-    int numFreeSegments = segmentCtx->GetNumOfFreeSegment();
-    GcMode gcMode = gcCtx->GetCurrentGcMode(numFreeSegments);
+    GcMode gcMode = gcCtx->GetCurrentGcMode();
 
     if ((false == thresholdCheck) || (gcMode != MODE_NO_GC))
     {
@@ -193,6 +190,7 @@ Copier::_CompareThresholdState(void)
             _InitVariables();
             _ChangeEventState(CopierStateType::COPIER_COPY_PREPARE_STATE);
 
+            int numFreeSegments = segmentCtx->GetNumOfFreeSegment();
             POS_TRACE_DEBUG((int)POS_EVENT_ID::GC_GET_VICTIM_SEGMENT,
                 "trigger start, cnt:{}, victimId:{}",
                 numFreeSegments, victimId);

--- a/src/metadata/gc_map_update.cpp
+++ b/src/metadata/gc_map_update.cpp
@@ -72,7 +72,7 @@ GcMapUpdate::_DoSpecificJob(void)
 
     StripeId currentLsid = stripe->GetUserLsid();
     stripeMap->SetLSA(stripe->GetVsid(), stripe->GetUserLsid(), IN_USER_AREA);
-    contextManager->UpdateOccupiedStripeCount(currentLsid);
+    segmentCtx->UpdateOccupiedStripeCount(currentLsid);
 
     uint32_t validCount = mapUpdateInfoList.blockMapUpdateList.size();
     for (auto it : mapUpdateInfoList.blockMapUpdateList)

--- a/src/wbt/set_gc_threshold_wbt_command.cpp
+++ b/src/wbt/set_gc_threshold_wbt_command.cpp
@@ -114,11 +114,8 @@ SetGcThresholdWbtCommand::Execute(Args &argv, JsonElement &elem)
             return returnValue;
         }
 
-        uint32_t arrayId = iContextManager->GetArrayId();
-        segmentCtx->UpdateGcFreeSegment(arrayId);
         int numOfFreeSegments = segmentCtx->GetNumOfFreeSegment();
-
-        if (MODE_URGENT_GC != gcCtx->GetCurrentGcMode(numOfFreeSegments))
+        if (MODE_URGENT_GC != gcCtx->UpdateCurrentGcMode(numOfFreeSegments))
         {
             IBlockAllocator* iBlockAllocator =
                 AllocatorServiceSingleton::Instance()->GetIBlockAllocator(arrayName);

--- a/test/integration-tests/allocator/context_manager_integration_test.cpp
+++ b/test/integration-tests/allocator/context_manager_integration_test.cpp
@@ -225,14 +225,13 @@ TEST(ContextManagerIntegrationTest, UpdateSegmentContext_testIfSegmentOverwritte
 
     // Set valid block count of each segments to 32 for test
     uint32_t maxValidBlkCount = 32;
-    uint32_t stripesPerSegment = 1024;
     ON_CALL(addrInfo, GetblksPerSegment).WillByDefault(Return(maxValidBlkCount));
-    ON_CALL(addrInfo, GetstripesPerSegment).WillByDefault(Return(stripesPerSegment));
+    ON_CALL(addrInfo, GetstripesPerSegment).WillByDefault(Return(STRIPE_PER_SEGMENT));
     for (SegmentId segId = 0; segId < numSegments; segId++)
     {
         VirtualBlks blks = {
             .startVsa = {
-                .stripeId = segId * stripesPerSegment,
+                .stripeId = segId * STRIPE_PER_SEGMENT,
                 .offset = 0},
             .numBlks = maxValidBlkCount};
         segmentCtx->ValidateBlks(blks);

--- a/test/integration-tests/allocator/context_manager_integration_test.cpp
+++ b/test/integration-tests/allocator/context_manager_integration_test.cpp
@@ -67,7 +67,7 @@ TEST(ContextManagerIntegrationTest, DISABLED_GetRebuildTargetSegment_FreeUserDat
     NiceMock<MockRebuildCtx>* rebuildCtx = new NiceMock<MockRebuildCtx>();
 
     // SegmentCtx (Real)
-    SegmentCtx* segmentCtx = new SegmentCtx(nullptr, rebuildCtx, allocatorAddressInfo, gcCtx);
+    SegmentCtx* segmentCtx = new SegmentCtx(nullptr, rebuildCtx, allocatorAddressInfo, gcCtx, 0);
 
     // Start Test
     for (int i = 0; i < TEST_TRIAL; ++i)
@@ -75,11 +75,21 @@ TEST(ContextManagerIntegrationTest, DISABLED_GetRebuildTargetSegment_FreeUserDat
         int nanoSec = std::rand() % 100;
         std::thread th1(&SegmentCtx::GetRebuildTargetSegment, segmentCtx);
         std::this_thread::sleep_for(std::chrono::nanoseconds(nanoSec));
-        std::thread th2(&SegmentCtx::DecreaseValidBlockCount, segmentCtx, 0, 1, false);
+        VirtualBlks blksToInvalidate = {
+            .startVsa = {
+                .stripeId = 0,
+                .offset = 0},
+            .numBlks = 1};
+        std::thread th2(&SegmentCtx::InvalidateBlks, segmentCtx, blksToInvalidate, false);
         th1.join();
         th2.join();
 
-        std::thread th3(&SegmentCtx::DecreaseValidBlockCount, segmentCtx, 0, 1, false);
+        VirtualBlks blksToInvalidate2 = {
+            .startVsa = {
+                .stripeId = 3,
+                .offset = 0},
+            .numBlks = 1};
+        std::thread th3(&SegmentCtx::InvalidateBlks, segmentCtx, blksToInvalidate2, false);
         std::this_thread::sleep_for(std::chrono::nanoseconds(nanoSec));
         std::thread th4(&SegmentCtx::GetRebuildTargetSegment, segmentCtx);
         th3.join();
@@ -203,7 +213,7 @@ TEST(ContextManagerIntegrationTest, UpdateSegmentContext_testIfSegmentOverwritte
     NiceMock<MockBlockAllocationStatus>* blockAllocStatus = new NiceMock<MockBlockAllocationStatus>();
     NiceMock<MockContextReplayer>* contextReplayer = new NiceMock<MockContextReplayer>;
     NiceMock<MockTelemetryPublisher> tp;
-    SegmentCtx* segmentCtx = new SegmentCtx(&tp, rebuildCtx, &addrInfo, gcCtx);
+    SegmentCtx* segmentCtx = new SegmentCtx(&tp, rebuildCtx, &addrInfo, gcCtx, 0);
     ON_CALL(addrInfo, IsUT).WillByDefault(Return(true));
 
     std::mutex allocatorLock;
@@ -215,17 +225,24 @@ TEST(ContextManagerIntegrationTest, UpdateSegmentContext_testIfSegmentOverwritte
 
     // Set valid block count of each segments to 32 for test
     uint32_t maxValidBlkCount = 32;
+    uint32_t stripesPerSegment = 1024;
     ON_CALL(addrInfo, GetblksPerSegment).WillByDefault(Return(maxValidBlkCount));
+    ON_CALL(addrInfo, GetstripesPerSegment).WillByDefault(Return(stripesPerSegment));
     for (SegmentId segId = 0; segId < numSegments; segId++)
     {
-        segmentCtx->IncreaseValidBlockCount(segId, maxValidBlkCount);
+        VirtualBlks blks = {
+            .startVsa = {
+                .stripeId = segId * stripesPerSegment,
+                .offset = 0},
+            .numBlks = maxValidBlkCount};
+        segmentCtx->ValidateBlks(blks);
     }
 
     // When : All stripes in each segment is occupied
     ON_CALL(addrInfo, GetstripesPerSegment).WillByDefault(Return(STRIPE_PER_SEGMENT));
     for (StripeId lsid = 0; lsid < STRIPE_PER_SEGMENT * numSegments; lsid++)
     {
-        contextManager.UpdateOccupiedStripeCount(lsid);
+        segmentCtx->UpdateOccupiedStripeCount(lsid);
     }
 
     // Then: State of occupied segments must be SSD
@@ -248,7 +265,7 @@ TEST(ContextManagerIntegrationTest, UpdateSegmentContext_testIfSegmentOverwritte
             .numBlks = maxValidBlkCount,
         };
 
-        contextManager.InvalidateBlks(blks, false);
+        segmentCtx->InvalidateBlks(blks, false);
     }
 
     // Then: State of overwritten segments must be FREE and occupied stripe count is zero

--- a/test/integration-tests/journal/fake/i_context_manager_mock.h
+++ b/test/integration-tests/journal/fake/i_context_manager_mock.h
@@ -31,7 +31,6 @@ public:
     virtual uint64_t GetStoredContextVersion(int owner) { return 0; }
     virtual SegmentCtx* GetSegmentCtx(void) { return nullptr; }
     virtual GcCtx* GetGcCtx(void) { return nullptr; }
-    virtual uint32_t GetArrayId(void) { return 0; }
 
     IContextManagerMock(void)
     {

--- a/test/unit-tests/allocator/context_manager/context_manager_mock.h
+++ b/test/unit-tests/allocator/context_manager/context_manager_mock.h
@@ -1,5 +1,4 @@
 #include <gmock/gmock.h>
-#include <set>
 #include <string>
 #include <list>
 #include <vector>
@@ -25,9 +24,6 @@ public:
     MOCK_METHOD(std::set<SegmentId>, GetNvramSegmentList, (), (override));
     MOCK_METHOD(int, GetGcThreshold, (GcMode mode), (override));
     MOCK_METHOD(uint64_t, GetStoredContextVersion, (int owner), (override));
-    MOCK_METHOD(void, ValidateBlks, (VirtualBlks blks), (override));
-    MOCK_METHOD(void, InvalidateBlks, (VirtualBlks blks, bool isForced), (override));
-    MOCK_METHOD(void, UpdateOccupiedStripeCount, (StripeId lsid), (override));
     MOCK_METHOD(int, SetNextSsdLsid, (), (override));
     MOCK_METHOD(char*, GetContextSectionAddr, (int owner, int section), (override));
     MOCK_METHOD(int, GetContextSectionSize, (int owner, int section), (override));

--- a/test/unit-tests/allocator/context_manager/context_manager_test.cpp
+++ b/test/unit-tests/allocator/context_manager/context_manager_test.cpp
@@ -92,48 +92,6 @@ TEST(ContextManager, FlushContexts_testFlushStarted)
     EXPECT_LE(0, ret);
 }
 
-TEST(ContextManager, UpdateOccupiedStripeCount_testWhenSegmentIsNotFreed)
-{
-    // given
-    NiceMock<MockAllocatorAddressInfo> addrInfo;
-    NiceMock<MockAllocatorCtx>* allocCtx = new NiceMock<MockAllocatorCtx>();
-    NiceMock<MockSegmentCtx>* segCtx = new NiceMock<MockSegmentCtx>();
-    NiceMock<MockRebuildCtx>* reCtx = new NiceMock<MockRebuildCtx>();
-    NiceMock<MockGcCtx>* gcCtx = new NiceMock<MockGcCtx>();
-    NiceMock<MockBlockAllocationStatus>* blockAllocStatus = new NiceMock<MockBlockAllocationStatus>();
-    NiceMock<MockContextIoManager>* ioManager = new NiceMock<MockContextIoManager>;
-    NiceMock<MockTelemetryPublisher> tc;
-    ContextManager ctxManager(&tc, allocCtx, segCtx, reCtx, gcCtx, blockAllocStatus, ioManager, nullptr, &addrInfo, 0);
-
-    // expect
-    EXPECT_CALL(addrInfo, GetstripesPerSegment).WillOnce(Return(1024));
-    EXPECT_CALL(*segCtx, IncreaseOccupiedStripeCount).WillOnce(Return(false));
-
-    // when
-    ctxManager.UpdateOccupiedStripeCount(5);
-}
-
-TEST(ContextManager, UpdateOccupiedStripeCount_testWhenSegmentFreed)
-{
-    // given
-    NiceMock<MockAllocatorAddressInfo> addrInfo;
-    NiceMock<MockAllocatorCtx>* allocCtx = new NiceMock<MockAllocatorCtx>();
-    NiceMock<MockSegmentCtx>* segCtx = new NiceMock<MockSegmentCtx>();
-    NiceMock<MockRebuildCtx>* reCtx = new NiceMock<MockRebuildCtx>();
-    NiceMock<MockGcCtx>* gcCtx = new NiceMock<MockGcCtx>();
-    NiceMock<MockBlockAllocationStatus>* blockAllocStatus = new NiceMock<MockBlockAllocationStatus>();
-    NiceMock<MockContextIoManager>* ioManager = new NiceMock<MockContextIoManager>;
-    NiceMock<MockTelemetryPublisher> tc;
-    ContextManager ctxManager(&tc, allocCtx, segCtx, reCtx, gcCtx, blockAllocStatus, ioManager, nullptr, &addrInfo, 0);
-
-    // expect
-    EXPECT_CALL(addrInfo, GetstripesPerSegment).WillOnce(Return(1024));
-    EXPECT_CALL(*segCtx, IncreaseOccupiedStripeCount).WillOnce(Return(true));
-
-    // when
-    ctxManager.UpdateOccupiedStripeCount(5);
-}
-
 TEST(ContextManager, AllocateFreeSegment_TestFreeSegmentAllocationByState)
 {
     // given
@@ -528,64 +486,6 @@ TEST(ContextManager, NeedRebuildAgain_TestSimpleGetter)
     ContextManager ctxManager(&tc, allocCtx, segCtx, reCtx, gcCtx, blockAllocStatus, ioManager, nullptr, nullptr, 0);
     // when
     ctxManager.NeedRebuildAgain();
-}
-
-TEST(ContextManager, ValidateBlks_TestSimple)
-{
-    // given
-    NiceMock<MockAllocatorAddressInfo> addrInfo;
-    NiceMock<MockAllocatorCtx>* allocCtx = new NiceMock<MockAllocatorCtx>();
-    NiceMock<MockSegmentCtx>* segCtx = new NiceMock<MockSegmentCtx>();
-    NiceMock<MockRebuildCtx>* reCtx = new NiceMock<MockRebuildCtx>();
-    NiceMock<MockGcCtx>* gcCtx = new NiceMock<MockGcCtx>();
-    NiceMock<MockBlockAllocationStatus>* blockAllocStatus = new NiceMock<MockBlockAllocationStatus>();
-    NiceMock<MockContextIoManager>* ioManager = new NiceMock<MockContextIoManager>;
-    NiceMock<MockTelemetryPublisher> tc;
-    ContextManager sut(&tc, allocCtx, segCtx, reCtx, gcCtx, blockAllocStatus, ioManager, nullptr, &addrInfo, 0);
-
-    // given
-    VirtualBlkAddr vsa = {
-        .stripeId = 120,
-        .offset = 0};
-    VirtualBlks blks = {
-        .startVsa = vsa,
-        .numBlks = 1};
-
-    EXPECT_CALL(addrInfo, GetstripesPerSegment).WillRepeatedly(Return(100));
-    EXPECT_CALL(*segCtx, IncreaseValidBlockCount(1, 1)).Times(1);
-    // when
-    sut.ValidateBlks(blks);
-}
-
-TEST(ContextManager, InvalidateBlks_TestSimpleSetter)
-{
-    // given
-    NiceMock<MockAllocatorAddressInfo> addrInfo;
-    NiceMock<MockAllocatorCtx>* allocCtx = new NiceMock<MockAllocatorCtx>();
-    NiceMock<MockSegmentCtx>* segCtx = new NiceMock<MockSegmentCtx>();
-    NiceMock<MockRebuildCtx>* reCtx = new NiceMock<MockRebuildCtx>();
-    NiceMock<MockGcCtx>* gcCtx = new NiceMock<MockGcCtx>();
-    NiceMock<MockBlockAllocationStatus>* blockAllocStatus = new NiceMock<MockBlockAllocationStatus>();
-    NiceMock<MockContextIoManager>* ioManager = new NiceMock<MockContextIoManager>;
-    NiceMock<MockTelemetryPublisher> tc;
-    ContextManager sut(&tc, allocCtx, segCtx, reCtx, gcCtx, blockAllocStatus, ioManager, nullptr, &addrInfo, 0);
-
-    EXPECT_CALL(addrInfo, GetstripesPerSegment).WillRepeatedly(Return(10));
-
-    VirtualBlkAddr vsa = {
-        .stripeId = 0,
-        .offset = 0};
-    VirtualBlks blks = {
-        .startVsa = vsa,
-        .numBlks = 1};
-    // given 1.
-    EXPECT_CALL(*segCtx, DecreaseValidBlockCount).WillOnce(Return(false));
-    // when 1.
-    sut.InvalidateBlks(blks, false);
-    // given 2.
-    EXPECT_CALL(*segCtx, DecreaseValidBlockCount).WillOnce(Return(true));
-    // when 2.
-    sut.InvalidateBlks(blks, false);
 }
 
 TEST(ContextManager, MakeRebuildTargetSegmentList_TestwithFlushOrwithoutFlush)

--- a/test/unit-tests/allocator/context_manager/context_replayer_test.cpp
+++ b/test/unit-tests/allocator/context_manager/context_replayer_test.cpp
@@ -132,7 +132,6 @@ TEST(ContextReplayer, ReplayStripeFlushed_TestStripeFlushedWithSeveralConditions
 {
     // given
     AllocatorAddressInfo addrInfo;
-    addrInfo.SetstripesPerSegment(10);
     NiceMock<MockAllocatorCtx>* allocCtx = new NiceMock<MockAllocatorCtx>();
     NiceMock<MockSegmentCtx>* segCtx = new NiceMock<MockSegmentCtx>();
     NiceMock<MockRebuildCtx>* reCtx = new NiceMock<MockRebuildCtx>();
@@ -140,7 +139,7 @@ TEST(ContextReplayer, ReplayStripeFlushed_TestStripeFlushedWithSeveralConditions
     ContextReplayer ctxReplayer(allocCtx, segCtx, &addrInfo);
 
     // given
-    EXPECT_CALL(*segCtx, IncreaseOccupiedStripeCount(1)).WillOnce(Return(false));
+    EXPECT_CALL(*segCtx, UpdateOccupiedStripeCount(10));
     // when
     ctxReplayer.ReplayStripeFlushed(10);
 

--- a/test/unit-tests/allocator/context_manager/gc_ctx/gc_ctx_mock.h
+++ b/test/unit-tests/allocator/context_manager/gc_ctx/gc_ctx_mock.h
@@ -10,7 +10,8 @@ class MockGcCtx : public GcCtx
 {
 public:
     using GcCtx::GcCtx;
-    MOCK_METHOD(GcMode, GetCurrentGcMode, (int numFreeSegments), (override));
+    MOCK_METHOD(GcMode, GetCurrentGcMode, (), (override));
+    MOCK_METHOD(GcMode, UpdateCurrentGcMode, (int numFreeSegments), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/allocator/context_manager/gc_ctx/gc_ctx_test.cpp
+++ b/test/unit-tests/allocator/context_manager/gc_ctx/gc_ctx_test.cpp
@@ -16,12 +16,17 @@ TEST(GcCtx, GetCurrentGcMode_TestModeNoGC)
 
     gcCtx.SetNormalGcThreshold(10);
     gcCtx.SetUrgentThreshold(5);
-    gcCtx.GetCurrentGcMode(8);
-    // when
-    gcCtx.GetCurrentGcMode(13);
+
+    // when 1
+    int numFreeSegments = 8;
+    GcMode gcMode = gcCtx.UpdateCurrentGcMode(numFreeSegments);
+
+    // then 2
+    EXPECT_EQ(gcMode, GcMode::MODE_NORMAL_GC);
+    EXPECT_EQ(gcMode, gcCtx.GetCurrentGcMode());
 }
 
-TEST(GcCtx, GetCurrentGcMode_TestGetCurrentGcMode_ByNumberOfFreeSegment)
+TEST(GcCtx, UpdateCurrentGcMode_ByNumberOfFreeSegment)
 {
     // given
     NiceMock<MockBlockAllocationStatus> blockAllocStatus;
@@ -31,35 +36,41 @@ TEST(GcCtx, GetCurrentGcMode_TestGetCurrentGcMode_ByNumberOfFreeSegment)
     gcCtx->SetUrgentThreshold(5);
 
     // when 1.
-    GcMode ret = gcCtx->GetCurrentGcMode(11);
+    int numFreeSegments = 11;
+    GcMode ret = gcCtx->UpdateCurrentGcMode(numFreeSegments);
 
     // then 1.
     EXPECT_EQ(MODE_NO_GC, ret);
 
     // when 2.
-    ret = gcCtx->GetCurrentGcMode(10);
+    numFreeSegments = 10;
+    ret = gcCtx->UpdateCurrentGcMode(numFreeSegments);
     // then 2.
     EXPECT_EQ(MODE_NORMAL_GC, ret);
 
     // when 3.
-    ret = gcCtx->GetCurrentGcMode(9);
+    numFreeSegments = 9;
+    ret = gcCtx->UpdateCurrentGcMode(numFreeSegments);
     // then 3.
     EXPECT_EQ(MODE_NORMAL_GC, ret);
 
     EXPECT_CALL(blockAllocStatus, ProhibitUserBlockAllocation);
     // when 4.
-    ret = gcCtx->GetCurrentGcMode(5);
+    numFreeSegments = 5;
+    ret = gcCtx->UpdateCurrentGcMode(numFreeSegments);
     // then 4.
     EXPECT_EQ(MODE_URGENT_GC, ret);
 
     // when 5.
-    ret = gcCtx->GetCurrentGcMode(4);
+    numFreeSegments = 4;
+    ret = gcCtx->UpdateCurrentGcMode(numFreeSegments);
     // then 5.
     EXPECT_EQ(MODE_URGENT_GC, ret);
 
     EXPECT_CALL(blockAllocStatus, PermitUserBlockAllocation);
     // when 6.
-    ret = gcCtx->GetCurrentGcMode(8);
+    numFreeSegments = 8;
+    ret = gcCtx->UpdateCurrentGcMode(numFreeSegments);
     // then 6.
     EXPECT_EQ(MODE_NORMAL_GC, ret);
 }

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_mock.h
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_mock.h
@@ -23,11 +23,9 @@ public:
     MOCK_METHOD(std::string, GetFilename, (), (override));
     MOCK_METHOD(uint32_t, GetSignature, (), (override));
     MOCK_METHOD(int, GetNumSections, (), (override));
-    MOCK_METHOD(void, IncreaseValidBlockCount, (SegmentId segId, uint32_t cnt), (override));
-    MOCK_METHOD(bool, DecreaseValidBlockCount, (SegmentId segId, uint32_t cnt, bool isForced), (override));
+    MOCK_METHOD(void, MoveToFreeState, (SegmentId segId), (override));
     MOCK_METHOD(uint32_t, GetValidBlockCount, (SegmentId segId), (override));
     MOCK_METHOD(int, GetOccupiedStripeCount, (SegmentId segId), (override));
-    MOCK_METHOD(bool, IncreaseOccupiedStripeCount, (SegmentId segId), (override));
     MOCK_METHOD(SegmentState, GetSegmentState, (SegmentId segId), (override));
     MOCK_METHOD(void, ResetSegmentsStates, (), (override));
     MOCK_METHOD(void, AllocateSegment, (SegmentId segId), (override));
@@ -46,8 +44,9 @@ public:
     MOCK_METHOD(bool, LoadRebuildList, (), (override));
     MOCK_METHOD(void, CopySegmentInfoToBufferforWBT, (WBTAllocatorMetaType type, char* dstBuf), (override));
     MOCK_METHOD(void, CopySegmentInfoFromBufferforWBT, (WBTAllocatorMetaType type, char* dstBuf), (override));
-    MOCK_METHOD(void, UpdateGcFreeSegment, (uint32_t arrayId), (override));
-    MOCK_METHOD(void, MoveToFreeState, (SegmentId segId), (override));
+    MOCK_METHOD(void, ValidateBlks, (VirtualBlks blks), (override));
+    MOCK_METHOD(bool, InvalidateBlks, (VirtualBlks blks, bool isForced), (override));
+    MOCK_METHOD(bool, UpdateOccupiedStripeCount, (StripeId lsid), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/allocator/i_context_manager_mock.h
+++ b/test/unit-tests/allocator/i_context_manager_mock.h
@@ -11,7 +11,6 @@ class MockIContextManager : public IContextManager
 public:
     using IContextManager::IContextManager;
     MOCK_METHOD(int, FlushContexts, (EventSmartPtr callback, bool sync), (override));
-    MOCK_METHOD(void, UpdateOccupiedStripeCount, (StripeId lsid), (override));
     MOCK_METHOD(uint64_t, GetStoredContextVersion, (int owner), (override));
     MOCK_METHOD(SegmentId, AllocateFreeSegment, (), (override));
     MOCK_METHOD(SegmentId, AllocateGCVictimSegment, (), (override));
@@ -23,7 +22,6 @@ public:
     MOCK_METHOD(int, GetGcThreshold, (GcMode mode), (override));
     MOCK_METHOD(SegmentCtx*, GetSegmentCtx, (), (override));
     MOCK_METHOD(GcCtx*, GetGcCtx, (), (override));
-    MOCK_METHOD(uint32_t, GetArrayId, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/allocator/i_segment_ctx_mock.h
+++ b/test/unit-tests/allocator/i_segment_ctx_mock.h
@@ -11,8 +11,8 @@ class MockISegmentCtx : public ISegmentCtx
 public:
     using ISegmentCtx::ISegmentCtx;
     MOCK_METHOD(void, ValidateBlks, (VirtualBlks blks), (override));
-    MOCK_METHOD(void, InvalidateBlks, (VirtualBlks blks, bool isForced), (override));
-    MOCK_METHOD(void, UpdateOccupiedStripeCount, (StripeId lsid), (override));
+    MOCK_METHOD(bool, InvalidateBlks, (VirtualBlks blks, bool isForced), (override));
+    MOCK_METHOD(bool, UpdateOccupiedStripeCount, (StripeId lsid), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/gc/copier_test.cpp
+++ b/test/unit-tests/gc/copier_test.cpp
@@ -170,16 +170,14 @@ protected:
 TEST_F(CopierTestFixture, Execute_NoGcMode)
 {
     // check gc mode when no gc situation
-    int numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_NO_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_NO_GC));
     EXPECT_FALSE(copier->Execute());
 }
 
 TEST_F(CopierTestFixture, Execute_testNormalGcAndGetUnmapSegmentId)
 {
     // check gc mode when normal gc situation and do not find victim segment
-    int numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_NORMAL_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_NORMAL_GC));
     EXPECT_CALL(*iContextManager, AllocateGCVictimSegment()).WillOnce(Return(UNMAP_SEGMENT));
     EXPECT_FALSE(copier->Execute());
 }
@@ -187,8 +185,7 @@ TEST_F(CopierTestFixture, Execute_testNormalGcAndGetUnmapSegmentId)
 TEST_F(CopierTestFixture, Execute_testNormalGcAndGetTestSegmentId)
 {
     // check gc mode when normal gc situation and find victim segment
-    int numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_NORMAL_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_NORMAL_GC));
     EXPECT_CALL(*iContextManager, AllocateGCVictimSegment()).WillOnce(Return(TEST_SEGMENT_1));
     EXPECT_FALSE(copier->Execute());
 }
@@ -196,8 +193,7 @@ TEST_F(CopierTestFixture, Execute_testNormalGcAndGetTestSegmentId)
 TEST_F(CopierTestFixture, Execute_testUrgentGcAndGetTestSegmentId)
 {
     // check gc mode when normal gc situation and find victim segment
-    int numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_URGENT_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_URGENT_GC));
     EXPECT_CALL(*iContextManager, AllocateGCVictimSegment()).WillOnce(Return(TEST_SEGMENT_1));
     EXPECT_FALSE(copier->Execute());
 }
@@ -212,8 +208,7 @@ TEST_F(CopierTestFixture, Execute_testPrepareState)
     }
 
     // check gc mode when normal gc situation and find victim segment
-    int numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_NORMAL_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_NORMAL_GC));
     EXPECT_CALL(*iContextManager, AllocateGCVictimSegment()).WillOnce(Return(TEST_SEGMENT_1));
     EXPECT_FALSE(copier->Execute());
 
@@ -232,8 +227,7 @@ TEST_F(CopierTestFixture, Execute_testCompleteState)
     }
 
     // check gc mode when normal gc situation and find victim segment
-    int numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_NORMAL_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_NORMAL_GC));
     EXPECT_CALL(*iContextManager, AllocateGCVictimSegment()).WillOnce(Return(TEST_SEGMENT_1));
     EXPECT_FALSE(copier->Execute());
 
@@ -262,8 +256,7 @@ TEST_F(CopierTestFixture, Execute_testDisableThresholdCheck)
     }
 
     // check gc mode state and disable threshold check test
-    int numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_NO_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_NO_GC));
     EXPECT_CALL(*iContextManager, AllocateGCVictimSegment()).WillOnce(Return(TEST_SEGMENT_1));
     EXPECT_TRUE(copier->IsEnableThresholdCheck());
     copier->DisableThresholdCheck();
@@ -283,8 +276,7 @@ TEST_F(CopierTestFixture, Execute_testStopWhenPrepareState)
 {
     EXPECT_CALL(*meta, GetGcStripeManager()).WillRepeatedly(Return(gcStripeManager));
     // check gc mode state and disable threshold check test
-    int numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_NORMAL_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_NORMAL_GC));
     EXPECT_CALL(*iContextManager, AllocateGCVictimSegment()).WillOnce(Return(TEST_SEGMENT_1));
     EXPECT_FALSE(copier->Execute());
 
@@ -313,8 +305,7 @@ TEST_F(CopierTestFixture, Execute_testStopWhenCompleteState)
     }
 
     // check gc mode state and disable threshold check test
-    int numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_NORMAL_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_NORMAL_GC));
     EXPECT_CALL(*iContextManager, AllocateGCVictimSegment()).WillOnce(Return(TEST_SEGMENT_1));
     EXPECT_FALSE(copier->Execute());
 
@@ -356,8 +347,7 @@ TEST_F(CopierTestFixture, Execute_testPauseAndResume)
     }
 
     // check gc mode when normal gc situation and find victim segment
-    int numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_NORMAL_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_NORMAL_GC));
     EXPECT_CALL(*iContextManager, AllocateGCVictimSegment()).WillOnce(Return(TEST_SEGMENT_1));
     EXPECT_FALSE(copier->Execute());
 
@@ -398,19 +388,16 @@ TEST_F(CopierTestFixture, Execute_testComplexityScenario)
     }
 
     // check gc mode when no gc situation
-    int numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_NO_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_NO_GC));
     EXPECT_FALSE(copier->Execute());
 
     // check gc mode when normal gc situation and do not find victim segment
-    numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_NORMAL_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_NORMAL_GC));
     EXPECT_CALL(*iContextManager, AllocateGCVictimSegment()).WillOnce(Return(UNMAP_SEGMENT));
     EXPECT_FALSE(copier->Execute());
 
     // check gc mode when normal gc situation and find victim segment
-    numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_NORMAL_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_NORMAL_GC));
     EXPECT_CALL(*iContextManager, AllocateGCVictimSegment()).WillOnce(Return(TEST_SEGMENT_1));
     EXPECT_FALSE(copier->Execute());
 
@@ -428,8 +415,7 @@ TEST_F(CopierTestFixture, Execute_testComplexityScenario)
     EXPECT_FALSE(copier->Execute());
 
     // check gc mode when normal gc situation and find victim segment
-    numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillOnce(Return(GcMode::MODE_URGENT_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillOnce(Return(GcMode::MODE_URGENT_GC));
     EXPECT_CALL(*iContextManager, AllocateGCVictimSegment()).WillOnce(Return(TEST_SEGMENT_2));
     EXPECT_FALSE(copier->Execute());
 
@@ -450,8 +436,7 @@ TEST_F(CopierTestFixture, Execute_testComplexityScenario)
     // gc resume test
     copier->Resume();
     EXPECT_FALSE(copier->IsPaused());
-    numFreeSegments = segCtx->GetNumOfFreeSegment();
-    EXPECT_CALL(*gcCtx, GetCurrentGcMode(numFreeSegments)).WillRepeatedly(Return(GcMode::MODE_NO_GC));
+    EXPECT_CALL(*gcCtx, GetCurrentGcMode).WillRepeatedly(Return(GcMode::MODE_NO_GC));
     EXPECT_FALSE(copier->Execute());
 
     // gc stop test

--- a/test/unit-tests/metadata/gc_map_update_test.cpp
+++ b/test/unit-tests/metadata/gc_map_update_test.cpp
@@ -72,7 +72,7 @@ TEST(GcMapUpdate, _DoSpecificJob_testWithValidMapAndInvalidSegBlks)
 
     ON_CALL(stripe, GetUserLsid).WillByDefault(Return(userLsid));
     ON_CALL(stripe, GetVsid).WillByDefault(Return(vsid));
-    EXPECT_CALL(contextManager, UpdateOccupiedStripeCount(userLsid)).Times(1);
+    EXPECT_CALL(segmentCtx, UpdateOccupiedStripeCount(userLsid)).Times(1);
 
     for (auto it : mapUpdateInfoList.blockMapUpdateList)
     {


### PR DESCRIPTION
- Make SegmentCtx to implement ISegmentCtx interface
- Split GetCurrentGcMode and UpdateCurrentGcMode to remove not really needed
 segment ctx call from outside

Signed-off-by: Huijeong Kim <huijeong.kim@samsung.com>