### PR TITLE
[AWIBOF-6320] Add RAID6 option to CLI array commands

### DIFF
--- a/doc/guides/cli/poseidonos-cli_array_autocreate.md
+++ b/doc/guides/cli/poseidonos-cli_array_autocreate.md
@@ -15,11 +15,11 @@ Syntax:
 	(--num-data-devs | -d) Number [(--num-spare | -s) Number] [--raid RaidType]
 	[--no-raid] [--no-buffer]
 
-Example 1 (full flags): 
+Example 1 (without specifying RAID - default RAID level is used): 
 	poseidonos-cli array autocreate --array-name Array0 --buffer uram0 --num-data-devs 3 --num-spare 1
 
-Example 2 (abbreviated flags): 	
-	poseidonos-cli array autocreate -a Array1 -b uram0 -d 4 -s 1 -r RAID6
+Example 2 (creating an array using RAID6): 	
+	poseidonos-cli array autocreate --array-name Array0 --buffer uram0 --num-data-devs 3 --num-spare 1 --raid RAID6
           
 
 ```

--- a/doc/guides/cli/poseidonos-cli_array_autocreate.md
+++ b/doc/guides/cli/poseidonos-cli_array_autocreate.md
@@ -15,8 +15,10 @@ Syntax:
 	(--num-data-devs | -d) Number [(--num-spare | -s) Number] [--raid RaidType]
 	[--no-raid] [--no-buffer]
 
-Example: 
+Example 1 (full flags): 
 	poseidonos-cli array autocreate --array-name Array0 --buffer uram0 --num-data-devs 3 --num-spare 1
+
+Example 2 (abbreviated flags): 	
 	poseidonos-cli array autocreate -a Array1 -b uram0 -d 4 -s 1 -r RAID6
           
 

--- a/doc/guides/cli/poseidonos-cli_array_autocreate.md
+++ b/doc/guides/cli/poseidonos-cli_array_autocreate.md
@@ -17,6 +17,7 @@ Syntax:
 
 Example: 
 	poseidonos-cli array autocreate --array-name Array0 --buffer uram0 --num-data-devs 3 --num-spare 1
+	poseidonos-cli array autocreate -a Array1 -b uram0 -d 4 -s 1 -r RAID6
           
 
 ```

--- a/doc/guides/cli/poseidonos-cli_array_create.md
+++ b/doc/guides/cli/poseidonos-cli_array_create.md
@@ -12,14 +12,14 @@ Syntax:
 	(--data-devs | -d) DeviceNameList (--spare | -s) DeviceName [--raid RAID0 | RAID5 | RAID10 | RAID6] 
 	[--no-raid]
 
-Example 1 (full flags):  
+Example 1 (creating an array with RAID5):  
 	poseidonos-cli array create --array-name Array0 --buffer device0 
 	--data-devs nvme-device0,nvme-device1,nvme-device2,nvme-device3 --spare nvme-device4 --raid RAID5
 	
-Eample 2 (abbreviated flags): 	
-	poseidonos-cli array create -a Array0 -buffer device0 
-	-d nvme-device0,nvme-device1,nvme-device2,nvme-device3 -s nvme-device4 -r RAID6
-          
+Eample 2 (creating an array with RAID6): 	
+	poseidonos-cli array create --array-name Array0 --buffer device0 
+	--data-devs nvme-device0,nvme-device1,nvme-device2,nvme-device3 --spare nvme-device4 --raid RAID6
+
 
 ```
 poseidonos-cli array create [flags]

--- a/doc/guides/cli/poseidonos-cli_array_create.md
+++ b/doc/guides/cli/poseidonos-cli_array_create.md
@@ -12,9 +12,11 @@ Syntax:
 	(--data-devs | -d) DeviceNameList (--spare | -s) DeviceName [--raid RAID0 | RAID5 | RAID10 | RAID6] 
 	[--no-raid]
 
-Example: 
+Example 1 (full flags):  
 	poseidonos-cli array create --array-name Array0 --buffer device0 
 	--data-devs nvme-device0,nvme-device1,nvme-device2,nvme-device3 --spare nvme-device4 --raid RAID5
+	
+Eample 2 (abbreviated flags): 	
 	poseidonos-cli array create -a Array0 -buffer device0 
 	-d nvme-device0,nvme-device1,nvme-device2,nvme-device3 -s nvme-device4 -r RAID6
           

--- a/doc/guides/cli/poseidonos-cli_array_create.md
+++ b/doc/guides/cli/poseidonos-cli_array_create.md
@@ -15,6 +15,8 @@ Syntax:
 Example: 
 	poseidonos-cli array create --array-name Array0 --buffer device0 
 	--data-devs nvme-device0,nvme-device1,nvme-device2,nvme-device3 --spare nvme-device4 --raid RAID5
+	poseidonos-cli array create -a Array0 -buffer device0 
+	-d nvme-device0,nvme-device1,nvme-device2,nvme-device3 -s nvme-device4 -r RAID6
           
 
 ```

--- a/src/include/raid_type.h
+++ b/src/include/raid_type.h
@@ -45,6 +45,7 @@ enum class RaidTypeEnum
     RAID0,
     RAID5,
     RAID10,
+    RAID6,
     TYPE_COUNT,
 };
 

--- a/tool/cli/cmd/arraycmds/autocreate_array.go
+++ b/tool/cli/cmd/arraycmds/autocreate_array.go
@@ -29,8 +29,10 @@ Syntax:
 	(--num-data-devs | -d) Number [(--num-spare | -s) Number] [--raid RaidType]
 	[--no-raid] [--no-buffer]
 
