### PR TITLE
[AWIBOF-6360] Add LISTHAVOLUME command

### DIFF
--- a/doc/guides/cli/poseidonos-cli_cluster.md
+++ b/doc/guides/cli/poseidonos-cli_cluster.md
@@ -46,4 +46,5 @@ poseidonos-cli cluster [flags]
 
 * [poseidonos-cli](poseidonos-cli.md)	 - poseidonos-cli - A command-line interface for PoseidonOS
 * [poseidonos-cli cluster ln](poseidonos-cli_cluster_ln.md)	 - List all nodes in the system.
+* [poseidonos-cli cluster lv](poseidonos-cli_cluster_lv.md)	 - List all volumes in the cluster.
 

--- a/doc/guides/cli/poseidonos-cli_cluster_lv.md
+++ b/doc/guides/cli/poseidonos-cli_cluster_lv.md
@@ -1,0 +1,39 @@
+## poseidonos-cli cluster lv
+
+List all volumes in the cluster.
+
+### Synopsis
+
+
+List all nodes in the cluster.
+
+Syntax:
+	poseidonos-cli cluster lv
+          
+
+```
+poseidonos-cli cluster lv [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for lv
+```
+
+### Options inherited from parent commands
+
+```
+      --debug         Print response for debug.
+      --fs string     Field separator for the output. (default "|")
+      --ip string     Set IPv4 address to PoseidonOS for this command. (default "127.0.0.1")
+      --json-req      Print request in JSON form.
+      --json-res      Print response in JSON form.
+      --port string   Set the port number to PoseidonOS for this command. (default "18716")
+      --unit          Display unit (B, KB, MB, ...) when displaying capacity.
+```
+
+### SEE ALSO
+
+* [poseidonos-cli cluster](poseidonos-cli_cluster.md)	 - Cluster commands for PoseidonOS.
+

--- a/proto/cli.proto
+++ b/proto/cli.proto
@@ -548,3 +548,28 @@ message ListNodeResponse {
 	Result result = 3;
 	PosInfo info = 4;
 }
+
+message ListHaVolumeRequest {
+	string command = 1;
+	string rid = 2;
+	string requestor = 3;
+}
+
+message ListHaVolumeResponse {
+	string command = 1;
+	string rid = 2;
+	message Result {
+		Status status = 1;
+		message Volume {
+			int32 id = 1;
+			string name = 2;
+			string nodeName = 3;
+			string arrayName = 4;
+			int64 size = 5;
+			string lastseen = 6;
+		}
+		repeated Volume data = 2;
+	}
+	Result result = 3;
+	PosInfo info = 4;
+}

