### PR TITLE
[AWIBOF-5691] Fix MetaFsIoScheduler to refer to extents when splitting the request

### DIFF
--- a/src/metafs/lib/metafs_pool.h
+++ b/src/metafs/lib/metafs_pool.h
@@ -37,6 +37,7 @@
 #include <list>
 #include <memory>
 #include <stdexcept>
+#include <unordered_set>
 #include <vector>
 
 namespace pos
@@ -48,7 +49,8 @@ class MetaFsPool
 public:
     MetaFsPool(void) = delete;
     explicit MetaFsPool(const size_t poolSize)
-    : CAPACITY(poolSize)
+    : CAPACITY(poolSize),
+      usedCount_(0)
     {
         all_.reserve(CAPACITY);
     }
@@ -73,11 +75,15 @@ public:
             return nullptr;
         auto item = free_.front();
         free_.pop_front();
+        used_.emplace(item);
+        usedCount_++;
         return item;
     }
     virtual void Release(T item)
     {
         free_.emplace_back(item);
+        used_.erase(item);
+        usedCount_--;
     }
     virtual size_t GetCapacity(void) const
     {
@@ -96,5 +102,7 @@ private:
     const size_t CAPACITY;
     std::list<T> free_;
     std::vector<T> all_;
+    std::unordered_set<T> used_;
+    std::size_t usedCount_;
 };
 } // namespace pos

--- a/src/metafs/mim/metafs_io_request.cpp
+++ b/src/metafs/mim/metafs_io_request.cpp
@@ -208,4 +208,33 @@ MetaFsIoRequest::GetLogString(void) const
     log.append(", priority: " + (int)priority);
     return log;
 }
+
+MetaLpnType
+MetaFsIoRequest::GetStartLpn(void) const
+{
+    MetaLpnType start = 0;
+    MetaLpnType offsetInLpn = byteOffsetInFile / fileCtx->chunkSize;
+
+    for (int i = 0; i < extentsCount; ++i)
+    {
+        int64_t result = offsetInLpn - extents[i].GetCount();
+        if (result < 0)
+        {
+            start = extents[i].GetStartLpn() + offsetInLpn;
+            break;
+        }
+        offsetInLpn -= extents[i].GetCount();
+    }
+
+    return start;
+}
+
+size_t
+MetaFsIoRequest::GetRequestLpnCount(void) const
+{
+    size_t startLpn = byteOffsetInFile / fileCtx->chunkSize;
+    size_t endLpn = (byteOffsetInFile + byteSize - 1) / fileCtx->chunkSize;
+
+    return endLpn - startLpn + 1;
+}
 } // namespace pos

--- a/src/metafs/mim/metafs_io_request.h
+++ b/src/metafs/mim/metafs_io_request.h
@@ -33,16 +33,17 @@
 #pragma once
 
 #include <string>
+
 #include "meta_storage_specific.h"
 #include "metafs_common.h"
 #include "metafs_mutex.h"
 #include "metafs_spinlock.h"
 #include "os_header.h"
-#include "src/metafs/include/meta_file_context.h"
 #include "src/bio/volume_io.h"
-#include "src/metafs/include/meta_file_extent.h"
-#include "src/metafs/common/metafs_stopwatch.h"
 #include "src/meta_file_intf/meta_file_include.h"
+#include "src/metafs/common/metafs_stopwatch.h"
+#include "src/metafs/include/meta_file_context.h"
+#include "src/metafs/include/meta_file_extent.h"
 
 namespace pos
 {
@@ -85,6 +86,8 @@ enum class IoRequestStage
     Create,
     Enqueue,
     Dequeue,
+    EnqueueToRetryQ,
+    DequeueToRetryQ,
     Complete,
     Count
 };
@@ -111,6 +114,8 @@ public:
         return retryFlag;
     }
     virtual std::string GetLogString(void) const;
+    virtual MetaLpnType GetStartLpn(void) const;
+    virtual size_t GetRequestLpnCount(void) const;
 
     MetaIoRequestType reqType;
     MetaIoMode ioMode;

--- a/src/metafs/mim/metafs_io_scheduler.cpp
+++ b/src/metafs/mim/metafs_io_scheduler.cpp
@@ -47,11 +47,21 @@ MetaFsIoScheduler::MetaFsIoScheduler(const int threadId, const int coreId,
     TelemetryPublisher* tp)
 : MetaFsIoHandlerBase(threadId, coreId, threadName),
   TOTAL_CORE_COUNT(totalCoreCount),
