### PR TITLE
[AWIBOF-6430] change trigger of Package Upload workflow from workflow…

### DIFF
--- a/.github/workflows/72_hour.yml
+++ b/.github/workflows/72_hour.yml
@@ -95,3 +95,7 @@ jobs:
         name: Three_Days_CORE_DUMP
         path: |
           ${{github.workspace}}/tool/dump/*.tar.gz*
+
+  Call_Package_Upload:
+    needs: Three_Days_Test
+    uses: ./.github/workflows/package_upload.yml

--- a/.github/workflows/package_upload.yml
+++ b/.github/workflows/package_upload.yml
@@ -2,9 +2,7 @@
 name: Package_Upload
 
 on:
-  workflow_run:
-    workflows: [M8-72H_VM_Test]
-    types: [completed]
+  workflow_call:
 
   workflow_dispatch:
     inputs:
@@ -18,9 +16,7 @@ on:
 jobs:
   Upload_Package:
     runs-on: ubuntu-18.04
-    if: ${{github.event.workflow_run.conclusion == 'success'}} || ${{github.event_name == 'workflow_dispatch'}}
     steps:
-    
     - run: |
         sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 


### PR DESCRIPTION
[AWIBOF-6430](https://solims.swservice.samsungds.net:8080/issue/browse/AWIBOF-6430)
- 72_hour workflow에서 Three_Days_Test job이 성공으로 끝나면 package_upload workflow를 호출하도록 변경
- workflow run trigger가 workflow_call 일 경우 호출한 context에서 package build가 수행되기 때문에 빌드 된 package가 72H 테스트를 통과한 빌드임을 보장할 수 있게 됨.