--- a/proto/generated/cpp/cli.pb.cc
+++ b/proto/generated/cpp/cli.pb.cc
@@ -1156,8 +1156,67 @@ struct ListNodeResponseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT ListNodeResponseDefaultTypeInternal _ListNodeResponse_default_instance_;
+constexpr ListHaVolumeRequest::ListHaVolumeRequest(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : command_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , rid_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , requestor_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string){}
+struct ListHaVolumeRequestDefaultTypeInternal {
+  constexpr ListHaVolumeRequestDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~ListHaVolumeRequestDefaultTypeInternal() {}
+  union {
+    ListHaVolumeRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT ListHaVolumeRequestDefaultTypeInternal _ListHaVolumeRequest_default_instance_;
+constexpr ListHaVolumeResponse_Result_Volume::ListHaVolumeResponse_Result_Volume(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : name_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , nodename_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , arrayname_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , lastseen_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , size_(PROTOBUF_LONGLONG(0))
+  , id_(0){}
+struct ListHaVolumeResponse_Result_VolumeDefaultTypeInternal {
+  constexpr ListHaVolumeResponse_Result_VolumeDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~ListHaVolumeResponse_Result_VolumeDefaultTypeInternal() {}
+  union {
+    ListHaVolumeResponse_Result_Volume _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT ListHaVolumeResponse_Result_VolumeDefaultTypeInternal _ListHaVolumeResponse_Result_Volume_default_instance_;
+constexpr ListHaVolumeResponse_Result::ListHaVolumeResponse_Result(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : data_()
+  , status_(nullptr){}
+struct ListHaVolumeResponse_ResultDefaultTypeInternal {
+  constexpr ListHaVolumeResponse_ResultDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~ListHaVolumeResponse_ResultDefaultTypeInternal() {}
+  union {
+    ListHaVolumeResponse_Result _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT ListHaVolumeResponse_ResultDefaultTypeInternal _ListHaVolumeResponse_Result_default_instance_;
+constexpr ListHaVolumeResponse::ListHaVolumeResponse(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : command_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , rid_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , result_(nullptr)
+  , info_(nullptr){}
+struct ListHaVolumeResponseDefaultTypeInternal {
+  constexpr ListHaVolumeResponseDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~ListHaVolumeResponseDefaultTypeInternal() {}
+  union {
+    ListHaVolumeResponse _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT ListHaVolumeResponseDefaultTypeInternal _ListHaVolumeResponse_default_instance_;
 }  // namespace grpc_cli
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_cli_2eproto[82];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_cli_2eproto[86];
 static constexpr ::PROTOBUF_NAMESPACE_ID::EnumDescriptor const** file_level_enum_descriptors_cli_2eproto = nullptr;
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_cli_2eproto = nullptr;
 
@@ -1816,6 +1875,41 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_cli_2eproto::offsets[] PROTOBU
   PROTOBUF_FIELD_OFFSET(::grpc_cli::ListNodeResponse, rid_),
   PROTOBUF_FIELD_OFFSET(::grpc_cli::ListNodeResponse, result_),
   PROTOBUF_FIELD_OFFSET(::grpc_cli::ListNodeResponse, info_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeRequest, command_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeRequest, rid_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeRequest, requestor_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse_Result_Volume, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse_Result_Volume, id_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse_Result_Volume, name_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse_Result_Volume, nodename_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse_Result_Volume, arrayname_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse_Result_Volume, size_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse_Result_Volume, lastseen_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse_Result, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse_Result, status_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse_Result, data_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse, command_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse, rid_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse, result_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse, info_),
 };
 static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, 10, sizeof(::grpc_cli::Status)},
@@ -1900,6 +1994,10 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 630, -1, sizeof(::grpc_cli::ListNodeResponse_Result_Node)},
   { 638, -1, sizeof(::grpc_cli::ListNodeResponse_Result)},
   { 645, -1, sizeof(::grpc_cli::ListNodeResponse)},
+  { 654, -1, sizeof(::grpc_cli::ListHaVolumeRequest)},
+  { 662, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result_Volume)},
+  { 673, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result)},
+  { 680, -1, sizeof(::grpc_cli::ListHaVolumeResponse)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -1985,6 +2083,10 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListNodeResponse_Result_Node_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListNodeResponse_Result_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListNodeResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListHaVolumeRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListHaVolumeResponse_Result_Volume_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListHaVolumeResponse_Result_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListHaVolumeResponse_default_instance_),
 };
 
 const char descriptor_table_protodef_cli_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
@@ -2179,63 +2281,74 @@ const char descriptor_table_protodef_cli_2eproto[] PROTOBUF_SECTION_VARIABLE(pro
   "o\032\224\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli."
   "Status\0224\n\004data\030\002 \003(\0132&.grpc_cli.ListNode"
   "Response.Result.Node\0322\n\004Node\022\014\n\004name\030\001 \001"
-  "(\t\022\n\n\002ip\030\002 \001(\t\022\020\n\010lastseen\030\003 \001(\t2\362\016\n\006Pos"
-  "Cli\022_\n\nSystemInfo\022\033.grpc_cli.SystemInfoR"
-  "equest\032\034.grpc_cli.SystemInfoResponse\"\026\202\323"
-  "\344\223\002\020\022\016/v1/systeminfo\022_\n\nSystemStop\022\033.grp"
-  "c_cli.SystemStopRequest\032\034.grpc_cli.Syste"
-  "mStopResponse\"\026\202\323\344\223\002\020\022\016/v1/systemstop\022}\n"
-  "\021GetSystemProperty\022\".grpc_cli.GetSystemP"
-  "ropertyRequest\032#.grpc_cli.GetSystemPrope"
-  "rtyResponse\"\037\202\323\344\223\002\031\022\027/v1/get_system_prop"
-  "erty\022\205\001\n\021SetSystemProperty\022\".grpc_cli.Se"
-  "tSystemPropertyRequest\032#.grpc_cli.SetSys"
-  "temPropertyResponse\"\'\202\323\344\223\002!\022\037/v1/set_sys"
-  "tem_property/{level}\022p\n\016StartTelemetry\022\037"
-  ".grpc_cli.StartTelemetryRequest\032 .grpc_c"
-  "li.StartTelemetryResponse\"\033\202\323\344\223\002\025\022\023/v1/s"
-  "tart_telemetry\022l\n\rStopTelemetry\022\036.grpc_c"
-  "li.StopTelemetryRequest\032\037.grpc_cli.StopT"
-  "elemetryResponse\"\032\202\323\344\223\002\024\022\022/v1/stop_telem"
-  "etry\022P\n\rResetEventWrr\022\036.grpc_cli.ResetEv"
-  "entWrrRequest\032\037.grpc_cli.ResetEventWrrRe"
-  "sponse\022A\n\010ResetMbr\022\031.grpc_cli.ResetMbrRe"
-  "quest\032\032.grpc_cli.ResetMbrResponse\022S\n\016Sto"
-  "pRebuilding\022\037.grpc_cli.StopRebuildingReq"
-  "uest\032 .grpc_cli.StopRebuildingResponse\022S"
-  "\n\016UpdateEventWrr\022\037.grpc_cli.UpdateEventW"
-  "rrRequest\032 .grpc_cli.UpdateEventWrrRespo"
-  "nse\022W\n\010AddSpare\022\031.grpc_cli.AddSpareReque"
-  "st\032\032.grpc_cli.AddSpareResponse\"\024\202\323\344\223\002\016\"\014"
-  "/v1/addspare\022c\n\013RemoveSpare\022\034.grpc_cli.R"
-  "emoveSpareRequest\032\035.grpc_cli.RemoveSpare"
-  "Response\"\027\202\323\344\223\002\021\"\017/v1/removespare\022c\n\013Cre"
-  "ateArray\022\034.grpc_cli.CreateArrayRequest\032\035"
-  ".grpc_cli.CreateArrayResponse\"\027\202\323\344\223\002\021\"\017/"
-  "v1/createarray\022s\n\017AutocreateArray\022 .grpc"
-  "_cli.AutocreateArrayRequest\032!.grpc_cli.A"
-  "utocreateArrayResponse\"\033\202\323\344\223\002\025\"\023/v1/auto"
-  "createarray\022d\n\013DeleteArray\022\034.grpc_cli.De"
-  "leteArrayRequest\032\035.grpc_cli.DeleteArrayR"
-  "esponse\"\030\202\323\344\223\002\022\"\020/v1/deletearray/\022_\n\nMou"
-  "ntArray\022\033.grpc_cli.MountArrayRequest\032\034.g"
-  "rpc_cli.MountArrayResponse\"\026\202\323\344\223\002\020\"\016/v1/"
-  "mountarray\022g\n\014UnmountArray\022\035.grpc_cli.Un"
-  "mountArrayRequest\032\036.grpc_cli.UnmountArra"
-  "yResponse\"\030\202\323\344\223\002\022\"\020/v1/unmountarray\022[\n\tL"
-  "istArray\022\032.grpc_cli.ListArrayRequest\032\033.g"
-  "rpc_cli.ListArrayResponse\"\025\202\323\344\223\002\017\"\r/v1/l"
-  "istarray\022[\n\tArrayInfo\022\032.grpc_cli.ArrayIn"
-  "foRequest\032\033.grpc_cli.ArrayInfoResponse\"\025"
-  "\202\323\344\223\002\017\"\r/v1/arrayinfoB\tZ\007cli/apib\006proto3"
+  "(\t\022\n\n\002ip\030\002 \001(\t\022\020\n\010lastseen\030\003 \001(\t\"F\n\023List"
+  "HaVolumeRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
+  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\336\002\n\024ListHaVolum"
+  "eResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022"
+  "5\n\006result\030\003 \001(\0132%.grpc_cli.ListHaVolumeR"
+  "esponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli."
+  "PosInfo\032\317\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grp"
+  "c_cli.Status\022:\n\004data\030\002 \003(\0132,.grpc_cli.Li"
+  "stHaVolumeResponse.Result.Volume\032g\n\006Volu"
+  "me\022\n\n\002id\030\001 \001(\005\022\014\n\004name\030\002 \001(\t\022\020\n\010nodeName"
+  "\030\003 \001(\t\022\021\n\tarrayName\030\004 \001(\t\022\014\n\004size\030\005 \001(\003\022"
+  "\020\n\010lastseen\030\006 \001(\t2\362\016\n\006PosCli\022_\n\nSystemIn"
+  "fo\022\033.grpc_cli.SystemInfoRequest\032\034.grpc_c"
+  "li.SystemInfoResponse\"\026\202\323\344\223\002\020\022\016/v1/syste"
+  "minfo\022_\n\nSystemStop\022\033.grpc_cli.SystemSto"
+  "pRequest\032\034.grpc_cli.SystemStopResponse\"\026"
+  "\202\323\344\223\002\020\022\016/v1/systemstop\022}\n\021GetSystemPrope"
+  "rty\022\".grpc_cli.GetSystemPropertyRequest\032"
+  "#.grpc_cli.GetSystemPropertyResponse\"\037\202\323"
+  "\344\223\002\031\022\027/v1/get_system_property\022\205\001\n\021SetSys"
+  "temProperty\022\".grpc_cli.SetSystemProperty"
+  "Request\032#.grpc_cli.SetSystemPropertyResp"
+  "onse\"\'\202\323\344\223\002!\022\037/v1/set_system_property/{l"
+  "evel}\022p\n\016StartTelemetry\022\037.grpc_cli.Start"
+  "TelemetryRequest\032 .grpc_cli.StartTelemet"
+  "ryResponse\"\033\202\323\344\223\002\025\022\023/v1/start_telemetry\022"
+  "l\n\rStopTelemetry\022\036.grpc_cli.StopTelemetr"
+  "yRequest\032\037.grpc_cli.StopTelemetryRespons"
+  "e\"\032\202\323\344\223\002\024\022\022/v1/stop_telemetry\022P\n\rResetEv"
+  "entWrr\022\036.grpc_cli.ResetEventWrrRequest\032\037"
+  ".grpc_cli.ResetEventWrrResponse\022A\n\010Reset"
+  "Mbr\022\031.grpc_cli.ResetMbrRequest\032\032.grpc_cl"
+  "i.ResetMbrResponse\022S\n\016StopRebuilding\022\037.g"
+  "rpc_cli.StopRebuildingRequest\032 .grpc_cli"
+  ".StopRebuildingResponse\022S\n\016UpdateEventWr"
+  "r\022\037.grpc_cli.UpdateEventWrrRequest\032 .grp"
+  "c_cli.UpdateEventWrrResponse\022W\n\010AddSpare"
+  "\022\031.grpc_cli.AddSpareRequest\032\032.grpc_cli.A"
+  "ddSpareResponse\"\024\202\323\344\223\002\016\"\014/v1/addspare\022c\n"
+  "\013RemoveSpare\022\034.grpc_cli.RemoveSpareReque"
+  "st\032\035.grpc_cli.RemoveSpareResponse\"\027\202\323\344\223\002"
+  "\021\"\017/v1/removespare\022c\n\013CreateArray\022\034.grpc"
+  "_cli.CreateArrayRequest\032\035.grpc_cli.Creat"
+  "eArrayResponse\"\027\202\323\344\223\002\021\"\017/v1/createarray\022"
+  "s\n\017AutocreateArray\022 .grpc_cli.Autocreate"
+  "ArrayRequest\032!.grpc_cli.AutocreateArrayR"
+  "esponse\"\033\202\323\344\223\002\025\"\023/v1/autocreatearray\022d\n\013"
+  "DeleteArray\022\034.grpc_cli.DeleteArrayReques"
+  "t\032\035.grpc_cli.DeleteArrayResponse\"\030\202\323\344\223\002\022"
+  "\"\020/v1/deletearray/\022_\n\nMountArray\022\033.grpc_"
+  "cli.MountArrayRequest\032\034.grpc_cli.MountAr"
+  "rayResponse\"\026\202\323\344\223\002\020\"\016/v1/mountarray\022g\n\014U"
+  "nmountArray\022\035.grpc_cli.UnmountArrayReque"
+  "st\032\036.grpc_cli.UnmountArrayResponse\"\030\202\323\344\223"
+  "\002\022\"\020/v1/unmountarray\022[\n\tListArray\022\032.grpc"
+  "_cli.ListArrayRequest\032\033.grpc_cli.ListArr"
+  "ayResponse\"\025\202\323\344\223\002\017\"\r/v1/listarray\022[\n\tArr"
+  "ayInfo\022\032.grpc_cli.ArrayInfoRequest\032\033.grp"
+  "c_cli.ArrayInfoResponse\"\025\202\323\344\223\002\017\"\r/v1/arr"
+  "ayinfoB\tZ\007cli/apib\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_cli_2eproto_deps[1] = {
   &::descriptor_table_annotations_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_cli_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_cli_2eproto = {
-  false, false, 9600, descriptor_table_protodef_cli_2eproto, "cli.proto", 
-  &descriptor_table_cli_2eproto_once, descriptor_table_cli_2eproto_deps, 1, 82,
+  false, false, 10025, descriptor_table_protodef_cli_2eproto, "cli.proto", 
+  &descriptor_table_cli_2eproto_once, descriptor_table_cli_2eproto_deps, 1, 86,
   schemas, file_default_instances, TableStruct_cli_2eproto::offsets,
   file_level_metadata_cli_2eproto, file_level_enum_descriptors_cli_2eproto, file_level_service_descriptors_cli_2eproto,
 };
@@ -24870,6 +24983,1222 @@ void ListNodeResponse::InternalSwap(ListNodeResponse* other) {
 }
 
 
+// ===================================================================
+
+class ListHaVolumeRequest::_Internal {
+ public:
+};
+
+ListHaVolumeRequest::ListHaVolumeRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.ListHaVolumeRequest)
+}
+ListHaVolumeRequest::ListHaVolumeRequest(const ListHaVolumeRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_command().empty()) {
+    command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_command(), 
+      GetArena());
+  }
+  rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_rid().empty()) {
+    rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_rid(), 
+      GetArena());
+  }
+  requestor_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_requestor().empty()) {
+    requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_requestor(), 
+      GetArena());
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.ListHaVolumeRequest)
+}
+
+void ListHaVolumeRequest::SharedCtor() {
+command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+requestor_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+ListHaVolumeRequest::~ListHaVolumeRequest() {
+  // @@protoc_insertion_point(destructor:grpc_cli.ListHaVolumeRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void ListHaVolumeRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  command_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  rid_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  requestor_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+void ListHaVolumeRequest::ArenaDtor(void* object) {
+  ListHaVolumeRequest* _this = reinterpret_cast< ListHaVolumeRequest* >(object);
+  (void)_this;
+}
+void ListHaVolumeRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void ListHaVolumeRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void ListHaVolumeRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.ListHaVolumeRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  command_.ClearToEmpty();
+  rid_.ClearToEmpty();
+  requestor_.ClearToEmpty();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ListHaVolumeRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // string command = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          auto str = _internal_mutable_command();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaVolumeRequest.command"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string rid = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_rid();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaVolumeRequest.rid"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string requestor = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          auto str = _internal_mutable_requestor();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaVolumeRequest.requestor"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* ListHaVolumeRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.ListHaVolumeRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_command().data(), static_cast<int>(this->_internal_command().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaVolumeRequest.command");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_command(), target);
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_rid().data(), static_cast<int>(this->_internal_rid().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaVolumeRequest.rid");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_rid(), target);
+  }
+
+  // string requestor = 3;
+  if (this->requestor().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_requestor().data(), static_cast<int>(this->_internal_requestor().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaVolumeRequest.requestor");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_requestor(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.ListHaVolumeRequest)
+  return target;
+}
+
+size_t ListHaVolumeRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.ListHaVolumeRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_command());
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_rid());
+  }
+
+  // string requestor = 3;
+  if (this->requestor().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_requestor());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ListHaVolumeRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.ListHaVolumeRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ListHaVolumeRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<ListHaVolumeRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.ListHaVolumeRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.ListHaVolumeRequest)
+    MergeFrom(*source);
+  }
+}
+
+void ListHaVolumeRequest::MergeFrom(const ListHaVolumeRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.ListHaVolumeRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.command().size() > 0) {
+    _internal_set_command(from._internal_command());
+  }
+  if (from.rid().size() > 0) {
+    _internal_set_rid(from._internal_rid());
+  }
+  if (from.requestor().size() > 0) {
+    _internal_set_requestor(from._internal_requestor());
+  }
+}
+
+void ListHaVolumeRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.ListHaVolumeRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ListHaVolumeRequest::CopyFrom(const ListHaVolumeRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.ListHaVolumeRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ListHaVolumeRequest::IsInitialized() const {
+  return true;
+}
+
+void ListHaVolumeRequest::InternalSwap(ListHaVolumeRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  command_.Swap(&other->command_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  rid_.Swap(&other->rid_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  requestor_.Swap(&other->requestor_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ListHaVolumeRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class ListHaVolumeResponse_Result_Volume::_Internal {
+ public:
+};
+
+ListHaVolumeResponse_Result_Volume::ListHaVolumeResponse_Result_Volume(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.ListHaVolumeResponse.Result.Volume)
+}
+ListHaVolumeResponse_Result_Volume::ListHaVolumeResponse_Result_Volume(const ListHaVolumeResponse_Result_Volume& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  name_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_name().empty()) {
+    name_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_name(), 
+      GetArena());
+  }
+  nodename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_nodename().empty()) {
+    nodename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_nodename(), 
+      GetArena());
+  }
+  arrayname_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_arrayname().empty()) {
+    arrayname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_arrayname(), 
+      GetArena());
+  }
+  lastseen_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_lastseen().empty()) {
+    lastseen_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_lastseen(), 
+      GetArena());
+  }
+  ::memcpy(&size_, &from.size_,
+    static_cast<size_t>(reinterpret_cast<char*>(&id_) -
+    reinterpret_cast<char*>(&size_)) + sizeof(id_));
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.ListHaVolumeResponse.Result.Volume)
+}
+
+void ListHaVolumeResponse_Result_Volume::SharedCtor() {
+name_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+nodename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+arrayname_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+lastseen_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+    reinterpret_cast<char*>(&size_) - reinterpret_cast<char*>(this)),
+    0, static_cast<size_t>(reinterpret_cast<char*>(&id_) -
+    reinterpret_cast<char*>(&size_)) + sizeof(id_));
+}
+
+ListHaVolumeResponse_Result_Volume::~ListHaVolumeResponse_Result_Volume() {
+  // @@protoc_insertion_point(destructor:grpc_cli.ListHaVolumeResponse.Result.Volume)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void ListHaVolumeResponse_Result_Volume::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  name_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  nodename_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  arrayname_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  lastseen_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+void ListHaVolumeResponse_Result_Volume::ArenaDtor(void* object) {
+  ListHaVolumeResponse_Result_Volume* _this = reinterpret_cast< ListHaVolumeResponse_Result_Volume* >(object);
+  (void)_this;
+}
+void ListHaVolumeResponse_Result_Volume::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void ListHaVolumeResponse_Result_Volume::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void ListHaVolumeResponse_Result_Volume::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.ListHaVolumeResponse.Result.Volume)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  name_.ClearToEmpty();
+  nodename_.ClearToEmpty();
+  arrayname_.ClearToEmpty();
+  lastseen_.ClearToEmpty();
+  ::memset(&size_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&id_) -
+      reinterpret_cast<char*>(&size_)) + sizeof(id_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ListHaVolumeResponse_Result_Volume::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // int32 id = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
+          id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string name = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_name();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaVolumeResponse.Result.Volume.name"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string nodeName = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          auto str = _internal_mutable_nodename();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaVolumeResponse.Result.Volume.nodeName"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string arrayName = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 34)) {
+          auto str = _internal_mutable_arrayname();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaVolumeResponse.Result.Volume.arrayName"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // int64 size = 5;
+      case 5:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 40)) {
+          size_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string lastseen = 6;
+      case 6:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 50)) {
+          auto str = _internal_mutable_lastseen();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaVolumeResponse.Result.Volume.lastseen"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* ListHaVolumeResponse_Result_Volume::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.ListHaVolumeResponse.Result.Volume)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // int32 id = 1;
+  if (this->id() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(1, this->_internal_id(), target);
+  }
+
+  // string name = 2;
+  if (this->name().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_name().data(), static_cast<int>(this->_internal_name().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaVolumeResponse.Result.Volume.name");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_name(), target);
+  }
+
+  // string nodeName = 3;
+  if (this->nodename().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_nodename().data(), static_cast<int>(this->_internal_nodename().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaVolumeResponse.Result.Volume.nodeName");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_nodename(), target);
+  }
+
+  // string arrayName = 4;
+  if (this->arrayname().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_arrayname().data(), static_cast<int>(this->_internal_arrayname().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaVolumeResponse.Result.Volume.arrayName");
+    target = stream->WriteStringMaybeAliased(
+        4, this->_internal_arrayname(), target);
+  }
+
+  // int64 size = 5;
+  if (this->size() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt64ToArray(5, this->_internal_size(), target);
+  }
+
+  // string lastseen = 6;
+  if (this->lastseen().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_lastseen().data(), static_cast<int>(this->_internal_lastseen().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaVolumeResponse.Result.Volume.lastseen");
+    target = stream->WriteStringMaybeAliased(
+        6, this->_internal_lastseen(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.ListHaVolumeResponse.Result.Volume)
+  return target;
+}
+
+size_t ListHaVolumeResponse_Result_Volume::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.ListHaVolumeResponse.Result.Volume)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string name = 2;
+  if (this->name().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_name());
+  }
+
+  // string nodeName = 3;
+  if (this->nodename().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_nodename());
+  }
+
+  // string arrayName = 4;
+  if (this->arrayname().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_arrayname());
+  }
+
+  // string lastseen = 6;
+  if (this->lastseen().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_lastseen());
+  }
+
+  // int64 size = 5;
+  if (this->size() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int64Size(
+        this->_internal_size());
+  }
+
+  // int32 id = 1;
+  if (this->id() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
+        this->_internal_id());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ListHaVolumeResponse_Result_Volume::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.ListHaVolumeResponse.Result.Volume)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ListHaVolumeResponse_Result_Volume* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<ListHaVolumeResponse_Result_Volume>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.ListHaVolumeResponse.Result.Volume)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.ListHaVolumeResponse.Result.Volume)
+    MergeFrom(*source);
+  }
+}
+
+void ListHaVolumeResponse_Result_Volume::MergeFrom(const ListHaVolumeResponse_Result_Volume& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.ListHaVolumeResponse.Result.Volume)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.name().size() > 0) {
+    _internal_set_name(from._internal_name());
+  }
+  if (from.nodename().size() > 0) {
+    _internal_set_nodename(from._internal_nodename());
+  }
+  if (from.arrayname().size() > 0) {
+    _internal_set_arrayname(from._internal_arrayname());
+  }
+  if (from.lastseen().size() > 0) {
+    _internal_set_lastseen(from._internal_lastseen());
+  }
+  if (from.size() != 0) {
+    _internal_set_size(from._internal_size());
+  }
+  if (from.id() != 0) {
+    _internal_set_id(from._internal_id());
+  }
+}
+
+void ListHaVolumeResponse_Result_Volume::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.ListHaVolumeResponse.Result.Volume)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ListHaVolumeResponse_Result_Volume::CopyFrom(const ListHaVolumeResponse_Result_Volume& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.ListHaVolumeResponse.Result.Volume)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ListHaVolumeResponse_Result_Volume::IsInitialized() const {
+  return true;
+}
+
+void ListHaVolumeResponse_Result_Volume::InternalSwap(ListHaVolumeResponse_Result_Volume* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  name_.Swap(&other->name_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  nodename_.Swap(&other->nodename_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  arrayname_.Swap(&other->arrayname_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  lastseen_.Swap(&other->lastseen_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(ListHaVolumeResponse_Result_Volume, id_)
+      + sizeof(ListHaVolumeResponse_Result_Volume::id_)
+      - PROTOBUF_FIELD_OFFSET(ListHaVolumeResponse_Result_Volume, size_)>(
+          reinterpret_cast<char*>(&size_),
+          reinterpret_cast<char*>(&other->size_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ListHaVolumeResponse_Result_Volume::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class ListHaVolumeResponse_Result::_Internal {
+ public:
+  static const ::grpc_cli::Status& status(const ListHaVolumeResponse_Result* msg);
+};
+
+const ::grpc_cli::Status&
+ListHaVolumeResponse_Result::_Internal::status(const ListHaVolumeResponse_Result* msg) {
+  return *msg->status_;
+}
+ListHaVolumeResponse_Result::ListHaVolumeResponse_Result(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  data_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.ListHaVolumeResponse.Result)
+}
+ListHaVolumeResponse_Result::ListHaVolumeResponse_Result(const ListHaVolumeResponse_Result& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      data_(from.data_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_status()) {
+    status_ = new ::grpc_cli::Status(*from.status_);
+  } else {
+    status_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.ListHaVolumeResponse.Result)
+}
+
+void ListHaVolumeResponse_Result::SharedCtor() {
+status_ = nullptr;
+}
+
+ListHaVolumeResponse_Result::~ListHaVolumeResponse_Result() {
+  // @@protoc_insertion_point(destructor:grpc_cli.ListHaVolumeResponse.Result)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void ListHaVolumeResponse_Result::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete status_;
+}
+
+void ListHaVolumeResponse_Result::ArenaDtor(void* object) {
+  ListHaVolumeResponse_Result* _this = reinterpret_cast< ListHaVolumeResponse_Result* >(object);
+  (void)_this;
+}
+void ListHaVolumeResponse_Result::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void ListHaVolumeResponse_Result::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void ListHaVolumeResponse_Result::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.ListHaVolumeResponse.Result)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  data_.Clear();
+  if (GetArena() == nullptr && status_ != nullptr) {
+    delete status_;
+  }
+  status_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ListHaVolumeResponse_Result::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .grpc_cli.Status status = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_status(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // repeated .grpc_cli.ListHaVolumeResponse.Result.Volume data = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_data(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<18>(ptr));
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* ListHaVolumeResponse_Result::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.ListHaVolumeResponse.Result)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .grpc_cli.Status status = 1;
+  if (this->has_status()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::status(this), target, stream);
+  }
+
+  // repeated .grpc_cli.ListHaVolumeResponse.Result.Volume data = 2;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->_internal_data_size()); i < n; i++) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(2, this->_internal_data(i), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.ListHaVolumeResponse.Result)
+  return target;
+}
+
+size_t ListHaVolumeResponse_Result::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.ListHaVolumeResponse.Result)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .grpc_cli.ListHaVolumeResponse.Result.Volume data = 2;
+  total_size += 1UL * this->_internal_data_size();
+  for (const auto& msg : this->data_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // .grpc_cli.Status status = 1;
+  if (this->has_status()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *status_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ListHaVolumeResponse_Result::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.ListHaVolumeResponse.Result)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ListHaVolumeResponse_Result* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<ListHaVolumeResponse_Result>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.ListHaVolumeResponse.Result)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.ListHaVolumeResponse.Result)
+    MergeFrom(*source);
+  }
+}
+
+void ListHaVolumeResponse_Result::MergeFrom(const ListHaVolumeResponse_Result& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.ListHaVolumeResponse.Result)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  data_.MergeFrom(from.data_);
+  if (from.has_status()) {
+    _internal_mutable_status()->::grpc_cli::Status::MergeFrom(from._internal_status());
+  }
+}
+
+void ListHaVolumeResponse_Result::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.ListHaVolumeResponse.Result)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ListHaVolumeResponse_Result::CopyFrom(const ListHaVolumeResponse_Result& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.ListHaVolumeResponse.Result)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ListHaVolumeResponse_Result::IsInitialized() const {
+  return true;
+}
+
+void ListHaVolumeResponse_Result::InternalSwap(ListHaVolumeResponse_Result* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  data_.InternalSwap(&other->data_);
+  swap(status_, other->status_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ListHaVolumeResponse_Result::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class ListHaVolumeResponse::_Internal {
+ public:
+  static const ::grpc_cli::ListHaVolumeResponse_Result& result(const ListHaVolumeResponse* msg);
+  static const ::grpc_cli::PosInfo& info(const ListHaVolumeResponse* msg);
+};
+
+const ::grpc_cli::ListHaVolumeResponse_Result&
+ListHaVolumeResponse::_Internal::result(const ListHaVolumeResponse* msg) {
+  return *msg->result_;
+}
+const ::grpc_cli::PosInfo&
+ListHaVolumeResponse::_Internal::info(const ListHaVolumeResponse* msg) {
+  return *msg->info_;
+}
+ListHaVolumeResponse::ListHaVolumeResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.ListHaVolumeResponse)
+}
+ListHaVolumeResponse::ListHaVolumeResponse(const ListHaVolumeResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_command().empty()) {
+    command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_command(), 
+      GetArena());
+  }
+  rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_rid().empty()) {
+    rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_rid(), 
+      GetArena());
+  }
+  if (from._internal_has_result()) {
+    result_ = new ::grpc_cli::ListHaVolumeResponse_Result(*from.result_);
+  } else {
+    result_ = nullptr;
+  }
+  if (from._internal_has_info()) {
+    info_ = new ::grpc_cli::PosInfo(*from.info_);
+  } else {
+    info_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.ListHaVolumeResponse)
+}
+
+void ListHaVolumeResponse::SharedCtor() {
+command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+    reinterpret_cast<char*>(&result_) - reinterpret_cast<char*>(this)),
+    0, static_cast<size_t>(reinterpret_cast<char*>(&info_) -
+    reinterpret_cast<char*>(&result_)) + sizeof(info_));
+}
+
+ListHaVolumeResponse::~ListHaVolumeResponse() {
+  // @@protoc_insertion_point(destructor:grpc_cli.ListHaVolumeResponse)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void ListHaVolumeResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  command_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  rid_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (this != internal_default_instance()) delete result_;
+  if (this != internal_default_instance()) delete info_;
+}
+
+void ListHaVolumeResponse::ArenaDtor(void* object) {
+  ListHaVolumeResponse* _this = reinterpret_cast< ListHaVolumeResponse* >(object);
+  (void)_this;
+}
+void ListHaVolumeResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void ListHaVolumeResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void ListHaVolumeResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.ListHaVolumeResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  command_.ClearToEmpty();
+  rid_.ClearToEmpty();
+  if (GetArena() == nullptr && result_ != nullptr) {
+    delete result_;
+  }
+  result_ = nullptr;
+  if (GetArena() == nullptr && info_ != nullptr) {
+    delete info_;
+  }
+  info_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ListHaVolumeResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // string command = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          auto str = _internal_mutable_command();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaVolumeResponse.command"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string rid = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_rid();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaVolumeResponse.rid"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .grpc_cli.ListHaVolumeResponse.Result result = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          ptr = ctx->ParseMessage(_internal_mutable_result(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .grpc_cli.PosInfo info = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 34)) {
+          ptr = ctx->ParseMessage(_internal_mutable_info(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* ListHaVolumeResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.ListHaVolumeResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_command().data(), static_cast<int>(this->_internal_command().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaVolumeResponse.command");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_command(), target);
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_rid().data(), static_cast<int>(this->_internal_rid().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaVolumeResponse.rid");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_rid(), target);
+  }
+
+  // .grpc_cli.ListHaVolumeResponse.Result result = 3;
+  if (this->has_result()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        3, _Internal::result(this), target, stream);
+  }
+
+  // .grpc_cli.PosInfo info = 4;
+  if (this->has_info()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        4, _Internal::info(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.ListHaVolumeResponse)
+  return target;
+}
+
+size_t ListHaVolumeResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.ListHaVolumeResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_command());
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_rid());
+  }
+
+  // .grpc_cli.ListHaVolumeResponse.Result result = 3;
+  if (this->has_result()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *result_);
+  }
+
+  // .grpc_cli.PosInfo info = 4;
+  if (this->has_info()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *info_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ListHaVolumeResponse::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.ListHaVolumeResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ListHaVolumeResponse* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<ListHaVolumeResponse>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.ListHaVolumeResponse)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.ListHaVolumeResponse)
+    MergeFrom(*source);
+  }
+}
+
+void ListHaVolumeResponse::MergeFrom(const ListHaVolumeResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.ListHaVolumeResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.command().size() > 0) {
+    _internal_set_command(from._internal_command());
+  }
+  if (from.rid().size() > 0) {
+    _internal_set_rid(from._internal_rid());
+  }
+  if (from.has_result()) {
+    _internal_mutable_result()->::grpc_cli::ListHaVolumeResponse_Result::MergeFrom(from._internal_result());
+  }
+  if (from.has_info()) {
+    _internal_mutable_info()->::grpc_cli::PosInfo::MergeFrom(from._internal_info());
+  }
+}
+
+void ListHaVolumeResponse::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.ListHaVolumeResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ListHaVolumeResponse::CopyFrom(const ListHaVolumeResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.ListHaVolumeResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ListHaVolumeResponse::IsInitialized() const {
+  return true;
+}
+
+void ListHaVolumeResponse::InternalSwap(ListHaVolumeResponse* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  command_.Swap(&other->command_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  rid_.Swap(&other->rid_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(ListHaVolumeResponse, info_)
+      + sizeof(ListHaVolumeResponse::info_)
+      - PROTOBUF_FIELD_OFFSET(ListHaVolumeResponse, result_)>(
+          reinterpret_cast<char*>(&result_),
+          reinterpret_cast<char*>(&other->result_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ListHaVolumeResponse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
 // @@protoc_insertion_point(namespace_scope)
 }  // namespace grpc_cli
 PROTOBUF_NAMESPACE_OPEN
@@ -25118,6 +26447,18 @@ template<> PROTOBUF_NOINLINE ::grpc_cli::ListNodeResponse_Result* Arena::CreateM
 }
 template<> PROTOBUF_NOINLINE ::grpc_cli::ListNodeResponse* Arena::CreateMaybeMessage< ::grpc_cli::ListNodeResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::grpc_cli::ListNodeResponse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::ListHaVolumeRequest* Arena::CreateMaybeMessage< ::grpc_cli::ListHaVolumeRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::ListHaVolumeRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::ListHaVolumeResponse_Result_Volume* Arena::CreateMaybeMessage< ::grpc_cli::ListHaVolumeResponse_Result_Volume >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::ListHaVolumeResponse_Result_Volume >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::ListHaVolumeResponse_Result* Arena::CreateMaybeMessage< ::grpc_cli::ListHaVolumeResponse_Result >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::ListHaVolumeResponse_Result >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::ListHaVolumeResponse* Arena::CreateMaybeMessage< ::grpc_cli::ListHaVolumeResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::ListHaVolumeResponse >(arena);
 }
 PROTOBUF_NAMESPACE_CLOSE
 

--- a/proto/generated/cpp/cli.pb.h
+++ b/proto/generated/cpp/cli.pb.h
@@ -47,7 +47,7 @@ struct TableStruct_cli_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[82]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[86]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -152,6 +152,18 @@ extern ListArrayResponse_ResultDefaultTypeInternal _ListArrayResponse_Result_def
 class ListArrayResponse_Result_ArrayList;
 struct ListArrayResponse_Result_ArrayListDefaultTypeInternal;
 extern ListArrayResponse_Result_ArrayListDefaultTypeInternal _ListArrayResponse_Result_ArrayList_default_instance_;
+class ListHaVolumeRequest;
+struct ListHaVolumeRequestDefaultTypeInternal;
+extern ListHaVolumeRequestDefaultTypeInternal _ListHaVolumeRequest_default_instance_;
+class ListHaVolumeResponse;
+struct ListHaVolumeResponseDefaultTypeInternal;
+extern ListHaVolumeResponseDefaultTypeInternal _ListHaVolumeResponse_default_instance_;
+class ListHaVolumeResponse_Result;
+struct ListHaVolumeResponse_ResultDefaultTypeInternal;
+extern ListHaVolumeResponse_ResultDefaultTypeInternal _ListHaVolumeResponse_Result_default_instance_;
+class ListHaVolumeResponse_Result_Volume;
+struct ListHaVolumeResponse_Result_VolumeDefaultTypeInternal;
+extern ListHaVolumeResponse_Result_VolumeDefaultTypeInternal _ListHaVolumeResponse_Result_Volume_default_instance_;
 class ListNodeRequest;
 struct ListNodeRequestDefaultTypeInternal;
 extern ListNodeRequestDefaultTypeInternal _ListNodeRequest_default_instance_;
@@ -336,6 +348,10 @@ template<> ::grpc_cli::ListArrayRequest* Arena::CreateMaybeMessage<::grpc_cli::L
 template<> ::grpc_cli::ListArrayResponse* Arena::CreateMaybeMessage<::grpc_cli::ListArrayResponse>(Arena*);
 template<> ::grpc_cli::ListArrayResponse_Result* Arena::CreateMaybeMessage<::grpc_cli::ListArrayResponse_Result>(Arena*);
 template<> ::grpc_cli::ListArrayResponse_Result_ArrayList* Arena::CreateMaybeMessage<::grpc_cli::ListArrayResponse_Result_ArrayList>(Arena*);
+template<> ::grpc_cli::ListHaVolumeRequest* Arena::CreateMaybeMessage<::grpc_cli::ListHaVolumeRequest>(Arena*);
+template<> ::grpc_cli::ListHaVolumeResponse* Arena::CreateMaybeMessage<::grpc_cli::ListHaVolumeResponse>(Arena*);
+template<> ::grpc_cli::ListHaVolumeResponse_Result* Arena::CreateMaybeMessage<::grpc_cli::ListHaVolumeResponse_Result>(Arena*);
+template<> ::grpc_cli::ListHaVolumeResponse_Result_Volume* Arena::CreateMaybeMessage<::grpc_cli::ListHaVolumeResponse_Result_Volume>(Arena*);
 template<> ::grpc_cli::ListNodeRequest* Arena::CreateMaybeMessage<::grpc_cli::ListNodeRequest>(Arena*);
 template<> ::grpc_cli::ListNodeResponse* Arena::CreateMaybeMessage<::grpc_cli::ListNodeResponse>(Arena*);
 template<> ::grpc_cli::ListNodeResponse_Result* Arena::CreateMaybeMessage<::grpc_cli::ListNodeResponse_Result>(Arena*);
@@ -15179,6 +15195,778 @@ class ListNodeResponse PROTOBUF_FINAL :
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr command_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr rid_;
   ::grpc_cli::ListNodeResponse_Result* result_;
+  ::grpc_cli::PosInfo* info_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ListHaVolumeRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.ListHaVolumeRequest) */ {
+ public:
+  inline ListHaVolumeRequest() : ListHaVolumeRequest(nullptr) {}
+  virtual ~ListHaVolumeRequest();
+  explicit constexpr ListHaVolumeRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  ListHaVolumeRequest(const ListHaVolumeRequest& from);
+  ListHaVolumeRequest(ListHaVolumeRequest&& from) noexcept
+    : ListHaVolumeRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline ListHaVolumeRequest& operator=(const ListHaVolumeRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ListHaVolumeRequest& operator=(ListHaVolumeRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const ListHaVolumeRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ListHaVolumeRequest* internal_default_instance() {
+    return reinterpret_cast<const ListHaVolumeRequest*>(
+               &_ListHaVolumeRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    82;
+
+  friend void swap(ListHaVolumeRequest& a, ListHaVolumeRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ListHaVolumeRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ListHaVolumeRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ListHaVolumeRequest* New() const final {
+    return CreateMaybeMessage<ListHaVolumeRequest>(nullptr);
+  }
+
+  ListHaVolumeRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<ListHaVolumeRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const ListHaVolumeRequest& from);
+  void MergeFrom(const ListHaVolumeRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ListHaVolumeRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.ListHaVolumeRequest";
+  }
+  protected:
+  explicit ListHaVolumeRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kCommandFieldNumber = 1,
+    kRidFieldNumber = 2,
+    kRequestorFieldNumber = 3,
+  };
+  // string command = 1;
+  void clear_command();
+  const std::string& command() const;
+  void set_command(const std::string& value);
+  void set_command(std::string&& value);
+  void set_command(const char* value);
+  void set_command(const char* value, size_t size);
+  std::string* mutable_command();
+  std::string* release_command();
+  void set_allocated_command(std::string* command);
+  private:
+  const std::string& _internal_command() const;
+  void _internal_set_command(const std::string& value);
+  std::string* _internal_mutable_command();
+  public:
+
+  // string rid = 2;
+  void clear_rid();
+  const std::string& rid() const;
+  void set_rid(const std::string& value);
+  void set_rid(std::string&& value);
+  void set_rid(const char* value);
+  void set_rid(const char* value, size_t size);
+  std::string* mutable_rid();
+  std::string* release_rid();
+  void set_allocated_rid(std::string* rid);
+  private:
+  const std::string& _internal_rid() const;
+  void _internal_set_rid(const std::string& value);
+  std::string* _internal_mutable_rid();
+  public:
+
+  // string requestor = 3;
+  void clear_requestor();
+  const std::string& requestor() const;
+  void set_requestor(const std::string& value);
+  void set_requestor(std::string&& value);
+  void set_requestor(const char* value);
+  void set_requestor(const char* value, size_t size);
+  std::string* mutable_requestor();
+  std::string* release_requestor();
+  void set_allocated_requestor(std::string* requestor);
+  private:
+  const std::string& _internal_requestor() const;
+  void _internal_set_requestor(const std::string& value);
+  std::string* _internal_mutable_requestor();
+  public:
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.ListHaVolumeRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr command_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr rid_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr requestor_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ListHaVolumeResponse_Result_Volume PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.ListHaVolumeResponse.Result.Volume) */ {
+ public:
+  inline ListHaVolumeResponse_Result_Volume() : ListHaVolumeResponse_Result_Volume(nullptr) {}
+  virtual ~ListHaVolumeResponse_Result_Volume();
+  explicit constexpr ListHaVolumeResponse_Result_Volume(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  ListHaVolumeResponse_Result_Volume(const ListHaVolumeResponse_Result_Volume& from);
+  ListHaVolumeResponse_Result_Volume(ListHaVolumeResponse_Result_Volume&& from) noexcept
+    : ListHaVolumeResponse_Result_Volume() {
+    *this = ::std::move(from);
+  }
+
+  inline ListHaVolumeResponse_Result_Volume& operator=(const ListHaVolumeResponse_Result_Volume& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ListHaVolumeResponse_Result_Volume& operator=(ListHaVolumeResponse_Result_Volume&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const ListHaVolumeResponse_Result_Volume& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ListHaVolumeResponse_Result_Volume* internal_default_instance() {
+    return reinterpret_cast<const ListHaVolumeResponse_Result_Volume*>(
+               &_ListHaVolumeResponse_Result_Volume_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    83;
+
+  friend void swap(ListHaVolumeResponse_Result_Volume& a, ListHaVolumeResponse_Result_Volume& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ListHaVolumeResponse_Result_Volume* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ListHaVolumeResponse_Result_Volume* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ListHaVolumeResponse_Result_Volume* New() const final {
+    return CreateMaybeMessage<ListHaVolumeResponse_Result_Volume>(nullptr);
+  }
+
+  ListHaVolumeResponse_Result_Volume* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<ListHaVolumeResponse_Result_Volume>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const ListHaVolumeResponse_Result_Volume& from);
+  void MergeFrom(const ListHaVolumeResponse_Result_Volume& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ListHaVolumeResponse_Result_Volume* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.ListHaVolumeResponse.Result.Volume";
+  }
+  protected:
+  explicit ListHaVolumeResponse_Result_Volume(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kNameFieldNumber = 2,
+    kNodeNameFieldNumber = 3,
+    kArrayNameFieldNumber = 4,
+    kLastseenFieldNumber = 6,
+    kSizeFieldNumber = 5,
+    kIdFieldNumber = 1,
+  };
+  // string name = 2;
+  void clear_name();
+  const std::string& name() const;
+  void set_name(const std::string& value);
+  void set_name(std::string&& value);
+  void set_name(const char* value);
+  void set_name(const char* value, size_t size);
+  std::string* mutable_name();
+  std::string* release_name();
+  void set_allocated_name(std::string* name);
+  private:
+  const std::string& _internal_name() const;
+  void _internal_set_name(const std::string& value);
+  std::string* _internal_mutable_name();
+  public:
+
+  // string nodeName = 3;
+  void clear_nodename();
+  const std::string& nodename() const;
+  void set_nodename(const std::string& value);
+  void set_nodename(std::string&& value);
+  void set_nodename(const char* value);
+  void set_nodename(const char* value, size_t size);
+  std::string* mutable_nodename();
+  std::string* release_nodename();
+  void set_allocated_nodename(std::string* nodename);
+  private:
+  const std::string& _internal_nodename() const;
+  void _internal_set_nodename(const std::string& value);
+  std::string* _internal_mutable_nodename();
+  public:
+
+  // string arrayName = 4;
+  void clear_arrayname();
+  const std::string& arrayname() const;
+  void set_arrayname(const std::string& value);
+  void set_arrayname(std::string&& value);
+  void set_arrayname(const char* value);
+  void set_arrayname(const char* value, size_t size);
+  std::string* mutable_arrayname();
+  std::string* release_arrayname();
+  void set_allocated_arrayname(std::string* arrayname);
+  private:
+  const std::string& _internal_arrayname() const;
+  void _internal_set_arrayname(const std::string& value);
+  std::string* _internal_mutable_arrayname();
+  public:
+
+  // string lastseen = 6;
+  void clear_lastseen();
+  const std::string& lastseen() const;
+  void set_lastseen(const std::string& value);
+  void set_lastseen(std::string&& value);
+  void set_lastseen(const char* value);
+  void set_lastseen(const char* value, size_t size);
+  std::string* mutable_lastseen();
+  std::string* release_lastseen();
+  void set_allocated_lastseen(std::string* lastseen);
+  private:
+  const std::string& _internal_lastseen() const;
+  void _internal_set_lastseen(const std::string& value);
+  std::string* _internal_mutable_lastseen();
+  public:
+
+  // int64 size = 5;
+  void clear_size();
+  ::PROTOBUF_NAMESPACE_ID::int64 size() const;
+  void set_size(::PROTOBUF_NAMESPACE_ID::int64 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::int64 _internal_size() const;
+  void _internal_set_size(::PROTOBUF_NAMESPACE_ID::int64 value);
+  public:
+
+  // int32 id = 1;
+  void clear_id();
+  ::PROTOBUF_NAMESPACE_ID::int32 id() const;
+  void set_id(::PROTOBUF_NAMESPACE_ID::int32 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::int32 _internal_id() const;
+  void _internal_set_id(::PROTOBUF_NAMESPACE_ID::int32 value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.ListHaVolumeResponse.Result.Volume)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr name_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr nodename_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr arrayname_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr lastseen_;
+  ::PROTOBUF_NAMESPACE_ID::int64 size_;
+  ::PROTOBUF_NAMESPACE_ID::int32 id_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ListHaVolumeResponse_Result PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.ListHaVolumeResponse.Result) */ {
+ public:
+  inline ListHaVolumeResponse_Result() : ListHaVolumeResponse_Result(nullptr) {}
+  virtual ~ListHaVolumeResponse_Result();
+  explicit constexpr ListHaVolumeResponse_Result(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  ListHaVolumeResponse_Result(const ListHaVolumeResponse_Result& from);
+  ListHaVolumeResponse_Result(ListHaVolumeResponse_Result&& from) noexcept
+    : ListHaVolumeResponse_Result() {
+    *this = ::std::move(from);
+  }
+
+  inline ListHaVolumeResponse_Result& operator=(const ListHaVolumeResponse_Result& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ListHaVolumeResponse_Result& operator=(ListHaVolumeResponse_Result&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const ListHaVolumeResponse_Result& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ListHaVolumeResponse_Result* internal_default_instance() {
+    return reinterpret_cast<const ListHaVolumeResponse_Result*>(
+               &_ListHaVolumeResponse_Result_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    84;
+
+  friend void swap(ListHaVolumeResponse_Result& a, ListHaVolumeResponse_Result& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ListHaVolumeResponse_Result* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ListHaVolumeResponse_Result* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ListHaVolumeResponse_Result* New() const final {
+    return CreateMaybeMessage<ListHaVolumeResponse_Result>(nullptr);
+  }
+
+  ListHaVolumeResponse_Result* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<ListHaVolumeResponse_Result>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const ListHaVolumeResponse_Result& from);
+  void MergeFrom(const ListHaVolumeResponse_Result& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ListHaVolumeResponse_Result* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.ListHaVolumeResponse.Result";
+  }
+  protected:
+  explicit ListHaVolumeResponse_Result(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  typedef ListHaVolumeResponse_Result_Volume Volume;
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kDataFieldNumber = 2,
+    kStatusFieldNumber = 1,
+  };
+  // repeated .grpc_cli.ListHaVolumeResponse.Result.Volume data = 2;
+  int data_size() const;
+  private:
+  int _internal_data_size() const;
+  public:
+  void clear_data();
+  ::grpc_cli::ListHaVolumeResponse_Result_Volume* mutable_data(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::grpc_cli::ListHaVolumeResponse_Result_Volume >*
+      mutable_data();
+  private:
+  const ::grpc_cli::ListHaVolumeResponse_Result_Volume& _internal_data(int index) const;
+  ::grpc_cli::ListHaVolumeResponse_Result_Volume* _internal_add_data();
+  public:
+  const ::grpc_cli::ListHaVolumeResponse_Result_Volume& data(int index) const;
+  ::grpc_cli::ListHaVolumeResponse_Result_Volume* add_data();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::grpc_cli::ListHaVolumeResponse_Result_Volume >&
+      data() const;
+
+  // .grpc_cli.Status status = 1;
+  bool has_status() const;
+  private:
+  bool _internal_has_status() const;
+  public:
+  void clear_status();
+  const ::grpc_cli::Status& status() const;
+  ::grpc_cli::Status* release_status();
+  ::grpc_cli::Status* mutable_status();
+  void set_allocated_status(::grpc_cli::Status* status);
+  private:
+  const ::grpc_cli::Status& _internal_status() const;
+  ::grpc_cli::Status* _internal_mutable_status();
+  public:
+  void unsafe_arena_set_allocated_status(
+      ::grpc_cli::Status* status);
+  ::grpc_cli::Status* unsafe_arena_release_status();
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.ListHaVolumeResponse.Result)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::grpc_cli::ListHaVolumeResponse_Result_Volume > data_;
+  ::grpc_cli::Status* status_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ListHaVolumeResponse PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.ListHaVolumeResponse) */ {
+ public:
+  inline ListHaVolumeResponse() : ListHaVolumeResponse(nullptr) {}
+  virtual ~ListHaVolumeResponse();
+  explicit constexpr ListHaVolumeResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  ListHaVolumeResponse(const ListHaVolumeResponse& from);
+  ListHaVolumeResponse(ListHaVolumeResponse&& from) noexcept
+    : ListHaVolumeResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline ListHaVolumeResponse& operator=(const ListHaVolumeResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ListHaVolumeResponse& operator=(ListHaVolumeResponse&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const ListHaVolumeResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ListHaVolumeResponse* internal_default_instance() {
+    return reinterpret_cast<const ListHaVolumeResponse*>(
+               &_ListHaVolumeResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    85;
+
+  friend void swap(ListHaVolumeResponse& a, ListHaVolumeResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ListHaVolumeResponse* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ListHaVolumeResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ListHaVolumeResponse* New() const final {
+    return CreateMaybeMessage<ListHaVolumeResponse>(nullptr);
+  }
+
+  ListHaVolumeResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<ListHaVolumeResponse>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const ListHaVolumeResponse& from);
+  void MergeFrom(const ListHaVolumeResponse& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ListHaVolumeResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.ListHaVolumeResponse";
+  }
+  protected:
+  explicit ListHaVolumeResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  typedef ListHaVolumeResponse_Result Result;
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kCommandFieldNumber = 1,
+    kRidFieldNumber = 2,
+    kResultFieldNumber = 3,
+    kInfoFieldNumber = 4,
+  };
+  // string command = 1;
+  void clear_command();
+  const std::string& command() const;
+  void set_command(const std::string& value);
+  void set_command(std::string&& value);
+  void set_command(const char* value);
+  void set_command(const char* value, size_t size);
+  std::string* mutable_command();
+  std::string* release_command();
+  void set_allocated_command(std::string* command);
+  private:
+  const std::string& _internal_command() const;
+  void _internal_set_command(const std::string& value);
+  std::string* _internal_mutable_command();
+  public:
+
+  // string rid = 2;
+  void clear_rid();
+  const std::string& rid() const;
+  void set_rid(const std::string& value);
+  void set_rid(std::string&& value);
+  void set_rid(const char* value);
+  void set_rid(const char* value, size_t size);
+  std::string* mutable_rid();
+  std::string* release_rid();
+  void set_allocated_rid(std::string* rid);
+  private:
+  const std::string& _internal_rid() const;
+  void _internal_set_rid(const std::string& value);
+  std::string* _internal_mutable_rid();
+  public:
+
+  // .grpc_cli.ListHaVolumeResponse.Result result = 3;
+  bool has_result() const;
+  private:
+  bool _internal_has_result() const;
+  public:
+  void clear_result();
+  const ::grpc_cli::ListHaVolumeResponse_Result& result() const;
+  ::grpc_cli::ListHaVolumeResponse_Result* release_result();
+  ::grpc_cli::ListHaVolumeResponse_Result* mutable_result();
+  void set_allocated_result(::grpc_cli::ListHaVolumeResponse_Result* result);
+  private:
+  const ::grpc_cli::ListHaVolumeResponse_Result& _internal_result() const;
+  ::grpc_cli::ListHaVolumeResponse_Result* _internal_mutable_result();
+  public:
+  void unsafe_arena_set_allocated_result(
+      ::grpc_cli::ListHaVolumeResponse_Result* result);
+  ::grpc_cli::ListHaVolumeResponse_Result* unsafe_arena_release_result();
+
+  // .grpc_cli.PosInfo info = 4;
+  bool has_info() const;
+  private:
+  bool _internal_has_info() const;
+  public:
+  void clear_info();
+  const ::grpc_cli::PosInfo& info() const;
+  ::grpc_cli::PosInfo* release_info();
+  ::grpc_cli::PosInfo* mutable_info();
+  void set_allocated_info(::grpc_cli::PosInfo* info);
+  private:
+  const ::grpc_cli::PosInfo& _internal_info() const;
+  ::grpc_cli::PosInfo* _internal_mutable_info();
+  public:
+  void unsafe_arena_set_allocated_info(
+      ::grpc_cli::PosInfo* info);
+  ::grpc_cli::PosInfo* unsafe_arena_release_info();
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.ListHaVolumeResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr command_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr rid_;
+  ::grpc_cli::ListHaVolumeResponse_Result* result_;
   ::grpc_cli::PosInfo* info_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_cli_2eproto;
@@ -31081,9 +31869,910 @@ inline void ListNodeResponse::set_allocated_info(::grpc_cli::PosInfo* info) {
   // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListNodeResponse.info)
 }
 
+// -------------------------------------------------------------------
+
+// ListHaVolumeRequest
+
+// string command = 1;
+inline void ListHaVolumeRequest::clear_command() {
+  command_.ClearToEmpty();
+}
+inline const std::string& ListHaVolumeRequest::command() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeRequest.command)
+  return _internal_command();
+}
+inline void ListHaVolumeRequest::set_command(const std::string& value) {
+  _internal_set_command(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaVolumeRequest.command)
+}
+inline std::string* ListHaVolumeRequest::mutable_command() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaVolumeRequest.command)
+  return _internal_mutable_command();
+}
+inline const std::string& ListHaVolumeRequest::_internal_command() const {
+  return command_.Get();
+}
+inline void ListHaVolumeRequest::_internal_set_command(const std::string& value) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaVolumeRequest::set_command(std::string&& value) {
+  
+  command_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaVolumeRequest.command)
+}
+inline void ListHaVolumeRequest::set_command(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaVolumeRequest.command)
+}
+inline void ListHaVolumeRequest::set_command(const char* value,
+    size_t size) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaVolumeRequest.command)
+}
+inline std::string* ListHaVolumeRequest::_internal_mutable_command() {
+  
+  return command_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaVolumeRequest::release_command() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaVolumeRequest.command)
+  return command_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaVolumeRequest::set_allocated_command(std::string* command) {
+  if (command != nullptr) {
+    
+  } else {
+    
+  }
+  command_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), command,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaVolumeRequest.command)
+}
+
+// string rid = 2;
+inline void ListHaVolumeRequest::clear_rid() {
+  rid_.ClearToEmpty();
+}
+inline const std::string& ListHaVolumeRequest::rid() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeRequest.rid)
+  return _internal_rid();
+}
+inline void ListHaVolumeRequest::set_rid(const std::string& value) {
+  _internal_set_rid(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaVolumeRequest.rid)
+}
+inline std::string* ListHaVolumeRequest::mutable_rid() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaVolumeRequest.rid)
+  return _internal_mutable_rid();
+}
+inline const std::string& ListHaVolumeRequest::_internal_rid() const {
+  return rid_.Get();
+}
+inline void ListHaVolumeRequest::_internal_set_rid(const std::string& value) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaVolumeRequest::set_rid(std::string&& value) {
+  
+  rid_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaVolumeRequest.rid)
+}
+inline void ListHaVolumeRequest::set_rid(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaVolumeRequest.rid)
+}
+inline void ListHaVolumeRequest::set_rid(const char* value,
+    size_t size) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaVolumeRequest.rid)
+}
+inline std::string* ListHaVolumeRequest::_internal_mutable_rid() {
+  
+  return rid_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaVolumeRequest::release_rid() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaVolumeRequest.rid)
+  return rid_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaVolumeRequest::set_allocated_rid(std::string* rid) {
+  if (rid != nullptr) {
+    
+  } else {
+    
+  }
+  rid_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), rid,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaVolumeRequest.rid)
+}
+
+// string requestor = 3;
+inline void ListHaVolumeRequest::clear_requestor() {
+  requestor_.ClearToEmpty();
+}
+inline const std::string& ListHaVolumeRequest::requestor() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeRequest.requestor)
+  return _internal_requestor();
+}
+inline void ListHaVolumeRequest::set_requestor(const std::string& value) {
+  _internal_set_requestor(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaVolumeRequest.requestor)
+}
+inline std::string* ListHaVolumeRequest::mutable_requestor() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaVolumeRequest.requestor)
+  return _internal_mutable_requestor();
+}
+inline const std::string& ListHaVolumeRequest::_internal_requestor() const {
+  return requestor_.Get();
+}
+inline void ListHaVolumeRequest::_internal_set_requestor(const std::string& value) {
+  
+  requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaVolumeRequest::set_requestor(std::string&& value) {
+  
+  requestor_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaVolumeRequest.requestor)
+}
+inline void ListHaVolumeRequest::set_requestor(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaVolumeRequest.requestor)
+}
+inline void ListHaVolumeRequest::set_requestor(const char* value,
+    size_t size) {
+  
+  requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaVolumeRequest.requestor)
+}
+inline std::string* ListHaVolumeRequest::_internal_mutable_requestor() {
+  
+  return requestor_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaVolumeRequest::release_requestor() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaVolumeRequest.requestor)
+  return requestor_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaVolumeRequest::set_allocated_requestor(std::string* requestor) {
+  if (requestor != nullptr) {
+    
+  } else {
+    
+  }
+  requestor_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), requestor,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaVolumeRequest.requestor)
+}
+
+// -------------------------------------------------------------------
+
+// ListHaVolumeResponse_Result_Volume
+
+// int32 id = 1;
+inline void ListHaVolumeResponse_Result_Volume::clear_id() {
+  id_ = 0;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 ListHaVolumeResponse_Result_Volume::_internal_id() const {
+  return id_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 ListHaVolumeResponse_Result_Volume::id() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeResponse.Result.Volume.id)
+  return _internal_id();
+}
+inline void ListHaVolumeResponse_Result_Volume::_internal_set_id(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  
+  id_ = value;
+}
+inline void ListHaVolumeResponse_Result_Volume::set_id(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  _internal_set_id(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaVolumeResponse.Result.Volume.id)
+}
+
+// string name = 2;
+inline void ListHaVolumeResponse_Result_Volume::clear_name() {
+  name_.ClearToEmpty();
+}
+inline const std::string& ListHaVolumeResponse_Result_Volume::name() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeResponse.Result.Volume.name)
+  return _internal_name();
+}
+inline void ListHaVolumeResponse_Result_Volume::set_name(const std::string& value) {
+  _internal_set_name(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaVolumeResponse.Result.Volume.name)
+}
+inline std::string* ListHaVolumeResponse_Result_Volume::mutable_name() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaVolumeResponse.Result.Volume.name)
+  return _internal_mutable_name();
+}
+inline const std::string& ListHaVolumeResponse_Result_Volume::_internal_name() const {
+  return name_.Get();
+}
+inline void ListHaVolumeResponse_Result_Volume::_internal_set_name(const std::string& value) {
+  
+  name_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaVolumeResponse_Result_Volume::set_name(std::string&& value) {
+  
+  name_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaVolumeResponse.Result.Volume.name)
+}
+inline void ListHaVolumeResponse_Result_Volume::set_name(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  name_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaVolumeResponse.Result.Volume.name)
+}
+inline void ListHaVolumeResponse_Result_Volume::set_name(const char* value,
+    size_t size) {
+  
+  name_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaVolumeResponse.Result.Volume.name)
+}
+inline std::string* ListHaVolumeResponse_Result_Volume::_internal_mutable_name() {
+  
+  return name_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaVolumeResponse_Result_Volume::release_name() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaVolumeResponse.Result.Volume.name)
+  return name_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaVolumeResponse_Result_Volume::set_allocated_name(std::string* name) {
+  if (name != nullptr) {
+    
+  } else {
+    
+  }
+  name_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), name,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaVolumeResponse.Result.Volume.name)
+}
+
+// string nodeName = 3;
+inline void ListHaVolumeResponse_Result_Volume::clear_nodename() {
+  nodename_.ClearToEmpty();
+}
+inline const std::string& ListHaVolumeResponse_Result_Volume::nodename() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeResponse.Result.Volume.nodeName)
+  return _internal_nodename();
+}
+inline void ListHaVolumeResponse_Result_Volume::set_nodename(const std::string& value) {
+  _internal_set_nodename(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaVolumeResponse.Result.Volume.nodeName)
+}
+inline std::string* ListHaVolumeResponse_Result_Volume::mutable_nodename() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaVolumeResponse.Result.Volume.nodeName)
+  return _internal_mutable_nodename();
+}
+inline const std::string& ListHaVolumeResponse_Result_Volume::_internal_nodename() const {
+  return nodename_.Get();
+}
+inline void ListHaVolumeResponse_Result_Volume::_internal_set_nodename(const std::string& value) {
+  
+  nodename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaVolumeResponse_Result_Volume::set_nodename(std::string&& value) {
+  
+  nodename_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaVolumeResponse.Result.Volume.nodeName)
+}
+inline void ListHaVolumeResponse_Result_Volume::set_nodename(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  nodename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaVolumeResponse.Result.Volume.nodeName)
+}
+inline void ListHaVolumeResponse_Result_Volume::set_nodename(const char* value,
+    size_t size) {
+  
+  nodename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaVolumeResponse.Result.Volume.nodeName)
+}
+inline std::string* ListHaVolumeResponse_Result_Volume::_internal_mutable_nodename() {
+  
+  return nodename_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaVolumeResponse_Result_Volume::release_nodename() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaVolumeResponse.Result.Volume.nodeName)
+  return nodename_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaVolumeResponse_Result_Volume::set_allocated_nodename(std::string* nodename) {
+  if (nodename != nullptr) {
+    
+  } else {
+    
+  }
+  nodename_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), nodename,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaVolumeResponse.Result.Volume.nodeName)
+}
+
+// string arrayName = 4;
+inline void ListHaVolumeResponse_Result_Volume::clear_arrayname() {
+  arrayname_.ClearToEmpty();
+}
+inline const std::string& ListHaVolumeResponse_Result_Volume::arrayname() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeResponse.Result.Volume.arrayName)
+  return _internal_arrayname();
+}
+inline void ListHaVolumeResponse_Result_Volume::set_arrayname(const std::string& value) {
+  _internal_set_arrayname(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaVolumeResponse.Result.Volume.arrayName)
+}
+inline std::string* ListHaVolumeResponse_Result_Volume::mutable_arrayname() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaVolumeResponse.Result.Volume.arrayName)
+  return _internal_mutable_arrayname();
+}
+inline const std::string& ListHaVolumeResponse_Result_Volume::_internal_arrayname() const {
+  return arrayname_.Get();
+}
+inline void ListHaVolumeResponse_Result_Volume::_internal_set_arrayname(const std::string& value) {
+  
+  arrayname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaVolumeResponse_Result_Volume::set_arrayname(std::string&& value) {
+  
+  arrayname_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaVolumeResponse.Result.Volume.arrayName)
+}
+inline void ListHaVolumeResponse_Result_Volume::set_arrayname(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  arrayname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaVolumeResponse.Result.Volume.arrayName)
+}
+inline void ListHaVolumeResponse_Result_Volume::set_arrayname(const char* value,
+    size_t size) {
+  
+  arrayname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaVolumeResponse.Result.Volume.arrayName)
+}
+inline std::string* ListHaVolumeResponse_Result_Volume::_internal_mutable_arrayname() {
+  
+  return arrayname_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaVolumeResponse_Result_Volume::release_arrayname() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaVolumeResponse.Result.Volume.arrayName)
+  return arrayname_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaVolumeResponse_Result_Volume::set_allocated_arrayname(std::string* arrayname) {
+  if (arrayname != nullptr) {
+    
+  } else {
+    
+  }
+  arrayname_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), arrayname,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaVolumeResponse.Result.Volume.arrayName)
+}
+
+// int64 size = 5;
+inline void ListHaVolumeResponse_Result_Volume::clear_size() {
+  size_ = PROTOBUF_LONGLONG(0);
+}
+inline ::PROTOBUF_NAMESPACE_ID::int64 ListHaVolumeResponse_Result_Volume::_internal_size() const {
+  return size_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int64 ListHaVolumeResponse_Result_Volume::size() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeResponse.Result.Volume.size)
+  return _internal_size();
+}
+inline void ListHaVolumeResponse_Result_Volume::_internal_set_size(::PROTOBUF_NAMESPACE_ID::int64 value) {
+  
+  size_ = value;
+}
+inline void ListHaVolumeResponse_Result_Volume::set_size(::PROTOBUF_NAMESPACE_ID::int64 value) {
+  _internal_set_size(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaVolumeResponse.Result.Volume.size)
+}
+
+// string lastseen = 6;
+inline void ListHaVolumeResponse_Result_Volume::clear_lastseen() {
+  lastseen_.ClearToEmpty();
+}
+inline const std::string& ListHaVolumeResponse_Result_Volume::lastseen() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeResponse.Result.Volume.lastseen)
+  return _internal_lastseen();
+}
+inline void ListHaVolumeResponse_Result_Volume::set_lastseen(const std::string& value) {
+  _internal_set_lastseen(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaVolumeResponse.Result.Volume.lastseen)
+}
+inline std::string* ListHaVolumeResponse_Result_Volume::mutable_lastseen() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaVolumeResponse.Result.Volume.lastseen)
+  return _internal_mutable_lastseen();
+}
+inline const std::string& ListHaVolumeResponse_Result_Volume::_internal_lastseen() const {
+  return lastseen_.Get();
+}
+inline void ListHaVolumeResponse_Result_Volume::_internal_set_lastseen(const std::string& value) {
+  
+  lastseen_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaVolumeResponse_Result_Volume::set_lastseen(std::string&& value) {
+  
+  lastseen_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaVolumeResponse.Result.Volume.lastseen)
+}
+inline void ListHaVolumeResponse_Result_Volume::set_lastseen(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  lastseen_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaVolumeResponse.Result.Volume.lastseen)
+}
+inline void ListHaVolumeResponse_Result_Volume::set_lastseen(const char* value,
+    size_t size) {
+  
+  lastseen_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaVolumeResponse.Result.Volume.lastseen)
+}
+inline std::string* ListHaVolumeResponse_Result_Volume::_internal_mutable_lastseen() {
+  
+  return lastseen_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaVolumeResponse_Result_Volume::release_lastseen() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaVolumeResponse.Result.Volume.lastseen)
+  return lastseen_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaVolumeResponse_Result_Volume::set_allocated_lastseen(std::string* lastseen) {
+  if (lastseen != nullptr) {
+    
+  } else {
+    
+  }
+  lastseen_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), lastseen,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaVolumeResponse.Result.Volume.lastseen)
+}
+
+// -------------------------------------------------------------------
+
+// ListHaVolumeResponse_Result
+
+// .grpc_cli.Status status = 1;
+inline bool ListHaVolumeResponse_Result::_internal_has_status() const {
+  return this != internal_default_instance() && status_ != nullptr;
+}
+inline bool ListHaVolumeResponse_Result::has_status() const {
+  return _internal_has_status();
+}
+inline void ListHaVolumeResponse_Result::clear_status() {
+  if (GetArena() == nullptr && status_ != nullptr) {
+    delete status_;
+  }
+  status_ = nullptr;
+}
+inline const ::grpc_cli::Status& ListHaVolumeResponse_Result::_internal_status() const {
+  const ::grpc_cli::Status* p = status_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::Status&>(
+      ::grpc_cli::_Status_default_instance_);
+}
+inline const ::grpc_cli::Status& ListHaVolumeResponse_Result::status() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeResponse.Result.status)
+  return _internal_status();
+}
+inline void ListHaVolumeResponse_Result::unsafe_arena_set_allocated_status(
+    ::grpc_cli::Status* status) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(status_);
+  }
+  status_ = status;
+  if (status) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.ListHaVolumeResponse.Result.status)
+}
+inline ::grpc_cli::Status* ListHaVolumeResponse_Result::release_status() {
+  
+  ::grpc_cli::Status* temp = status_;
+  status_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::Status* ListHaVolumeResponse_Result::unsafe_arena_release_status() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaVolumeResponse.Result.status)
+  
+  ::grpc_cli::Status* temp = status_;
+  status_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::Status* ListHaVolumeResponse_Result::_internal_mutable_status() {
+  
+  if (status_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::Status>(GetArena());
+    status_ = p;
+  }
+  return status_;
+}
+inline ::grpc_cli::Status* ListHaVolumeResponse_Result::mutable_status() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaVolumeResponse.Result.status)
+  return _internal_mutable_status();
+}
+inline void ListHaVolumeResponse_Result::set_allocated_status(::grpc_cli::Status* status) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete status_;
+  }
+  if (status) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(status);
+    if (message_arena != submessage_arena) {
+      status = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, status, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  status_ = status;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaVolumeResponse.Result.status)
+}
+
+// repeated .grpc_cli.ListHaVolumeResponse.Result.Volume data = 2;
+inline int ListHaVolumeResponse_Result::_internal_data_size() const {
+  return data_.size();
+}
+inline int ListHaVolumeResponse_Result::data_size() const {
+  return _internal_data_size();
+}
+inline void ListHaVolumeResponse_Result::clear_data() {
+  data_.Clear();
+}
+inline ::grpc_cli::ListHaVolumeResponse_Result_Volume* ListHaVolumeResponse_Result::mutable_data(int index) {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaVolumeResponse.Result.data)
+  return data_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::grpc_cli::ListHaVolumeResponse_Result_Volume >*
+ListHaVolumeResponse_Result::mutable_data() {
+  // @@protoc_insertion_point(field_mutable_list:grpc_cli.ListHaVolumeResponse.Result.data)
+  return &data_;
+}
+inline const ::grpc_cli::ListHaVolumeResponse_Result_Volume& ListHaVolumeResponse_Result::_internal_data(int index) const {
+  return data_.Get(index);
+}
+inline const ::grpc_cli::ListHaVolumeResponse_Result_Volume& ListHaVolumeResponse_Result::data(int index) const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeResponse.Result.data)
+  return _internal_data(index);
+}
+inline ::grpc_cli::ListHaVolumeResponse_Result_Volume* ListHaVolumeResponse_Result::_internal_add_data() {
+  return data_.Add();
+}
+inline ::grpc_cli::ListHaVolumeResponse_Result_Volume* ListHaVolumeResponse_Result::add_data() {
+  // @@protoc_insertion_point(field_add:grpc_cli.ListHaVolumeResponse.Result.data)
+  return _internal_add_data();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::grpc_cli::ListHaVolumeResponse_Result_Volume >&
+ListHaVolumeResponse_Result::data() const {
+  // @@protoc_insertion_point(field_list:grpc_cli.ListHaVolumeResponse.Result.data)
+  return data_;
+}
+
+// -------------------------------------------------------------------
+
+// ListHaVolumeResponse
+
+// string command = 1;
+inline void ListHaVolumeResponse::clear_command() {
+  command_.ClearToEmpty();
+}
+inline const std::string& ListHaVolumeResponse::command() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeResponse.command)
+  return _internal_command();
+}
+inline void ListHaVolumeResponse::set_command(const std::string& value) {
+  _internal_set_command(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaVolumeResponse.command)
+}
+inline std::string* ListHaVolumeResponse::mutable_command() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaVolumeResponse.command)
+  return _internal_mutable_command();
+}
+inline const std::string& ListHaVolumeResponse::_internal_command() const {
+  return command_.Get();
+}
+inline void ListHaVolumeResponse::_internal_set_command(const std::string& value) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaVolumeResponse::set_command(std::string&& value) {
+  
+  command_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaVolumeResponse.command)
+}
+inline void ListHaVolumeResponse::set_command(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaVolumeResponse.command)
+}
+inline void ListHaVolumeResponse::set_command(const char* value,
+    size_t size) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaVolumeResponse.command)
+}
+inline std::string* ListHaVolumeResponse::_internal_mutable_command() {
+  
+  return command_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaVolumeResponse::release_command() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaVolumeResponse.command)
+  return command_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaVolumeResponse::set_allocated_command(std::string* command) {
+  if (command != nullptr) {
+    
+  } else {
+    
+  }
+  command_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), command,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaVolumeResponse.command)
+}
+
+// string rid = 2;
+inline void ListHaVolumeResponse::clear_rid() {
+  rid_.ClearToEmpty();
+}
+inline const std::string& ListHaVolumeResponse::rid() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeResponse.rid)
+  return _internal_rid();
+}
+inline void ListHaVolumeResponse::set_rid(const std::string& value) {
+  _internal_set_rid(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaVolumeResponse.rid)
+}
+inline std::string* ListHaVolumeResponse::mutable_rid() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaVolumeResponse.rid)
+  return _internal_mutable_rid();
+}
+inline const std::string& ListHaVolumeResponse::_internal_rid() const {
+  return rid_.Get();
+}
+inline void ListHaVolumeResponse::_internal_set_rid(const std::string& value) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaVolumeResponse::set_rid(std::string&& value) {
+  
+  rid_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaVolumeResponse.rid)
+}
+inline void ListHaVolumeResponse::set_rid(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaVolumeResponse.rid)
+}
+inline void ListHaVolumeResponse::set_rid(const char* value,
+    size_t size) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaVolumeResponse.rid)
+}
+inline std::string* ListHaVolumeResponse::_internal_mutable_rid() {
+  
+  return rid_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaVolumeResponse::release_rid() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaVolumeResponse.rid)
+  return rid_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaVolumeResponse::set_allocated_rid(std::string* rid) {
+  if (rid != nullptr) {
+    
+  } else {
+    
+  }
+  rid_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), rid,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaVolumeResponse.rid)
+}
+
+// .grpc_cli.ListHaVolumeResponse.Result result = 3;
+inline bool ListHaVolumeResponse::_internal_has_result() const {
+  return this != internal_default_instance() && result_ != nullptr;
+}
+inline bool ListHaVolumeResponse::has_result() const {
+  return _internal_has_result();
+}
+inline void ListHaVolumeResponse::clear_result() {
+  if (GetArena() == nullptr && result_ != nullptr) {
+    delete result_;
+  }
+  result_ = nullptr;
+}
+inline const ::grpc_cli::ListHaVolumeResponse_Result& ListHaVolumeResponse::_internal_result() const {
+  const ::grpc_cli::ListHaVolumeResponse_Result* p = result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::ListHaVolumeResponse_Result&>(
+      ::grpc_cli::_ListHaVolumeResponse_Result_default_instance_);
+}
+inline const ::grpc_cli::ListHaVolumeResponse_Result& ListHaVolumeResponse::result() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeResponse.result)
+  return _internal_result();
+}
+inline void ListHaVolumeResponse::unsafe_arena_set_allocated_result(
+    ::grpc_cli::ListHaVolumeResponse_Result* result) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(result_);
+  }
+  result_ = result;
+  if (result) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.ListHaVolumeResponse.result)
+}
+inline ::grpc_cli::ListHaVolumeResponse_Result* ListHaVolumeResponse::release_result() {
+  
+  ::grpc_cli::ListHaVolumeResponse_Result* temp = result_;
+  result_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::ListHaVolumeResponse_Result* ListHaVolumeResponse::unsafe_arena_release_result() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaVolumeResponse.result)
+  
+  ::grpc_cli::ListHaVolumeResponse_Result* temp = result_;
+  result_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::ListHaVolumeResponse_Result* ListHaVolumeResponse::_internal_mutable_result() {
+  
+  if (result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::ListHaVolumeResponse_Result>(GetArena());
+    result_ = p;
+  }
+  return result_;
+}
+inline ::grpc_cli::ListHaVolumeResponse_Result* ListHaVolumeResponse::mutable_result() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaVolumeResponse.result)
+  return _internal_mutable_result();
+}
+inline void ListHaVolumeResponse::set_allocated_result(::grpc_cli::ListHaVolumeResponse_Result* result) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete result_;
+  }
+  if (result) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(result);
+    if (message_arena != submessage_arena) {
+      result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, result, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  result_ = result;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaVolumeResponse.result)
+}
+
+// .grpc_cli.PosInfo info = 4;
+inline bool ListHaVolumeResponse::_internal_has_info() const {
+  return this != internal_default_instance() && info_ != nullptr;
+}
+inline bool ListHaVolumeResponse::has_info() const {
+  return _internal_has_info();
+}
+inline void ListHaVolumeResponse::clear_info() {
+  if (GetArena() == nullptr && info_ != nullptr) {
+    delete info_;
+  }
+  info_ = nullptr;
+}
+inline const ::grpc_cli::PosInfo& ListHaVolumeResponse::_internal_info() const {
+  const ::grpc_cli::PosInfo* p = info_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::PosInfo&>(
+      ::grpc_cli::_PosInfo_default_instance_);
+}
+inline const ::grpc_cli::PosInfo& ListHaVolumeResponse::info() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaVolumeResponse.info)
+  return _internal_info();
+}
+inline void ListHaVolumeResponse::unsafe_arena_set_allocated_info(
+    ::grpc_cli::PosInfo* info) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(info_);
+  }
+  info_ = info;
+  if (info) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.ListHaVolumeResponse.info)
+}
+inline ::grpc_cli::PosInfo* ListHaVolumeResponse::release_info() {
+  
+  ::grpc_cli::PosInfo* temp = info_;
+  info_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::PosInfo* ListHaVolumeResponse::unsafe_arena_release_info() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaVolumeResponse.info)
+  
+  ::grpc_cli::PosInfo* temp = info_;
+  info_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::PosInfo* ListHaVolumeResponse::_internal_mutable_info() {
+  
+  if (info_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::PosInfo>(GetArena());
+    info_ = p;
+  }
+  return info_;
+}
+inline ::grpc_cli::PosInfo* ListHaVolumeResponse::mutable_info() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaVolumeResponse.info)
+  return _internal_mutable_info();
+}
+inline void ListHaVolumeResponse::set_allocated_info(::grpc_cli::PosInfo* info) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete info_;
+  }
+  if (info) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(info);
+    if (message_arena != submessage_arena) {
+      info = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, info, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  info_ = info;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaVolumeResponse.info)
+}
+
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/tool/cli/cmd/clustercmds/general.go
+++ b/tool/cli/cmd/clustercmds/general.go
@@ -32,4 +32,5 @@ Example (to list nodes in the system):
 
 func init() {
 	ClusterCmd.AddCommand(ListNodeCmd)
+	ClusterCmd.AddCommand(ListHaVolumeCmd)
 }