-  MIO_CORE_COUNT(CPU_COUNT(&mioCoreSet)),
   MIO_CORE_SET(mioCoreSet),
+  mioCoreCount_(CPU_COUNT(&mioCoreSet)),
   config_(config),
   tp_(tp),
-  cpuStallCnt_(0)
+  cpuStallCnt_(0),
+  currentReqMsg_(nullptr),
+  chunkSize_(0),
+  fileBaseLpn_(0),
+  startLpn_(0),
+  currentLpn_(0),
+  requestCount_(0),
+  remainCount_(0),
+  extentsCount_(0),
+  currentExtent_(0),
+  extents_(nullptr)
 {
 }
 
@@ -80,73 +90,139 @@ MetaFsIoScheduler::ExitThread(void)
 }
 
 void
-MetaFsIoScheduler::IssueRequest(MetaFsIoRequest* reqMsg)
+MetaFsIoScheduler::_SetRequestCount(int count)
 {
-    FileSizeType chunkSize = reqMsg->fileCtx->chunkSize;
-    uint64_t byteOffset = 0;
-    MetaLpnType fileBaseLpn = reqMsg->fileCtx->fileBaseLpn;
-    MetaLpnType startLpn = fileBaseLpn + (reqMsg->byteOffsetInFile / chunkSize);
-    MetaLpnType endLpn = fileBaseLpn + ((reqMsg->byteOffsetInFile + reqMsg->byteSize - 1) / chunkSize);
-
-    // set the request count to process the callback count
-    if (MetaIoMode::Async == reqMsg->ioMode)
+    if (MetaIoMode::Async == currentReqMsg_->ioMode)
     {
-        ((MetaFsAioCbCxt*)reqMsg->aiocb)->SetCallbackCount(endLpn - startLpn + 1);
+        ((MetaFsAioCbCxt*)currentReqMsg_->aiocb)->SetCallbackCount(count);
     }
     else
     {
-        reqMsg->originalMsg->requestCount = endLpn - startLpn + 1;
+        currentReqMsg_->originalMsg->requestCount = count;
     }
+}
 
