### PR TITLE
[AWIBOF-6325] Disable gRPC in CLI

### DIFF
--- a/tool/cli/cmd/globals/flags.go
+++ b/tool/cli/cmd/globals/flags.go
@@ -5,4 +5,4 @@ var IsJSONReq = false
 var IsJSONRes = false
 var IsTestingReqBld = false // True indicates the command is being executed in unit-testing mode.
 var DisplayUnit = false     // Display unit (MB, GB, TB, ...) when true
-var EnableGrpc = true
+var EnableGrpc = false


### PR DESCRIPTION
Disable gRPC in CLI.

Currently, it is under development to change the communication
protocl for CLI from socket to gRPC. The problem is, timing issues
occur because some commands use gRPC and other commands use socket
(there are two CLI servers currently).

Therefore, until all the protocol is changed for every CLI command,
we disable the gRPC in CLI.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>