### PR TITLE
[SHPOS-752] Fixed serial number was generated in the wrong form durin…

### DIFF
--- a/src/cli/create_subsystem_command.cpp
+++ b/src/cli/create_subsystem_command.cpp
@@ -135,7 +135,7 @@ CreateSubsystemCommand::_SetDefaultOptions(json& doc)
 {
     string key("subsystem");
     string number;
-
+    serialNumber = DEFAULT_SERIAL_NUMBER;
     size_t found = subnqn.rfind(key);
     if (found != string::npos)
     {


### PR DESCRIPTION
auto subsystem create command 사용 시 serial number 초기화가 빠져있어 serial number가 잘못 생성되는 이슈를 해결한 간단한 bugfix 입니다. 