### PR TITLE
[AWIBOF-6531] Increase CLI request timeout to 90 seconds

### DIFF
--- a/tool/cli/cmd/grpcmgr/grpcmgr.go
+++ b/tool/cli/cmd/grpcmgr/grpcmgr.go
@@ -14,7 +14,7 @@ import (
 
 const dialErrorMsg = "Could not connect to the CLI server. Is PoseidonOS running?"
 const dialTimeout = 10
-const reqTimeout = 30
+const reqTimeout = 90
 
 func SendSystemInfoRpc(req *pb.SystemInfoRequest) (*pb.SystemInfoResponse, error) {
 	conn, err := grpc.Dial(globals.GrpcServerAddress, grpc.WithTimeout(time.Second*dialTimeout), grpc.WithInsecure(), grpc.WithBlock())


### PR DESCRIPTION
Increase CLI request timeout from 30 seconds to 90 seconds.

With 30 seconds timeout, a deadline_exceeded event occurs
because some commands take longer than 30 seconds.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>