-    for (MetaLpnType idx = startLpn; idx <= endLpn; idx++)
+void
+MetaFsIoScheduler::_SetCurrentContext(MetaFsIoRequest* reqMsg)
+{
+    currentReqMsg_ = reqMsg;
+
+    chunkSize_ = currentReqMsg_->fileCtx->chunkSize;
+    fileBaseLpn_ = currentReqMsg_->fileCtx->fileBaseLpn;
+    startLpn_ = reqMsg->GetStartLpn();
+    currentLpn_ = startLpn_;
+    requestCount_ = reqMsg->GetRequestLpnCount();
+    remainCount_ = requestCount_;
+    extentsCount_ = currentReqMsg_->fileCtx->extentsCount;
+    extents_ = currentReqMsg_->fileCtx->extents;
+
+    // set the request count to process the callback count
+    _SetRequestCount(requestCount_);
+}
+
+void
+MetaFsIoScheduler::_ClearCurrentContext(void)
+{
+    currentReqMsg_ = nullptr;
+    chunkSize_ = 0;
+    fileBaseLpn_ = 0;
+    startLpn_ = 0;
+    currentLpn_ = 0;
+    requestCount_ = 0;
+    remainCount_ = 0;
+    extentsCount_ = 0;
+    currentExtent_ = 0;
+    extents_ = nullptr;
+}
+
+void
+MetaFsIoScheduler::_UpdateCurrentLpnToNextExtent(void)
+{
+    if (currentLpn_ > extents_[currentExtent_].GetLast())
+    {
+        ++currentExtent_;
+        currentLpn_ = extents_[currentExtent_].GetStartLpn();
+    }
+}
+
+void
+MetaFsIoScheduler::_UpdateCurrentExtent(void)
+{
+    while (currentExtent_ < extentsCount_)
+    {
+        if (currentLpn_ <= extents_[currentExtent_].GetLast())
+        {
+            break;
+        }
+        ++currentExtent_;
+    }
+}
+
+void
+MetaFsIoScheduler::IssueRequest(MetaFsIoRequest* reqMsg)
+{
+    uint64_t byteOffset = 0;
+    bool isFirstLpn = true;
+
+    _SetCurrentContext(reqMsg);
+    _UpdateCurrentExtent();
+
+    while (remainCount_)
     {
         // reqMsg     : only for meta scheduler, not meta handler thread
         // cloneReqMsg: new copy, sent to meta handler thread by scheduler
         // reqMsg->originalMsg: from a user thread
-        MetaFsIoRequest* cloneReqMsg = new MetaFsIoRequest(*reqMsg);
+        MetaFsIoRequest* cloneReqMsg = new MetaFsIoRequest(*currentReqMsg_);
 
         // 1st
-        if (idx == startLpn)
+        if (isFirstLpn)
         {
-            cloneReqMsg->buf = reqMsg->buf;
-            cloneReqMsg->byteOffsetInFile = reqMsg->byteOffsetInFile;
-            if (chunkSize < (reqMsg->byteSize + (reqMsg->byteOffsetInFile % chunkSize)))
+            isFirstLpn = false;
+            cloneReqMsg->buf = currentReqMsg_->buf;
+            cloneReqMsg->byteOffsetInFile = currentReqMsg_->byteOffsetInFile;
+            if (chunkSize_ < (currentReqMsg_->byteSize + (currentReqMsg_->byteOffsetInFile % chunkSize_)))
             {
-                cloneReqMsg->byteSize = chunkSize - (reqMsg->byteOffsetInFile % chunkSize);
+                cloneReqMsg->byteSize = chunkSize_ - (currentReqMsg_->byteOffsetInFile % chunkSize_);
             }
             else
             {
-                cloneReqMsg->byteSize = reqMsg->byteSize;
+                cloneReqMsg->byteSize = currentReqMsg_->byteSize;
             }
         }
         // last
-        else if (idx == endLpn)
+        else if (remainCount_ == 1)
         {
-            cloneReqMsg->buf = (FileBufType)((uint64_t)reqMsg->buf + byteOffset);
-            cloneReqMsg->byteOffsetInFile = reqMsg->byteOffsetInFile + byteOffset;
-            cloneReqMsg->byteSize = reqMsg->byteSize - byteOffset;
+            cloneReqMsg->buf = (FileBufType)((uint64_t)currentReqMsg_->buf + byteOffset);
+            cloneReqMsg->byteOffsetInFile = currentReqMsg_->byteOffsetInFile + byteOffset;
+            cloneReqMsg->byteSize = currentReqMsg_->byteSize - byteOffset;
         }
         else
         {
-            cloneReqMsg->buf = (FileBufType)((uint64_t)reqMsg->buf + byteOffset);
-            cloneReqMsg->byteOffsetInFile = reqMsg->byteOffsetInFile + byteOffset;
-            cloneReqMsg->byteSize = chunkSize;
+            cloneReqMsg->buf = (FileBufType)((uint64_t)currentReqMsg_->buf + byteOffset);
+            cloneReqMsg->byteOffsetInFile = currentReqMsg_->byteOffsetInFile + byteOffset;
+            cloneReqMsg->byteSize = chunkSize_;
         }
 
         byteOffset += cloneReqMsg->byteSize;
-        cloneReqMsg->baseMetaLpn = idx;
+        cloneReqMsg->baseMetaLpn = currentLpn_;
 
-        metaIoWorkerList_[idx % MIO_CORE_COUNT]->EnqueueNewReq(cloneReqMsg);
+        metaIoWorkerList_[currentLpn_ % mioCoreCount_]->EnqueueNewReq(cloneReqMsg);
+
+        ++currentLpn_;
+        --remainCount_;
+        _UpdateCurrentLpnToNextExtent();
     }
 
     // delete msg instance, this instance was only for meta scheduler
     delete reqMsg;
+
+    _ClearCurrentContext();
 }
 
 void
 MetaFsIoScheduler::EnqueueNewReq(MetaFsIoRequest* reqMsg)
 {
-    ioMultiQ.Enqueue(reqMsg, reqMsg->priority);
+    ioMultiQ_.Enqueue(reqMsg, reqMsg->priority);
 }
 
 bool
@@ -199,7 +275,7 @@ MetaFsIoScheduler::_CreateMioThread(void)
 {
     const std::string fileName = "MioHandler";
     uint32_t handlerId = 0;
-    int availableMioCoreCnt = MIO_CORE_COUNT;
+    int availableMioCoreCnt = CPU_COUNT(&MIO_CORE_SET);
     for (uint32_t coreId = 0; coreId < TOTAL_CORE_COUNT; ++coreId)
     {
         if (CPU_ISSET(coreId, &MIO_CORE_SET))
@@ -224,8 +300,15 @@ MetaFsIoScheduler::_CreateMioThread(void)
     {
         POS_TRACE_ERROR((int)POS_EVENT_ID::MFS_ERROR_MESSAGE,
             "The Count of created MioHandler: {}, expected count: {}",
-            MIO_CORE_COUNT - availableMioCoreCnt, MIO_CORE_COUNT);
+            mioCoreCount_ - availableMioCoreCnt, mioCoreCount_);
     }
+}
+
+void
+MetaFsIoScheduler::RegisterMetaIoWorkerForTest(ScalableMetaIoWorker* metaIoWorker)
+{
+    metaIoWorkerList_.emplace_back(metaIoWorker);
+    mioCoreCount_ = metaIoWorkerList_.size();
 }
 
 void