--- a/tool/cli/cmd/clustercmds/list_ha_volume.go
+++ b/tool/cli/cmd/clustercmds/list_ha_volume.go
@@ -1,0 +1,62 @@
+package clustercmds
+
+import (
+	pb "cli/api"
+	"fmt"
+	"log"
+
+	"cli/cmd/globals"
+
+	"cli/cmd/displaymgr"
+	"cli/cmd/grpcmgr"
+
+	_ "github.com/lib/pq"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+var ListHaVolumeCmd = &cobra.Command{
+	Use:   "lv",
+	Short: "List all volumes in the cluster.",
+	Long: `
+List all nodes in the cluster.
+
+Syntax:
+	poseidonos-cli cluster lv
+          `,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		command := "LISTHAVOLUME"
+		uuid := globals.GenerateUUID()
+
+		req := &pb.ListHaVolumeRequest{Command: command, Rid: uuid, Requestor: "cli"}
+		reqJSON, err := protojson.Marshal(req)
+		if err != nil {
+			log.Fatalf("failed to marshal the protobuf request: %v", err)
+		}
+
+		displaymgr.PrintRequest(string(reqJSON))
+
+		if !(globals.IsTestingReqBld) {
+			var resJSON string
+
+			res, err := grpcmgr.SendListHaVolume(req)
+			if err != nil {
+				fmt.Println(err)
+				log.Println(err)
+				return
+			}
+			resByte, err := protojson.Marshal(res)
+			if err != nil {
+				log.Fatalf("failed to marshal the protobuf response: %v", err)
+			}
+			resJSON = string(resByte)
+
+			displaymgr.PrintResponse(command, resJSON, globals.IsDebug, globals.IsJSONRes, globals.DisplayUnit)
+		}
+	},
+}
+
+func init() {
+
+}

