### PR TITLE
[AWIBOF-6320] Add RAID6 to CLI

### DIFF
--- a/doc/guides/cli/poseidonos-cli_array_create.md
+++ b/doc/guides/cli/poseidonos-cli_array_create.md
@@ -9,7 +9,7 @@ Create an array for PoseidonOS.
 
 Syntax: 
 	poseidonos-cli array create (--array-name | -a) ArrayName (--buffer | -b) DeviceName 
-	(--data-devs | -d) DeviceNameList (--spare | -s) DeviceName [--raid RAID0 | RAID5 | RAID10] 
+	(--data-devs | -d) DeviceNameList (--spare | -s) DeviceName [--raid RAID0 | RAID5 | RAID10 | RAID6] 
 	[--no-raid]
 
 Example: 

--- a/tool/cli/cmd/arraycmds/create_array.go
+++ b/tool/cli/cmd/arraycmds/create_array.go
@@ -25,7 +25,7 @@ Create an array for PoseidonOS.
 
 Syntax: 
 	poseidonos-cli array create (--array-name | -a) ArrayName (--buffer | -b) DeviceName 
-	(--data-devs | -d) DeviceNameList (--spare | -s) DeviceName [--raid RAID0 | RAID5 | RAID10] 
+	(--data-devs | -d) DeviceNameList (--spare | -s) DeviceName [--raid RAID0 | RAID5 | RAID10 | RAID6] 
 	[--no-raid]
 
 Example: 

--- a/tool/cli/cmd/pos_cli_syntax.ebnf
+++ b/tool/cli/cmd/pos_cli_syntax.ebnf
@@ -62,6 +62,8 @@ RaidType =
   | "raid0"
   | "RAID10"
   | "raid10"
+  | "RAID6"
+  | "raid6"
   ] ;
 
 SubsystemNQN = Letter , { Letter | Digit | "-" | "_" } ;


### PR DESCRIPTION
Add RAID6 to CLI.

Add RAID6 option to CLI client for future support.

Signed-off-by: Junghyun Hong <jh34.hong@samsung.com>