@@ -255,6 +338,6 @@ MetaFsIoScheduler::Execute(void)
 MetaFsIoRequest*
 MetaFsIoScheduler::_FetchPendingNewReq(void)
 {
-    return ioMultiQ.Dequeue();
+    return ioMultiQ_.Dequeue();
 }
 } // namespace pos

--- a/src/metafs/mim/metafs_io_scheduler.h
+++ b/src/metafs/mim/metafs_io_scheduler.h
@@ -45,6 +45,7 @@ namespace pos
 class MetaFsIoScheduler : public MetaFsIoHandlerBase
 {
 public:
+    MetaFsIoScheduler(void) = delete;
     explicit MetaFsIoScheduler(const int threadId, const int coreId,
         const int totalCoreCount, const std::string& threadName,
         const cpu_set_t mioCoreSet, MetaFsConfigManager* config,
@@ -61,19 +62,36 @@ public:
     virtual void ExitThread(void) override;
     void Execute(void);
 
+    void RegisterMetaIoWorkerForTest(ScalableMetaIoWorker* metaIoWorker);
+
 private:
     MetaFsIoRequest* _FetchPendingNewReq(void);
     void _CreateMioThread(void);
+    void _SetRequestCount(int count);
+    void _SetCurrentContext(MetaFsIoRequest* reqMsg);
+    void _ClearCurrentContext(void);
+    void _UpdateCurrentLpnToNextExtent(void);
+    void _UpdateCurrentExtent(void);
 
     std::vector<ScalableMetaIoWorker*> metaIoWorkerList_;
     const size_t TOTAL_CORE_COUNT;
-    const size_t MIO_CORE_COUNT;
     const cpu_set_t MIO_CORE_SET;
+    size_t mioCoreCount_;
     MetaFsConfigManager* config_;
     TelemetryPublisher* tp_;
     size_t cpuStallCnt_;
     const size_t MAX_CPU_STALL_COUNT = 1000;
 
-    MetaFsIoMultilevelQ<MetaFsIoRequest*, RequestPriority> ioMultiQ;
+    MetaFsIoMultilevelQ<MetaFsIoRequest*, RequestPriority> ioMultiQ_;
+    MetaFsIoRequest* currentReqMsg_;
+    FileSizeType chunkSize_;
+    MetaLpnType fileBaseLpn_;
+    MetaLpnType startLpn_;
+    MetaLpnType currentLpn_;
+    size_t requestCount_;
+    size_t remainCount_;
+    int extentsCount_;
+    int currentExtent_;
+    MetaFileExtent* extents_;
 };
 } // namespace pos

--- a/src/metafs/mim/mfs_io_range_overlap_chker.cpp
+++ b/src/metafs/mim/mfs_io_range_overlap_chker.cpp
@@ -80,6 +80,7 @@ MetaFsIoRangeOverlapChker::FreeLockContext(uint64_t startLpn, bool isRead)
 
     if (true != isRead)
     {
+        assert(outstandingIoMap->IsSetBit(startLpn) == true);
         outstandingIoMap->ClearBit(startLpn);
     }
 }
@@ -91,6 +92,7 @@ MetaFsIoRangeOverlapChker::PushReqToRangeLockMap(MetaFsIoRequest* newReq)
     {
         if (newReq->reqType == MetaIoRequestType::Write)
         {
+            assert(outstandingIoMap->IsSetBit(newReq->baseMetaLpn) == false);
             outstandingIoMap->SetBit(newReq->baseMetaLpn);
         }
     }

--- a/src/metafs/mim/mio.cpp
+++ b/src/metafs/mim/mio.cpp
@@ -65,26 +65,6 @@ Mio::~Mio(void)
 {
 }
 