--- a/tool/cli/cmd/displaymgr/display_response.go
+++ b/tool/cli/cmd/displaymgr/display_response.go
@@ -572,6 +572,49 @@ func printResToHumanReadable(command string, resJSON string, displayUnit bool) {
 		}
 		w.Flush()
 
+	case "LISTHAVOLUME":
+		res := &pb.ListHaVolumeResponse{}
+		protojson.Unmarshal([]byte(resJSON), res)
+
+		if int(res.GetResult().GetStatus().GetCode()) != globals.CliServerSuccessCode {
+			printEventInfo(int(res.GetResult().GetStatus().GetCode()), res.GetResult().GetStatus().GetEventName(),
+				res.GetResult().GetStatus().GetDescription(), res.GetResult().GetStatus().GetCause(),
+				res.GetResult().GetStatus().GetSolution())
+			return
+		}
+
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+
+		// Header
+		fmt.Fprintln(w,
+			"Id\t"+
+				globals.FieldSeparator+"Name\t"+
+				globals.FieldSeparator+"NodeName\t"+
+				globals.FieldSeparator+"ArrayName\t"+
+				globals.FieldSeparator+"Size\t"+
+				globals.FieldSeparator+"Lastseen\t")
+
+		// Horizontal line
+		fmt.Fprintln(w,
+			"-------\t"+
+				globals.FieldSeparator+"-------------------\t"+
+				globals.FieldSeparator+"-------------------\t"+
+				globals.FieldSeparator+"-------------------\t"+
+				globals.FieldSeparator+"-------------------\t"+
+				globals.FieldSeparator+"-------------------\t")
+
+		// Data
+		for _, volume := range res.GetResult().GetData() {
+			fmt.Fprintln(w,
+				strconv.FormatInt(int64(volume.Id), 10)+"\t"+
+					globals.FieldSeparator+volume.Name+"\t"+
+					globals.FieldSeparator+volume.NodeName+"\t"+
+					globals.FieldSeparator+volume.ArrayName+"\t"+
+					globals.FieldSeparator+strconv.FormatInt(volume.Size, 10)+"\t"+
+					globals.FieldSeparator+volume.Lastseen+"\t")
+		}
+		w.Flush()
+
 	case "SYSTEMINFO":
 		res := messages.POSInfoResponse{}
 		json.Unmarshal([]byte(resJSON), &res)


