### PR TITLE
[AWIBOF-6360] Add LISTHAVOLUME command to CLI syntax

### DIFF
--- a/tool/cli/cmd/pos_cli_syntax.ebnf
+++ b/tool/cli/cmd/pos_cli_syntax.ebnf
@@ -306,6 +306,7 @@ UpdateEventWrrCmd = "update-event-wrr" , "--name" ,
 ResetEventWrrCmd = "reset-event-wrr" ;
 
 ClusterCmd = "cluster" ,
-  ( ListNodeCmd ) ;
+  ( ListNodeCmd | ListHaVolumeCmd ) ;
 
 ListNodeCmd = "ln" ;
+ListHaVolume = "lv" ;


### PR DESCRIPTION
Add LISTHAVOLUME command syntax to CLI syntax as it was omitted.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>