-MetaLpnType
-Mio::_GetCalculateStartLpn(MetaFsIoRequest* ioReq)
-{
-    MetaLpnType start = 0;
-    MetaLpnType offsetInLpn = ioReq->byteOffsetInFile / fileDataChunkSize;
-
-    for (int i = 0; i < ioReq->extentsCount; ++i)
-    {
-        int64_t result = offsetInLpn - ioReq->extents[i].GetCount();
-        if (result < 0)
-        {
-            start = ioReq->extents[i].GetStartLpn() + offsetInLpn;
-            break;
-        }
-        offsetInLpn -= ioReq->extents[i].GetCount();
-    }
-
-    return start;
-}
-
 void
 Mio::Setup(MetaFsIoRequest* ioReq, MetaLpnType baseLpn, MetaStorageSubsystem* metaStorage)
 {
@@ -97,7 +77,7 @@ Mio::Setup(MetaFsIoRequest* ioReq, MetaLpnType baseLpn, MetaStorageSubsystem* me
 
     fileDataChunkSize = MetaFsIoConfig::DEFAULT_META_PAGE_DATA_CHUNK_SIZE;
     opCode = ioOpcodeMap[static_cast<uint32_t>(originReq->reqType)];
-    startLpn = _GetCalculateStartLpn(ioReq);
+    startLpn = ioReq->GetStartLpn();
 
     MFS_TRACE_DEBUG((int)POS_EVENT_ID::MFS_DEBUG_MESSAGE,
         "[Mio ][SetupMio   ] type={}, req.tagId={}, fileOffset={}, baseLpn={}, startLpn={}",

--- a/src/metafs/mim/mio.h
+++ b/src/metafs/mim/mio.h
@@ -137,7 +137,6 @@ protected:
     Mpio* _AllocMpio(MpioIoInfo& mpioIoInfo, bool partialIO);
     void _HandleMpioDone(void* data);
     MpioType _LookupMpioType(MetaIoRequestType type);
-    MetaLpnType _GetCalculateStartLpn(MetaFsIoRequest* ioReq);
 
     MetaFsIoRequest* originReq;
     MetaIoOpcode opCode;

--- a/src/metafs/mim/mio_handler.cpp
+++ b/src/metafs/mim/mio_handler.cpp
@@ -189,6 +189,7 @@ MioHandler::_HandleIoSQ(void)
 
     if (_IsRangeOverlapConflicted(reqMsg) || _IsPendedRange(reqMsg))
     {
+        reqMsg->StoreTimestamp(IoRequestStage::EnqueueToRetryQ);
         _PushToRetry(reqMsg);
         return;
     }
@@ -291,6 +292,7 @@ MioHandler::_DiscoverIORangeOverlap(void)
                     pendingIoRetryQ.size());
 
                 _RegisterRangeLockInfo(pendingIoReq);
+                pendingIoReq->StoreTimestamp(IoRequestStage::DequeueToRetryQ);
                 ExecuteMio(*mio);
             }
         }
@@ -317,6 +319,7 @@ MioHandler::_ExecutePendedIo(MetaFsIoRequest* reqMsg)
         if (reqMsg->arrayId == msg->arrayId)
         {
             reqList->push_back(msg);
+            msg->StoreTimestamp(IoRequestStage::DequeueToRetryQ);
             pendingIoRetryQ.erase(it++);
         }
         else

--- a/src/metafs/mim/scalable_meta_io_worker.cpp
+++ b/src/metafs/mim/scalable_meta_io_worker.cpp
@@ -36,6 +36,16 @@
 
 namespace pos
 {
+// for test
+ScalableMetaIoWorker::ScalableMetaIoWorker(void)
+: MetaFsIoHandlerBase(0, 0, "Test"),
+  topHalf_(nullptr),
+  bottomHalf_(nullptr),
+  tp_(nullptr),
+  needToDeleteTp_(false)
+{
+}
+
 ScalableMetaIoWorker::ScalableMetaIoWorker(const int threadId, const int coreId,
     const std::string& threadName, MetaFsConfigManager* config,
     TelemetryPublisher* tp)
@@ -68,8 +78,17 @@ ScalableMetaIoWorker::~ScalableMetaIoWorker(void)
         tp_ = nullptr;
     }
 
-    delete topHalf_;
-    delete bottomHalf_;
+    if (topHalf_)
+    {
+        delete topHalf_;
+        topHalf_ = nullptr;
+    }
+
+    if (bottomHalf_)
+    {
+        delete bottomHalf_;
+        bottomHalf_ = nullptr;
+    }
 }
 
 void