### PR DESCRIPTION
Add LISTHAVOLUME command that displays the list of
volumes registered in HA cluster.

Name the command as LISTHAVOLUME to avoid the conflict to
LISTVOLUME command.

Refactor hadbmgr.go

Command execution:
lee@lee-Z390-DESIGNARE:~/Workspace/pos/pos-main/poseidonos/bin$ ./poseidonos-cli cluster lv
Id      |Name                |NodeName            |ArrayName           |Size                |Lastseen
------- |------------------- |------------------- |------------------- |------------------- |-------------------
1       |Volume1             |target0             |Array1              |1073741824          |2022-06-15T00:00:00Z
2       |Volume1             |clone0              |Array1              |1073741824          |2022-06-15T00:00:00Z
3       |Volume2             |clone1              |Array1              |2073741824          |2022-06-15T00:00:00Z
4       |Volume1             |target1             |Array1              |3073741824          |2022-06-13T00:00:00Z
5       |WalVolume1          |target0             |Array1              |4073741824          |2022-06-13T00:00:00Z
6       |WalVolume1          |target1             |Array1              |4073741824          |2022-06-13T00:00:00Z
7       |WalVolume1          |clone0              |Array1              |4073741824          |2022-06-13T00:00:00Z
8       |WalVolume1          |clone0              |Array1              |4073741824          |2022-06-13T00:00:00Z
9       |WalVolume1          |clone1              |Array1              |4073741824          |2022-06-13T00:00:00Z


Signed-off-by: mjlee34 <jun20.lee@samsung.com>