-Example: 
+Example 1 (full flags): 
 	poseidonos-cli array autocreate --array-name Array0 --buffer uram0 --num-data-devs 3 --num-spare 1
+
+Example 2 (abbreviated flags): 	
 	poseidonos-cli array autocreate -a Array1 -b uram0 -d 4 -s 1 -r RAID6
           `,
 

--- a/tool/cli/cmd/arraycmds/autocreate_array.go
+++ b/tool/cli/cmd/arraycmds/autocreate_array.go
@@ -31,6 +31,7 @@ Syntax:
 
 Example: 
 	poseidonos-cli array autocreate --array-name Array0 --buffer uram0 --num-data-devs 3 --num-spare 1
+	poseidonos-cli array autocreate -a Array1 -b uram0 -d 4 -s 1 -r RAID6
           `,
 
 	Run: func(cmd *cobra.Command, args []string) {

--- a/tool/cli/cmd/arraycmds/autocreate_array.go
+++ b/tool/cli/cmd/arraycmds/autocreate_array.go
@@ -33,7 +33,7 @@ Example 1 (without specifying RAID - default RAID level is used):
 	poseidonos-cli array autocreate --array-name Array0 --buffer uram0 --num-data-devs 3 --num-spare 1
 
 Example 2 (creating an array using RAID6): 	
-	poseidonos-cli array autocreate --array-name Array0 --buffer uram0 --num-data-devs 3 --num-spaer 1 --raid RAID6
+	poseidonos-cli array autocreate --array-name Array0 --buffer uram0 --num-data-devs 3 --num-spare 1 --raid RAID6
           `,
 
 	Run: func(cmd *cobra.Command, args []string) {

--- a/tool/cli/cmd/arraycmds/autocreate_array.go
+++ b/tool/cli/cmd/arraycmds/autocreate_array.go
@@ -29,11 +29,11 @@ Syntax:
 	(--num-data-devs | -d) Number [(--num-spare | -s) Number] [--raid RaidType]
 	[--no-raid] [--no-buffer]
 
-Example 1 (full flags): 
+Example 1 (without specifying RAID - default RAID level is used): 
 	poseidonos-cli array autocreate --array-name Array0 --buffer uram0 --num-data-devs 3 --num-spare 1
 
-Example 2 (abbreviated flags): 	
-	poseidonos-cli array autocreate -a Array1 -b uram0 -d 4 -s 1 -r RAID6
+Example 2 (creating an array using RAID6): 	
+	poseidonos-cli array autocreate --array-name Array0 --buffer uram0 --num-data-devs 3 --num-spaer 1 --raid RAID6
           `,
 
 	Run: func(cmd *cobra.Command, args []string) {

--- a/tool/cli/cmd/arraycmds/create_array.go
+++ b/tool/cli/cmd/arraycmds/create_array.go
@@ -28,14 +28,14 @@ Syntax:
 	(--data-devs | -d) DeviceNameList (--spare | -s) DeviceName [--raid RAID0 | RAID5 | RAID10 | RAID6] 
 	[--no-raid]
 
-Example 1 (full flags):  
+Example 1 (creating an array with RAID5):  
 	poseidonos-cli array create --array-name Array0 --buffer device0 
 	--data-devs nvme-device0,nvme-device1,nvme-device2,nvme-device3 --spare nvme-device4 --raid RAID5
 	
-Eample 2 (abbreviated flags): 	
-	poseidonos-cli array create -a Array0 -buffer device0 
-	-d nvme-device0,nvme-device1,nvme-device2,nvme-device3 -s nvme-device4 -r RAID6
-          `,
+Eample 2 (creating an array with RAID6): 	
+	poseidonos-cli array create --array-name Array0 --buffer device0 
+	--data-devs nvme-device0,nvme-device1,nvme-device2,nvme-device3 --spare nvme-device4 --raid RAID6
+`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 

--- a/tool/cli/cmd/arraycmds/create_array.go
+++ b/tool/cli/cmd/arraycmds/create_array.go
@@ -28,9 +28,11 @@ Syntax:
 	(--data-devs | -d) DeviceNameList (--spare | -s) DeviceName [--raid RAID0 | RAID5 | RAID10 | RAID6] 
 	[--no-raid]
 
-Example: 
+Example 1 (full flags):  
 	poseidonos-cli array create --array-name Array0 --buffer device0 
 	--data-devs nvme-device0,nvme-device1,nvme-device2,nvme-device3 --spare nvme-device4 --raid RAID5
+	
+Eample 2 (abbreviated flags): 	
 	poseidonos-cli array create -a Array0 -buffer device0 
 	-d nvme-device0,nvme-device1,nvme-device2,nvme-device3 -s nvme-device4 -r RAID6
           `,

--- a/tool/cli/cmd/arraycmds/create_array.go
+++ b/tool/cli/cmd/arraycmds/create_array.go
@@ -31,6 +31,8 @@ Syntax:
 Example: 
 	poseidonos-cli array create --array-name Array0 --buffer device0 
 	--data-devs nvme-device0,nvme-device1,nvme-device2,nvme-device3 --spare nvme-device4 --raid RAID5
+	poseidonos-cli array create -a Array0 -buffer device0 
+	-d nvme-device0,nvme-device1,nvme-device2,nvme-device3 -s nvme-device4 -r RAID6
           `,
 
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Add RAID6 options and examples to CLI array commands.

Add RAID6 options and examples to CREATEARRAY and AUTOCREATEARRAY commands for futher support.

Signed-off-by: Junghyun Hong <jh34.hong@samsung.com>