--- a/src/metafs/mim/scalable_meta_io_worker.h
+++ b/src/metafs/mim/scalable_meta_io_worker.h
@@ -46,8 +46,9 @@ class MetaFsConfigManager;
 class ScalableMetaIoWorker : public MetaFsIoHandlerBase
 {
 public:
-    ScalableMetaIoWorker(void) = delete;
-    explicit ScalableMetaIoWorker(const int threadId, const int coreId,
+    // for test
+    ScalableMetaIoWorker(void);
+    ScalableMetaIoWorker(const int threadId, const int coreId,
         const std::string& threadName, MetaFsConfigManager* configManager,
         TelemetryPublisher* tp = nullptr);
     virtual ~ScalableMetaIoWorker(void);
@@ -56,7 +57,7 @@ public:
     virtual bool AddArrayInfo(const int arrayId, const MaxMetaLpnMapPerMetaStorage& map) override;
     virtual bool RemoveArrayInfo(const int arrayId) override;
     void Execute(void);
-    void EnqueueNewReq(MetaFsIoRequest* reqMsg);
+    virtual void EnqueueNewReq(MetaFsIoRequest* reqMsg);
 
 private:
     MioHandler* topHalf_;

--- a/test/unit-tests/metafs/mim/metafs_io_scheduler_test.cpp
+++ b/test/unit-tests/metafs/mim/metafs_io_scheduler_test.cpp
@@ -1,51 +1,438 @@
+/*
+ *   BSD LICENSE
+ *   Copyright (c) 2021 Samsung Electronics Corporation
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Samsung Electronics Corporation nor the names of
+ *       its contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include "src/metafs/mim/metafs_io_scheduler.h"
 
 #include <gtest/gtest.h>
 
+#include <map>
+
+#include "src/metafs/mim/metafs_io_request.h"
+#include "src/metafs/mim/scalable_meta_io_worker.h"
+
 namespace pos
 {
-TEST(MetaFsIoScheduler, MetaFsIoScheduler_)
+class ScalableMetaIoWorkerTester : public ScalableMetaIoWorker
 {
+public:
+    ScalableMetaIoWorkerTester(void)
+    {
+    }
+    virtual void EnqueueNewReq(MetaFsIoRequest* req)
+    {
+        countMap.insert({req->baseMetaLpn, req->byteSize});
+    }
+    void ClearCount(void)
+    {
+        countMap.clear();
+    }
+    size_t GetRequestedCount(void)
+    {
+        return countMap.size();
+    }
+    size_t GetRequestedSize(void)
+    {
+        size_t size = 0;
+        for (auto& lpnInfo : countMap)
+        {
+            size += lpnInfo.second;
+        }
+        return size;
+    }
+    MetaLpnType GetTheFirstLpn(void)
+    {
+        return countMap.begin()->first;
+    }
+    MetaLpnType GetTheLastLpn(void)
+    {
+        return (countMap.rbegin())->first;
+    }
+
+private:
+    std::map<MetaLpnType, size_t> countMap;
+};
+
+TEST(MetaFsIoScheduler, IssueRequest_testIfAnAlignedRequestCreatesOneRequest)
+{
+    // given
+    ScalableMetaIoWorkerTester metaIoWorker;
+    MetaFileExtent extents;
+    extents.SetStartLpn(0);
+    extents.SetCount(1024);
+    cpu_set_t mioCoreSet;
+    CPU_SET(0, &mioCoreSet);
+    MetaFsIoScheduler scheduler(0, 0, 0, "Test", mioCoreSet, nullptr, nullptr);
+    scheduler.RegisterMetaIoWorkerForTest(&metaIoWorker);
+    MetaFileContext fileCtx;
+    fileCtx.chunkSize = 4032;
+    fileCtx.fileBaseLpn = 0;
+    fileCtx.extentsCount = 1;
+    fileCtx.extents = &extents;
+    MetaFsIoRequest originReq;
+    MetaFsIoRequest* req;
+
+    // when
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 0;
+    req->byteSize = 4032;
+
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 1);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 1);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 0);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 0);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 4032);
+
+    // when
+    metaIoWorker.ClearCount();
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 4032;
+    req->byteSize = 4032;
+
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 1);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 1);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 1);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 1);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 4032);
+
+    // when
+    metaIoWorker.ClearCount();
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 4032;
+    req->byteSize = 2016;
+
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 1);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 1);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 1);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 1);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 2016);
 }
 
-TEST(MetaFsIoScheduler, ClearHandlerThread_)
+TEST(MetaFsIoScheduler, IssueRequest_testIfAnUnalignedRequestCreatesTwoRequests)
 {
+    // given
+    ScalableMetaIoWorkerTester metaIoWorker;
+    MetaFileExtent extents;
+    extents.SetStartLpn(0);
+    extents.SetCount(1024);
+    cpu_set_t mioCoreSet;
+    CPU_SET(0, &mioCoreSet);
+    MetaFsIoScheduler scheduler(0, 0, 0, "Test", mioCoreSet, nullptr, nullptr);
+    scheduler.RegisterMetaIoWorkerForTest(&metaIoWorker);
+    MetaFileContext fileCtx;
+    fileCtx.chunkSize = 4032;
+    fileCtx.fileBaseLpn = 0;
+    fileCtx.extentsCount = 1;
+    fileCtx.extents = &extents;
+    MetaFsIoRequest originReq;
+    MetaFsIoRequest* req;
+
+    // when
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 0;
+    req->byteSize = 4032 + 2016;
+
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 2);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 2);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 0);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 1);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 4032 + 2016);
+
+    // when
+    metaIoWorker.ClearCount();
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 2016;
+    req->byteSize = 4032;
+
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 2);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 2);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 0);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 1);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 4032);
+
+    // when
+    metaIoWorker.ClearCount();
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 4032;
+    req->byteSize = 4032 + 2016;
+
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 2);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 2);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 1);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 2);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 4032 + 2016);
 }
 
-TEST(MetaFsIoScheduler, ClearQ_)
+TEST(MetaFsIoScheduler, IssueRequest_testIfABigAlignedRequestCreatesManyRequests)
 {
+    // given
+    ScalableMetaIoWorkerTester metaIoWorker;
+    MetaFileExtent extents;
+    extents.SetStartLpn(43082495);
+    extents.SetCount(2048);
+    cpu_set_t mioCoreSet;
+    CPU_SET(0, &mioCoreSet);
+    MetaFsIoScheduler scheduler(0, 0, 0, "Test", mioCoreSet, nullptr, nullptr);
+    scheduler.RegisterMetaIoWorkerForTest(&metaIoWorker);
+    MetaFileContext fileCtx;
+    fileCtx.chunkSize = 4032;
+    fileCtx.fileBaseLpn = 43082495;
+    fileCtx.extentsCount = 1;
+    fileCtx.extents = &extents;
+    MetaFsIoRequest originReq;
+    MetaFsIoRequest* req;
+
+    // when
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 0;
+    req->byteSize = 4032 * 1048; // 1048 lpns
+
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 1048);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 1048);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 43082495);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 43082495 + 1048 - 1);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 4032 * 1048);
 }
 
-TEST(MetaFsIoScheduler, RegisterMioHandler_)
+TEST(MetaFsIoScheduler, IssueRequest_testForProcessingRequestsForFilesWithMultiExtentSimple)
 {
+    // given
+    ScalableMetaIoWorkerTester metaIoWorker;
+    MetaFileExtent extents[3];
+    extents[0].SetStartLpn(5);
+    extents[0].SetCount(5);
+    extents[1].SetStartLpn(20);
+    extents[1].SetCount(10);
+    extents[2].SetStartLpn(40);
+    extents[2].SetCount(5);
+    cpu_set_t mioCoreSet;
+    CPU_SET(0, &mioCoreSet);
+    MetaFsIoScheduler scheduler(0, 0, 0, "Test", mioCoreSet, nullptr, nullptr);
+    scheduler.RegisterMetaIoWorkerForTest(&metaIoWorker);
+    MetaFileContext fileCtx;
+    fileCtx.chunkSize = 4032;
+    fileCtx.fileBaseLpn = 5;
+    fileCtx.extentsCount = 3;
+    fileCtx.extents = &extents[0];
+    MetaFsIoRequest originReq;
+    MetaFsIoRequest* req;
+
+    // when, 1st
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 4032;
+    req->byteSize = 4032; // lpn 6
+
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 1);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 1);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 6);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 6);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 4032);
+
+    // when, 2nd
+    metaIoWorker.ClearCount();
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 4032 * 2;
+    req->byteSize = 4032 * 6; // lpn 7,8,9,20,21,22
+
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 6);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 6);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 7);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 22);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 4032 * 6);
+
+    // when, 3rd
+    metaIoWorker.ClearCount();
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 4032 * 4;
+    req->byteSize = 4032 * 12; // lpn 9,20...29,40
+
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 12);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 12);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 9);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 40);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 4032 * 12);
 }
 
-TEST(MetaFsIoScheduler, IssueRequest_)
+TEST(MetaFsIoScheduler, IssueRequest_testForProcessingRequestsForFilesWithMultiExtent)
 {
-}
+    // given
+    ScalableMetaIoWorkerTester metaIoWorker;
+    MetaFileExtent extents[3];
+    extents[0].SetStartLpn(43082495);
+    extents[0].SetCount(1048);
+    extents[1].SetStartLpn(43085111);
+    extents[1].SetCount(2088);
+    extents[2].SetStartLpn(43089807);
+    extents[2].SetCount(512);
+    cpu_set_t mioCoreSet;
+    CPU_SET(0, &mioCoreSet);
+    MetaFsIoScheduler scheduler(0, 0, 0, "Test", mioCoreSet, nullptr, nullptr);
+    scheduler.RegisterMetaIoWorkerForTest(&metaIoWorker);
+    MetaFileContext fileCtx;
+    fileCtx.chunkSize = 4032;
+    fileCtx.fileBaseLpn = 43082495;
+    fileCtx.extentsCount = 3;
+    fileCtx.extents = &extents[0];
+    MetaFsIoRequest originReq;
+    MetaFsIoRequest* req;
 
-TEST(MetaFsIoScheduler, EnqueueNewReq_)
-{
-}
+    // when, 1st
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 4032; // from 2nd lpn (43082495 + 1)
+    req->byteSize = 4032;         // to 2nd lpn (43082495 + 1)
 
-TEST(MetaFsIoScheduler, GetMioHandlerCount_)
-{
-}
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 1);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 1);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 43082495 + 1);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 43082495 + 1);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 4032);
 
-TEST(MetaFsIoScheduler, StartThread_)
-{
-}
+    // when, 2nd
+    metaIoWorker.ClearCount();
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 4032 * 2; // from 3rd lpn (43082495 + 2)
+    req->byteSize = 4032 * 1024;      // to 1026th lpn (43082495 + 1025)
 
-TEST(MetaFsIoScheduler, Execute_)
-{
-}
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 4128768 / 4032);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 4128768 / 4032);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 43082495 + 2);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 43082495 + 2 + 1024 - 1);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 4128768);
 
-TEST(MetaFsIoScheduler, _GetCoreId_)
-{
-}
+    // when, 3rd
+    metaIoWorker.ClearCount();
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 4032 * 1026; // from 1027th lpn (43082495 + 1026)
+    req->byteSize = 4032 * 1024;         // to 1002nd of next extent (43085111 + 1001)
 
-TEST(MetaFsIoScheduler, _FetchPendingNewReq_)
-{
-}
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 4128768 / 4032);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 4128768 / 4032);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 43083521);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 43085111 + 1001);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 4128768);
 
+    // when, 4th
+    metaIoWorker.ClearCount();
+    req = new MetaFsIoRequest;
+    req->fileCtx = &fileCtx;
+    req->extents = req->fileCtx->extents;
+    req->extentsCount = req->fileCtx->extentsCount;
+    req->originalMsg = &originReq;
+    req->byteOffsetInFile = 4032 * 2050; // from 1003rd lpn of 2nd extent (43085111 + 1002)
+    req->byteSize = 4032 * 1024;         // to 2026th of the extent (43085111 + 2025)
+
+    // then
+    scheduler.IssueRequest(req);
+    EXPECT_EQ(originReq.requestCount, 4128768 / 4032);
+    EXPECT_EQ(metaIoWorker.GetRequestedCount(), 4128768 / 4032);
+    EXPECT_EQ(metaIoWorker.GetTheFirstLpn(), 43085111 + 1002);
+    EXPECT_EQ(metaIoWorker.GetTheLastLpn(), 43085111 + 2025);
+    EXPECT_EQ(metaIoWorker.GetRequestedSize(), 4128768);
+}
 } // namespace pos

--- a/test/unit-tests/metafs/mim/scalable_meta_io_worker_mock.h
+++ b/test/unit-tests/metafs/mim/scalable_meta_io_worker_mock.h
@@ -1,8 +1,36 @@
-#include <gmock/gmock.h>
+/*
+ *   BSD LICENSE
+ *   Copyright (c) 2021 Samsung Electronics Corporation
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Samsung Electronics Corporation nor the names of
+ *       its contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
-#include <list>
-#include <string>
-#include <vector>
+#include <gmock/gmock.h>
 
 #include "src/metafs/mim/scalable_meta_io_worker.h"
 
@@ -13,6 +41,7 @@ class MockScalableMetaIoWorker : public ScalableMetaIoWorker
 public:
     using ScalableMetaIoWorker::ScalableMetaIoWorker;
     MOCK_METHOD(void, StartThread, (), (override));
+    MOCK_METHOD(void, EnqueueNewReq, (MetaFsIoRequest * reqMsg));
 };
 
 } // namespace pos


### PR DESCRIPTION
meta io scheduler가 extent를 고려하여 request를 나누도록 수정하였습니다.