### PR TITLE
[AWIBOF-6545] Add BIOS, mainboard, baseboard, and processor information to SYSTEMINFO command

### DIFF
--- a/proto/cli.proto
+++ b/proto/cli.proto
@@ -190,6 +190,10 @@ message SystemInfoResponse {
 			string systemProductName = 6;
 			string systemSerialNumber = 7;
 			string systemUuid = 8;
+			string baseboardManufacturer = 9;
+			string baseboardProductName = 10;
+			string baseboardSerialNumber = 11;
+			string baseboardVersion = 12;
 		}
 		Data data = 2;
 	}

--- a/proto/cli.proto
+++ b/proto/cli.proto
@@ -184,6 +184,7 @@ message SystemInfoResponse {
 		message Data {
 			string version = 1;
 			string biosVersion = 2;
+			string biosVendor = 2;
 		}
 		Data data = 2;
 	}

--- a/proto/cli.proto
+++ b/proto/cli.proto
@@ -194,6 +194,9 @@ message SystemInfoResponse {
 			string baseboardProductName = 10;
 			string baseboardSerialNumber = 11;
 			string baseboardVersion = 12;
+			string processorManufacturer = 13;
+			string processorVersion = 14;
+			string processorFrequency = 15;
 		}
 		Data data = 2;
 	}

--- a/proto/cli.proto
+++ b/proto/cli.proto
@@ -184,8 +184,12 @@ message SystemInfoResponse {
 		message Data {
 			string version = 1;
 			string biosVersion = 2;
-			string biosVendor = 2;
-			string biosReleaseDate = 3;
+			string biosVendor = 3;
+			string biosReleaseDate = 4;
+			string systemManufacturer = 5;
+			string systemProductName = 6;
+			string systemSerialNumber = 7;
+			string systemUuid = 8;
 		}
 		Data data = 2;
 	}

--- a/proto/cli.proto
+++ b/proto/cli.proto
@@ -185,6 +185,7 @@ message SystemInfoResponse {
 			string version = 1;
 			string biosVersion = 2;
 			string biosVendor = 2;
+			string biosReleaseDate = 3;
 		}
 		Data data = 2;
 	}

--- a/proto/cli.proto
+++ b/proto/cli.proto
@@ -183,6 +183,7 @@ message SystemInfoResponse {
 		Status status = 1;
 		message Data {
 			string version = 1;
+			string biosVersion = 2;
 		}
 		Data data = 2;
 	}

--- a/proto/generated/cpp/cli.pb.cc
+++ b/proto/generated/cpp/cli.pb.cc
@@ -61,7 +61,8 @@ struct SystemInfoRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SystemInfoRequestDefaultTypeInternal _SystemInfoRequest_default_instance_;
 constexpr SystemInfoResponse_Result_Data::SystemInfoResponse_Result_Data(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
-  : version_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string){}
+  : version_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , biosversion_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string){}
 struct SystemInfoResponse_Result_DataDefaultTypeInternal {
   constexpr SystemInfoResponse_Result_DataDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
@@ -1197,6 +1198,127 @@ struct ListHaVolumeResponseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT ListHaVolumeResponseDefaultTypeInternal _ListHaVolumeResponse_default_instance_;
+constexpr ListHaReplicationRequest::ListHaReplicationRequest(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : command_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , rid_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , requestor_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string){}
+struct ListHaReplicationRequestDefaultTypeInternal {
+  constexpr ListHaReplicationRequestDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~ListHaReplicationRequestDefaultTypeInternal() {}
+  union {
+    ListHaReplicationRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT ListHaReplicationRequestDefaultTypeInternal _ListHaReplicationRequest_default_instance_;
+constexpr ListHaReplicationResponse_Result_Replication::ListHaReplicationResponse_Result_Replication(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : id_(0)
+  , sourcevolumeid_(0)
+  , sourcewalvolume_id_(0)
+  , destinationvolumeid_(0)
+  , destinationwalvolumeid_(0){}
+struct ListHaReplicationResponse_Result_ReplicationDefaultTypeInternal {
+  constexpr ListHaReplicationResponse_Result_ReplicationDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~ListHaReplicationResponse_Result_ReplicationDefaultTypeInternal() {}
+  union {
+    ListHaReplicationResponse_Result_Replication _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT ListHaReplicationResponse_Result_ReplicationDefaultTypeInternal _ListHaReplicationResponse_Result_Replication_default_instance_;
+constexpr ListHaReplicationResponse_Result::ListHaReplicationResponse_Result(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : data_()
+  , status_(nullptr){}
+struct ListHaReplicationResponse_ResultDefaultTypeInternal {
+  constexpr ListHaReplicationResponse_ResultDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~ListHaReplicationResponse_ResultDefaultTypeInternal() {}
+  union {
+    ListHaReplicationResponse_Result _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT ListHaReplicationResponse_ResultDefaultTypeInternal _ListHaReplicationResponse_Result_default_instance_;
+constexpr ListHaReplicationResponse::ListHaReplicationResponse(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : command_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , rid_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , result_(nullptr)
+  , info_(nullptr){}
+struct ListHaReplicationResponseDefaultTypeInternal {
+  constexpr ListHaReplicationResponseDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~ListHaReplicationResponseDefaultTypeInternal() {}
+  union {
+    ListHaReplicationResponse _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT ListHaReplicationResponseDefaultTypeInternal _ListHaReplicationResponse_default_instance_;
+constexpr StartHaReplicationRequest_Param::StartHaReplicationRequest_Param(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : primarynodename_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , primaryarrayname_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , primaryvolumename_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , primarywalvolumename_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , secondarynodename_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , secondaryarrayname_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , secondaryvolumename_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , secondarywalvolumename_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , stuats_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , timestamp_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string){}
+struct StartHaReplicationRequest_ParamDefaultTypeInternal {
+  constexpr StartHaReplicationRequest_ParamDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~StartHaReplicationRequest_ParamDefaultTypeInternal() {}
+  union {
+    StartHaReplicationRequest_Param _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT StartHaReplicationRequest_ParamDefaultTypeInternal _StartHaReplicationRequest_Param_default_instance_;
+constexpr StartHaReplicationRequest::StartHaReplicationRequest(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : command_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , rid_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , requestor_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , param_(nullptr){}
+struct StartHaReplicationRequestDefaultTypeInternal {
+  constexpr StartHaReplicationRequestDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~StartHaReplicationRequestDefaultTypeInternal() {}
+  union {
+    StartHaReplicationRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT StartHaReplicationRequestDefaultTypeInternal _StartHaReplicationRequest_default_instance_;
+constexpr StartHaReplicationResponse_Result::StartHaReplicationResponse_Result(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : status_(nullptr){}
+struct StartHaReplicationResponse_ResultDefaultTypeInternal {
+  constexpr StartHaReplicationResponse_ResultDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~StartHaReplicationResponse_ResultDefaultTypeInternal() {}
+  union {
+    StartHaReplicationResponse_Result _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT StartHaReplicationResponse_ResultDefaultTypeInternal _StartHaReplicationResponse_Result_default_instance_;
+constexpr StartHaReplicationResponse::StartHaReplicationResponse(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : command_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , rid_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , result_(nullptr)
+  , info_(nullptr){}
+struct StartHaReplicationResponseDefaultTypeInternal {
+  constexpr StartHaReplicationResponseDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~StartHaReplicationResponseDefaultTypeInternal() {}
+  union {
+    StartHaReplicationResponse _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT StartHaReplicationResponseDefaultTypeInternal _StartHaReplicationResponse_default_instance_;
 constexpr SetLogLevelRequest_Param::SetLogLevelRequest_Param(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : level_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string){}
@@ -1723,7 +1845,7 @@ struct GetSmartLogResponseDefaultTypeInternal {
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT GetSmartLogResponseDefaultTypeInternal _GetSmartLogResponse_default_instance_;
 }  // namespace grpc_cli
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_cli_2eproto[121];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_cli_2eproto[129];
 static constexpr ::PROTOBUF_NAMESPACE_ID::EnumDescriptor const** file_level_enum_descriptors_cli_2eproto = nullptr;
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_cli_2eproto = nullptr;
 
@@ -1763,6 +1885,7 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_cli_2eproto::offsets[] PROTOBU
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, version_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, biosversion_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -2406,6 +2529,79 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_cli_2eproto::offsets[] PROTOBU
   PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse, result_),
   PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaVolumeResponse, info_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationRequest, command_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationRequest, rid_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationRequest, requestor_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse_Result_Replication, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse_Result_Replication, id_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse_Result_Replication, sourcevolumeid_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse_Result_Replication, sourcewalvolume_id_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse_Result_Replication, destinationvolumeid_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse_Result_Replication, destinationwalvolumeid_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse_Result, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse_Result, status_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse_Result, data_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse, command_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse, rid_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse, result_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::ListHaReplicationResponse, info_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest_Param, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest_Param, primarynodename_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest_Param, primaryarrayname_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest_Param, primaryvolumename_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest_Param, primarywalvolumename_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest_Param, secondarynodename_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest_Param, secondaryarrayname_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest_Param, secondaryvolumename_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest_Param, secondarywalvolumename_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest_Param, stuats_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest_Param, timestamp_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest, command_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest, rid_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest, requestor_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationRequest, param_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationResponse_Result, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationResponse_Result, status_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationResponse, command_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationResponse, rid_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationResponse, result_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::StartHaReplicationResponse, info_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SetLogLevelRequest_Param, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -2720,123 +2916,131 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 15, -1, sizeof(::grpc_cli::PosInfo)},
   { 21, -1, sizeof(::grpc_cli::SystemInfoRequest)},
   { 29, -1, sizeof(::grpc_cli::SystemInfoResponse_Result_Data)},
-  { 35, -1, sizeof(::grpc_cli::SystemInfoResponse_Result)},
-  { 42, -1, sizeof(::grpc_cli::SystemInfoResponse)},
-  { 51, -1, sizeof(::grpc_cli::SystemStopRequest)},
-  { 59, -1, sizeof(::grpc_cli::SystemStopResponse_Result)},
-  { 65, -1, sizeof(::grpc_cli::SystemStopResponse)},
-  { 74, -1, sizeof(::grpc_cli::GetSystemPropertyRequest)},
-  { 82, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result_Data)},
-  { 88, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result)},
-  { 95, -1, sizeof(::grpc_cli::GetSystemPropertyResponse)},
-  { 104, -1, sizeof(::grpc_cli::SetSystemPropertyRequest_Param)},
-  { 110, -1, sizeof(::grpc_cli::SetSystemPropertyRequest)},
-  { 119, -1, sizeof(::grpc_cli::SetSystemPropertyResponse_Result)},
-  { 125, -1, sizeof(::grpc_cli::SetSystemPropertyResponse)},
-  { 134, -1, sizeof(::grpc_cli::StartTelemetryRequest)},
-  { 142, -1, sizeof(::grpc_cli::StartTelemetryResponse_Result)},
-  { 148, -1, sizeof(::grpc_cli::StartTelemetryResponse)},
-  { 157, -1, sizeof(::grpc_cli::StopTelemetryRequest)},
-  { 165, -1, sizeof(::grpc_cli::StopTelemetryResponse_Result)},
-  { 171, -1, sizeof(::grpc_cli::StopTelemetryResponse)},
-  { 180, -1, sizeof(::grpc_cli::ResetEventWrrRequest)},
-  { 188, -1, sizeof(::grpc_cli::ResetEventWrrResponse_Result)},
-  { 194, -1, sizeof(::grpc_cli::ResetEventWrrResponse)},
-  { 203, -1, sizeof(::grpc_cli::ResetMbrRequest)},
-  { 211, -1, sizeof(::grpc_cli::ResetMbrResponse_Result)},
-  { 217, -1, sizeof(::grpc_cli::ResetMbrResponse)},
-  { 226, -1, sizeof(::grpc_cli::StopRebuildingRequest_Param)},
-  { 232, -1, sizeof(::grpc_cli::StopRebuildingRequest)},
-  { 241, -1, sizeof(::grpc_cli::StopRebuildingResponse_Result)},
-  { 247, -1, sizeof(::grpc_cli::StopRebuildingResponse)},
-  { 256, -1, sizeof(::grpc_cli::UpdateEventWrrRequest_Param)},
-  { 263, -1, sizeof(::grpc_cli::UpdateEventWrrRequest)},
-  { 272, -1, sizeof(::grpc_cli::UpdateEventWrrResponse_Result)},
-  { 278, -1, sizeof(::grpc_cli::UpdateEventWrrResponse)},
-  { 287, -1, sizeof(::grpc_cli::AddSpareRequest_SpareDeviceName)},
-  { 293, -1, sizeof(::grpc_cli::AddSpareRequest_Param)},
-  { 300, -1, sizeof(::grpc_cli::AddSpareRequest)},
-  { 309, -1, sizeof(::grpc_cli::AddSpareResponse_Result)},
-  { 315, -1, sizeof(::grpc_cli::AddSpareResponse)},
-  { 324, -1, sizeof(::grpc_cli::DeviceNameList)},
-  { 330, -1, sizeof(::grpc_cli::RemoveSpareRequest_SpareDeviceName)},
-  { 336, -1, sizeof(::grpc_cli::RemoveSpareRequest_Param)},
-  { 343, -1, sizeof(::grpc_cli::RemoveSpareRequest)},
-  { 352, -1, sizeof(::grpc_cli::RemoveSpareResponse_Result)},
-  { 358, -1, sizeof(::grpc_cli::RemoveSpareResponse)},
-  { 367, -1, sizeof(::grpc_cli::CreateArrayRequest_Param)},
-  { 377, -1, sizeof(::grpc_cli::CreateArrayRequest)},
-  { 386, -1, sizeof(::grpc_cli::CreateArrayResponse_Result)},
-  { 392, -1, sizeof(::grpc_cli::CreateArrayResponse)},
-  { 401, -1, sizeof(::grpc_cli::AutocreateArrayRequest_Param)},
-  { 411, -1, sizeof(::grpc_cli::AutocreateArrayRequest)},
-  { 420, -1, sizeof(::grpc_cli::AutocreateArrayResponse_Result)},
-  { 426, -1, sizeof(::grpc_cli::AutocreateArrayResponse)},
-  { 435, -1, sizeof(::grpc_cli::DeleteArrayRequest_Param)},
-  { 441, -1, sizeof(::grpc_cli::DeleteArrayRequest)},
-  { 450, -1, sizeof(::grpc_cli::DeleteArrayResponse_Result)},
-  { 456, -1, sizeof(::grpc_cli::DeleteArrayResponse)},
-  { 465, 472, sizeof(::grpc_cli::MountArrayRequest_Param)},
-  { 474, -1, sizeof(::grpc_cli::MountArrayRequest)},
-  { 483, -1, sizeof(::grpc_cli::MountArrayResponse_Result)},
-  { 489, -1, sizeof(::grpc_cli::MountArrayResponse)},
-  { 498, -1, sizeof(::grpc_cli::UnmountArrayRequest_Param)},
-  { 504, -1, sizeof(::grpc_cli::UnmountArrayRequest)},
-  { 513, -1, sizeof(::grpc_cli::UnmountArrayResponse_Result)},
-  { 519, -1, sizeof(::grpc_cli::UnmountArrayResponse)},
-  { 528, -1, sizeof(::grpc_cli::Array)},
-  { 549, -1, sizeof(::grpc_cli::ListArrayRequest)},
-  { 557, -1, sizeof(::grpc_cli::ListArrayResponse_Result_ArrayList)},
-  { 563, -1, sizeof(::grpc_cli::ListArrayResponse_Result)},
-  { 570, -1, sizeof(::grpc_cli::ListArrayResponse)},
-  { 579, -1, sizeof(::grpc_cli::ArrayInfoRequest_Param)},
-  { 585, -1, sizeof(::grpc_cli::ArrayInfoRequest)},
-  { 594, -1, sizeof(::grpc_cli::ArrayInfoResponse_Result)},
-  { 601, -1, sizeof(::grpc_cli::ArrayInfoResponse)},
-  { 610, -1, sizeof(::grpc_cli::ListNodeRequest)},
-  { 618, -1, sizeof(::grpc_cli::ListNodeResponse_Result_Node)},
-  { 626, -1, sizeof(::grpc_cli::ListNodeResponse_Result)},
-  { 633, -1, sizeof(::grpc_cli::ListNodeResponse)},
-  { 642, -1, sizeof(::grpc_cli::ListHaVolumeRequest)},
-  { 650, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result_Volume)},
-  { 661, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result)},
-  { 668, -1, sizeof(::grpc_cli::ListHaVolumeResponse)},
-  { 677, -1, sizeof(::grpc_cli::SetLogLevelRequest_Param)},
-  { 683, -1, sizeof(::grpc_cli::SetLogLevelRequest)},
-  { 692, -1, sizeof(::grpc_cli::SetLogLevelResponse_Result)},
-  { 698, -1, sizeof(::grpc_cli::SetLogLevelResponse)},
-  { 707, -1, sizeof(::grpc_cli::SetLogPreferenceRequest_Param)},
-  { 713, -1, sizeof(::grpc_cli::SetLogPreferenceRequest)},
-  { 722, -1, sizeof(::grpc_cli::SetLogPreferenceResponse_Result)},
-  { 728, -1, sizeof(::grpc_cli::SetLogPreferenceResponse)},
-  { 737, -1, sizeof(::grpc_cli::LoggerInfoRequest)},
-  { 745, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result_LoggerInfo)},
-  { 759, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result)},
-  { 766, -1, sizeof(::grpc_cli::LoggerInfoResponse)},
-  { 775, -1, sizeof(::grpc_cli::GetLogLevelRequest)},
-  { 783, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result_LogLevel)},
-  { 789, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result)},
-  { 796, -1, sizeof(::grpc_cli::GetLogLevelResponse)},
-  { 805, -1, sizeof(::grpc_cli::ApplyLogFilterRequest)},
-  { 813, -1, sizeof(::grpc_cli::ApplyLogFilterResponse_Result)},
-  { 819, -1, sizeof(::grpc_cli::ApplyLogFilterResponse)},
-  { 828, -1, sizeof(::grpc_cli::CreateDeviceRequest_Param)},
-  { 838, -1, sizeof(::grpc_cli::CreateDeviceRequest)},
-  { 847, -1, sizeof(::grpc_cli::CreateDeviceResponse_Result)},
-  { 853, -1, sizeof(::grpc_cli::CreateDeviceResponse)},
-  { 862, -1, sizeof(::grpc_cli::ScanDeviceRequest)},
-  { 870, -1, sizeof(::grpc_cli::ScanDeviceResponse_Result)},
-  { 876, -1, sizeof(::grpc_cli::ScanDeviceResponse)},
-  { 885, -1, sizeof(::grpc_cli::Device)},
-  { 898, -1, sizeof(::grpc_cli::ListDeviceRequest)},
-  { 906, -1, sizeof(::grpc_cli::ListDeviceResponse_Result_DeviceList)},
-  { 912, -1, sizeof(::grpc_cli::ListDeviceResponse_Result)},
-  { 919, -1, sizeof(::grpc_cli::ListDeviceResponse)},
-  { 928, -1, sizeof(::grpc_cli::SmartLog)},
-  { 955, -1, sizeof(::grpc_cli::GetSmartLogRequest_Param)},
-  { 961, -1, sizeof(::grpc_cli::GetSmartLogRequest)},
-  { 970, -1, sizeof(::grpc_cli::GetSmartLogResponse_Result)},
-  { 977, -1, sizeof(::grpc_cli::GetSmartLogResponse)},
+  { 36, -1, sizeof(::grpc_cli::SystemInfoResponse_Result)},
+  { 43, -1, sizeof(::grpc_cli::SystemInfoResponse)},
+  { 52, -1, sizeof(::grpc_cli::SystemStopRequest)},
+  { 60, -1, sizeof(::grpc_cli::SystemStopResponse_Result)},
+  { 66, -1, sizeof(::grpc_cli::SystemStopResponse)},
+  { 75, -1, sizeof(::grpc_cli::GetSystemPropertyRequest)},
+  { 83, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result_Data)},
+  { 89, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result)},
+  { 96, -1, sizeof(::grpc_cli::GetSystemPropertyResponse)},
+  { 105, -1, sizeof(::grpc_cli::SetSystemPropertyRequest_Param)},
+  { 111, -1, sizeof(::grpc_cli::SetSystemPropertyRequest)},
+  { 120, -1, sizeof(::grpc_cli::SetSystemPropertyResponse_Result)},
+  { 126, -1, sizeof(::grpc_cli::SetSystemPropertyResponse)},
+  { 135, -1, sizeof(::grpc_cli::StartTelemetryRequest)},
+  { 143, -1, sizeof(::grpc_cli::StartTelemetryResponse_Result)},
+  { 149, -1, sizeof(::grpc_cli::StartTelemetryResponse)},
+  { 158, -1, sizeof(::grpc_cli::StopTelemetryRequest)},
+  { 166, -1, sizeof(::grpc_cli::StopTelemetryResponse_Result)},
+  { 172, -1, sizeof(::grpc_cli::StopTelemetryResponse)},
+  { 181, -1, sizeof(::grpc_cli::ResetEventWrrRequest)},
+  { 189, -1, sizeof(::grpc_cli::ResetEventWrrResponse_Result)},
+  { 195, -1, sizeof(::grpc_cli::ResetEventWrrResponse)},
+  { 204, -1, sizeof(::grpc_cli::ResetMbrRequest)},
+  { 212, -1, sizeof(::grpc_cli::ResetMbrResponse_Result)},
+  { 218, -1, sizeof(::grpc_cli::ResetMbrResponse)},
+  { 227, -1, sizeof(::grpc_cli::StopRebuildingRequest_Param)},
+  { 233, -1, sizeof(::grpc_cli::StopRebuildingRequest)},
+  { 242, -1, sizeof(::grpc_cli::StopRebuildingResponse_Result)},
+  { 248, -1, sizeof(::grpc_cli::StopRebuildingResponse)},
+  { 257, -1, sizeof(::grpc_cli::UpdateEventWrrRequest_Param)},
+  { 264, -1, sizeof(::grpc_cli::UpdateEventWrrRequest)},
+  { 273, -1, sizeof(::grpc_cli::UpdateEventWrrResponse_Result)},
+  { 279, -1, sizeof(::grpc_cli::UpdateEventWrrResponse)},
+  { 288, -1, sizeof(::grpc_cli::AddSpareRequest_SpareDeviceName)},
+  { 294, -1, sizeof(::grpc_cli::AddSpareRequest_Param)},
+  { 301, -1, sizeof(::grpc_cli::AddSpareRequest)},
+  { 310, -1, sizeof(::grpc_cli::AddSpareResponse_Result)},
+  { 316, -1, sizeof(::grpc_cli::AddSpareResponse)},
+  { 325, -1, sizeof(::grpc_cli::DeviceNameList)},
+  { 331, -1, sizeof(::grpc_cli::RemoveSpareRequest_SpareDeviceName)},
+  { 337, -1, sizeof(::grpc_cli::RemoveSpareRequest_Param)},
+  { 344, -1, sizeof(::grpc_cli::RemoveSpareRequest)},
+  { 353, -1, sizeof(::grpc_cli::RemoveSpareResponse_Result)},
+  { 359, -1, sizeof(::grpc_cli::RemoveSpareResponse)},
+  { 368, -1, sizeof(::grpc_cli::CreateArrayRequest_Param)},
+  { 378, -1, sizeof(::grpc_cli::CreateArrayRequest)},
+  { 387, -1, sizeof(::grpc_cli::CreateArrayResponse_Result)},
+  { 393, -1, sizeof(::grpc_cli::CreateArrayResponse)},
+  { 402, -1, sizeof(::grpc_cli::AutocreateArrayRequest_Param)},
+  { 412, -1, sizeof(::grpc_cli::AutocreateArrayRequest)},
+  { 421, -1, sizeof(::grpc_cli::AutocreateArrayResponse_Result)},
+  { 427, -1, sizeof(::grpc_cli::AutocreateArrayResponse)},
+  { 436, -1, sizeof(::grpc_cli::DeleteArrayRequest_Param)},
+  { 442, -1, sizeof(::grpc_cli::DeleteArrayRequest)},
+  { 451, -1, sizeof(::grpc_cli::DeleteArrayResponse_Result)},
+  { 457, -1, sizeof(::grpc_cli::DeleteArrayResponse)},
+  { 466, 473, sizeof(::grpc_cli::MountArrayRequest_Param)},
+  { 475, -1, sizeof(::grpc_cli::MountArrayRequest)},
+  { 484, -1, sizeof(::grpc_cli::MountArrayResponse_Result)},
+  { 490, -1, sizeof(::grpc_cli::MountArrayResponse)},
+  { 499, -1, sizeof(::grpc_cli::UnmountArrayRequest_Param)},
+  { 505, -1, sizeof(::grpc_cli::UnmountArrayRequest)},
+  { 514, -1, sizeof(::grpc_cli::UnmountArrayResponse_Result)},
+  { 520, -1, sizeof(::grpc_cli::UnmountArrayResponse)},
+  { 529, -1, sizeof(::grpc_cli::Array)},
+  { 550, -1, sizeof(::grpc_cli::ListArrayRequest)},
+  { 558, -1, sizeof(::grpc_cli::ListArrayResponse_Result_ArrayList)},
+  { 564, -1, sizeof(::grpc_cli::ListArrayResponse_Result)},
+  { 571, -1, sizeof(::grpc_cli::ListArrayResponse)},
+  { 580, -1, sizeof(::grpc_cli::ArrayInfoRequest_Param)},
+  { 586, -1, sizeof(::grpc_cli::ArrayInfoRequest)},
+  { 595, -1, sizeof(::grpc_cli::ArrayInfoResponse_Result)},
+  { 602, -1, sizeof(::grpc_cli::ArrayInfoResponse)},
+  { 611, -1, sizeof(::grpc_cli::ListNodeRequest)},
+  { 619, -1, sizeof(::grpc_cli::ListNodeResponse_Result_Node)},
+  { 627, -1, sizeof(::grpc_cli::ListNodeResponse_Result)},
+  { 634, -1, sizeof(::grpc_cli::ListNodeResponse)},
+  { 643, -1, sizeof(::grpc_cli::ListHaVolumeRequest)},
+  { 651, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result_Volume)},
+  { 662, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result)},
+  { 669, -1, sizeof(::grpc_cli::ListHaVolumeResponse)},
+  { 678, -1, sizeof(::grpc_cli::ListHaReplicationRequest)},
+  { 686, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result_Replication)},
+  { 696, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result)},
+  { 703, -1, sizeof(::grpc_cli::ListHaReplicationResponse)},
+  { 712, -1, sizeof(::grpc_cli::StartHaReplicationRequest_Param)},
+  { 727, -1, sizeof(::grpc_cli::StartHaReplicationRequest)},
+  { 736, -1, sizeof(::grpc_cli::StartHaReplicationResponse_Result)},
+  { 742, -1, sizeof(::grpc_cli::StartHaReplicationResponse)},
+  { 751, -1, sizeof(::grpc_cli::SetLogLevelRequest_Param)},
+  { 757, -1, sizeof(::grpc_cli::SetLogLevelRequest)},
+  { 766, -1, sizeof(::grpc_cli::SetLogLevelResponse_Result)},
+  { 772, -1, sizeof(::grpc_cli::SetLogLevelResponse)},
+  { 781, -1, sizeof(::grpc_cli::SetLogPreferenceRequest_Param)},
+  { 787, -1, sizeof(::grpc_cli::SetLogPreferenceRequest)},
+  { 796, -1, sizeof(::grpc_cli::SetLogPreferenceResponse_Result)},
+  { 802, -1, sizeof(::grpc_cli::SetLogPreferenceResponse)},
+  { 811, -1, sizeof(::grpc_cli::LoggerInfoRequest)},
+  { 819, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result_LoggerInfo)},
+  { 833, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result)},
+  { 840, -1, sizeof(::grpc_cli::LoggerInfoResponse)},
+  { 849, -1, sizeof(::grpc_cli::GetLogLevelRequest)},
+  { 857, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result_LogLevel)},
+  { 863, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result)},
+  { 870, -1, sizeof(::grpc_cli::GetLogLevelResponse)},
+  { 879, -1, sizeof(::grpc_cli::ApplyLogFilterRequest)},
+  { 887, -1, sizeof(::grpc_cli::ApplyLogFilterResponse_Result)},
+  { 893, -1, sizeof(::grpc_cli::ApplyLogFilterResponse)},
+  { 902, -1, sizeof(::grpc_cli::CreateDeviceRequest_Param)},
+  { 912, -1, sizeof(::grpc_cli::CreateDeviceRequest)},
+  { 921, -1, sizeof(::grpc_cli::CreateDeviceResponse_Result)},
+  { 927, -1, sizeof(::grpc_cli::CreateDeviceResponse)},
+  { 936, -1, sizeof(::grpc_cli::ScanDeviceRequest)},
+  { 944, -1, sizeof(::grpc_cli::ScanDeviceResponse_Result)},
+  { 950, -1, sizeof(::grpc_cli::ScanDeviceResponse)},
+  { 959, -1, sizeof(::grpc_cli::Device)},
+  { 972, -1, sizeof(::grpc_cli::ListDeviceRequest)},
+  { 980, -1, sizeof(::grpc_cli::ListDeviceResponse_Result_DeviceList)},
+  { 986, -1, sizeof(::grpc_cli::ListDeviceResponse_Result)},
+  { 993, -1, sizeof(::grpc_cli::ListDeviceResponse)},
+  { 1002, -1, sizeof(::grpc_cli::SmartLog)},
+  { 1029, -1, sizeof(::grpc_cli::GetSmartLogRequest_Param)},
+  { 1035, -1, sizeof(::grpc_cli::GetSmartLogRequest)},
+  { 1044, -1, sizeof(::grpc_cli::GetSmartLogResponse_Result)},
+  { 1051, -1, sizeof(::grpc_cli::GetSmartLogResponse)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -2925,6 +3129,14 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListHaVolumeResponse_Result_Volume_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListHaVolumeResponse_Result_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListHaVolumeResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListHaReplicationRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListHaReplicationResponse_Result_Replication_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListHaReplicationResponse_Result_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ListHaReplicationResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_StartHaReplicationRequest_Param_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_StartHaReplicationRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_StartHaReplicationResponse_Result_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_StartHaReplicationResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_SetLogLevelRequest_Param_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_SetLogLevelRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_SetLogLevelResponse_Result_default_instance_),
@@ -2972,378 +3184,405 @@ const char descriptor_table_protodef_cli_2eproto[] PROTOBUF_SECTION_VARIABLE(pro
   "tionB\010\n\006_causeB\013\n\t_solution\"\032\n\007PosInfo\022\017"
   "\n\007version\030\001 \001(\t\"D\n\021SystemInfoRequest\022\017\n\007"
   "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030"
-  "\003 \001(\t\"\205\002\n\022SystemInfoResponse\022\017\n\007command\030"
+  "\003 \001(\t\"\233\002\n\022SystemInfoResponse\022\017\n\007command\030"
   "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grp"
   "c_cli.SystemInfoResponse.Result\022\037\n\004info\030"
-  "\004 \001(\0132\021.grpc_cli.PosInfo\032{\n\006Result\022 \n\006st"
-  "atus\030\001 \001(\0132\020.grpc_cli.Status\0226\n\004data\030\002 \001"
-  "(\0132(.grpc_cli.SystemInfoResponse.Result."
-  "Data\032\027\n\004Data\022\017\n\007version\030\001 \001(\t\"D\n\021SystemS"
-  "topRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t"
-  "\022\021\n\trequestor\030\003 \001(\t\"\264\001\n\022SystemStopRespon"
-  "se\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006resu"
-  "lt\030\003 \001(\0132#.grpc_cli.SystemStopResponse.R"
-  "esult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*"
-  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
-  "us\"K\n\030GetSystemPropertyRequest\022\017\n\007comman"
-  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\""
-  "\242\002\n\031GetSystemPropertyResponse\022\017\n\007command"
-  "\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022:\n\006result\030\003 \001(\0132*.gr"
-  "pc_cli.GetSystemPropertyResponse.Result\022"
-  "\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\211\001\n\006Res"
-  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022=\n"
-  "\004data\030\002 \001(\0132/.grpc_cli.GetSystemProperty"
-  "Response.Result.Data\032\036\n\004Data\022\026\n\016rebuild_"
-  "policy\030\001 \001(\t\"\234\001\n\030SetSystemPropertyReques"
-  "t\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treque"
-  "stor\030\003 \001(\t\0227\n\005param\030\004 \001(\0132(.grpc_cli.Set"
-  "SystemPropertyRequest.Param\032\026\n\005Param\022\r\n\005"
-  "level\030\001 \001(\t\"\302\001\n\031SetSystemPropertyRespons"
-  "e\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022:\n\006resul"
-  "t\030\003 \001(\0132*.grpc_cli.SetSystemPropertyResp"
-  "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
-  "Info\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
-  "i.Status\"H\n\025StartTelemetryRequest\022\017\n\007com"
-  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001"
-  "(\t\"\274\001\n\026StartTelemetryResponse\022\017\n\007command"
-  "\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'.gr"
-  "pc_cli.StartTelemetryResponse.Result\022\037\n\004"
-  "info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022"
-  " \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"G\n\024Sto"
-  "pTelemetryRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
-  "d\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\272\001\n\025StopTelem"
-  "etryResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001"
-  "(\t\0226\n\006result\030\003 \001(\0132&.grpc_cli.StopTeleme"
+  "\004 \001(\0132\021.grpc_cli.PosInfo\032\220\001\n\006Result\022 \n\006s"
+  "tatus\030\001 \001(\0132\020.grpc_cli.Status\0226\n\004data\030\002 "
+  "\001(\0132(.grpc_cli.SystemInfoResponse.Result"
+  ".Data\032,\n\004Data\022\017\n\007version\030\001 \001(\t\022\023\n\013biosVe"
+  "rsion\030\002 \001(\t\"D\n\021SystemStopRequest\022\017\n\007comm"
+  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001("
+  "\t\"\264\001\n\022SystemStopResponse\022\017\n\007command\030\001 \001("
+  "\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cl"
+  "i.SystemStopResponse.Result\022\037\n\004info\030\004 \001("
+  "\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006status"
+  "\030\001 \001(\0132\020.grpc_cli.Status\"K\n\030GetSystemPro"
+  "pertyRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001"
+  "(\t\022\021\n\trequestor\030\003 \001(\t\"\242\002\n\031GetSystemPrope"
+  "rtyResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001("
+  "\t\022:\n\006result\030\003 \001(\0132*.grpc_cli.GetSystemPr"
+  "opertyResponse.Result\022\037\n\004info\030\004 \001(\0132\021.gr"
+  "pc_cli.PosInfo\032\211\001\n\006Result\022 \n\006status\030\001 \001("
+  "\0132\020.grpc_cli.Status\022=\n\004data\030\002 \001(\0132/.grpc"
+  "_cli.GetSystemPropertyResponse.Result.Da"
+  "ta\032\036\n\004Data\022\026\n\016rebuild_policy\030\001 \001(\t\"\234\001\n\030S"
+  "etSystemPropertyRequest\022\017\n\007command\030\001 \001(\t"
+  "\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0227\n\005para"
+  "m\030\004 \001(\0132(.grpc_cli.SetSystemPropertyRequ"
+  "est.Param\032\026\n\005Param\022\r\n\005level\030\001 \001(\t\"\302\001\n\031Se"
+  "tSystemPropertyResponse\022\017\n\007command\030\001 \001(\t"
+  "\022\013\n\003rid\030\002 \001(\t\022:\n\006result\030\003 \001(\0132*.grpc_cli"
+  ".SetSystemPropertyResponse.Result\022\037\n\004inf"
+  "o\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006"
+  "status\030\001 \001(\0132\020.grpc_cli.Status\"H\n\025StartT"
+  "elemetryRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
+  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\274\001\n\026StartTeleme"
+  "tryResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001("
+  "\t\0227\n\006result\030\003 \001(\0132\'.grpc_cli.StartTeleme"
   "tryResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_"
   "cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020."
-  "grpc_cli.Status\"G\n\024ResetEventWrrRequest\022"
+  "grpc_cli.Status\"G\n\024StopTelemetryRequest\022"
   "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequest"
-  "or\030\003 \001(\t\"\272\001\n\025ResetEventWrrResponse\022\017\n\007co"
+  "or\030\003 \001(\t\"\272\001\n\025StopTelemetryResponse\022\017\n\007co"
   "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0226\n\006result\030\003 \001(\013"
-  "2&.grpc_cli.ResetEventWrrResponse.Result"
+  "2&.grpc_cli.StopTelemetryResponse.Result"
   "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Res"
-  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"B\n"
-  "\017ResetMbrRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
-  "\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\260\001\n\020ResetMbrRe"
-  "sponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006"
-  "result\030\003 \001(\0132!.grpc_cli.ResetMbrResponse"
-  ".Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo"
-  "\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.St"
-  "atus\"\225\001\n\025StopRebuildingRequest\022\017\n\007comman"
-  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022"
-  "4\n\005param\030\004 \001(\0132%.grpc_cli.StopRebuilding"
-  "Request.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\274\001\n"
-  "\026StopRebuildingResponse\022\017\n\007command\030\001 \001(\t"
-  "\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'.grpc_cli"
-  ".StopRebuildingResponse.Result\022\037\n\004info\030\004"
-  " \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006sta"
-  "tus\030\001 \001(\0132\020.grpc_cli.Status\"\245\001\n\025UpdateEv"
-  "entWrrRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 "
-  "\001(\t\022\021\n\trequestor\030\003 \001(\t\0224\n\005param\030\004 \001(\0132%."
-  "grpc_cli.UpdateEventWrrRequest.Param\032%\n\005"
-  "Param\022\014\n\004name\030\001 \001(\t\022\016\n\006weight\030\002 \001(\003\"\274\001\n\026"
-  "UpdateEventWrrResponse\022\017\n\007command\030\001 \001(\t\022"
-  "\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'.grpc_cli."
-  "UpdateEventWrrResponse.Result\022\037\n\004info\030\004 "
+  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"G\n"
+  "\024ResetEventWrrRequest\022\017\n\007command\030\001 \001(\t\022\013"
+  "\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\272\001\n\025Reset"
+  "EventWrrResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
+  "\030\002 \001(\t\0226\n\006result\030\003 \001(\0132&.grpc_cli.ResetE"
+  "ventWrrResponse.Result\022\037\n\004info\030\004 \001(\0132\021.g"
+  "rpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001("
+  "\0132\020.grpc_cli.Status\"B\n\017ResetMbrRequest\022\017"
+  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequesto"
+  "r\030\003 \001(\t\"\260\001\n\020ResetMbrResponse\022\017\n\007command\030"
+  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grp"
+  "c_cli.ResetMbrResponse.Result\022\037\n\004info\030\004 "
   "\001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006stat"
-  "us\030\001 \001(\0132\020.grpc_cli.Status\"\353\001\n\017AddSpareR"
-  "equest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\t"
-  "requestor\030\003 \001(\t\022.\n\005param\030\004 \001(\0132\037.grpc_cl"
-  "i.AddSpareRequest.Param\032%\n\017SpareDeviceNa"
-  "me\022\022\n\ndeviceName\030\001 \001(\t\032P\n\005Param\022\r\n\005array"
-  "\030\001 \001(\t\0228\n\005spare\030\003 \003(\0132).grpc_cli.AddSpar"
-  "eRequest.SpareDeviceName\"\260\001\n\020AddSpareRes"
-  "ponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006r"
-  "esult\030\003 \001(\0132!.grpc_cli.AddSpareResponse."
-  "Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032"
-  "*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Sta"
-  "tus\"$\n\016DeviceNameList\022\022\n\ndeviceName\030\001 \001("
-  "\t\"\364\001\n\022RemoveSpareRequest\022\017\n\007command\030\001 \001("
-  "\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005par"
-  "am\030\004 \001(\0132\".grpc_cli.RemoveSpareRequest.P"
-  "aram\032%\n\017SpareDeviceName\022\022\n\ndeviceName\030\001 "
-  "\001(\t\032S\n\005Param\022\r\n\005array\030\001 \001(\t\022;\n\005spare\030\002 \003"
-  "(\0132,.grpc_cli.RemoveSpareRequest.SpareDe"
-  "viceName\"\266\001\n\023RemoveSpareResponse\022\017\n\007comm"
-  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$"
-  ".grpc_cli.RemoveSpareResponse.Result\022\037\n\004"
-  "info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022"
-  " \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\235\002\n\022Cr"
-  "eateArrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
-  "\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005param\030\004 \001(\013"
-  "2\".grpc_cli.CreateArrayRequest.Param\032\242\001\n"
-  "\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006buffer\030\002 \003(\0132\030.g"
-  "rpc_cli.DeviceNameList\022&\n\004data\030\003 \003(\0132\030.g"
-  "rpc_cli.DeviceNameList\022\'\n\005spare\030\004 \003(\0132\030."
-  "grpc_cli.DeviceNameList\022\020\n\010raidtype\030\005 \001("
-  "\t\"\266\001\n\023CreateArrayResponse\022\017\n\007command\030\001 \001"
-  "(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_c"
-  "li.CreateArrayResponse.Result\022\037\n\004info\030\004 "
-  "\001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006stat"
-  "us\030\001 \001(\0132\020.grpc_cli.Status\"\366\001\n\026Autocreat"
-  "eArrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 "
-  "\001(\t\022\021\n\trequestor\030\003 \001(\t\0225\n\005param\030\004 \001(\0132&."
-  "grpc_cli.AutocreateArrayRequest.Param\032t\n"
-  "\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006buffer\030\002 \003(\0132\030.g"
-  "rpc_cli.DeviceNameList\022\017\n\007numData\030\003 \001(\005\022"
-  "\020\n\010numSpare\030\004 \001(\005\022\020\n\010raidtype\030\005 \001(\t\"\276\001\n\027"
-  "AutocreateArrayResponse\022\017\n\007command\030\001 \001(\t"
-  "\022\013\n\003rid\030\002 \001(\t\0228\n\006result\030\003 \001(\0132(.grpc_cli"
-  ".AutocreateArrayResponse.Result\022\037\n\004info\030"
-  "\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006st"
-  "atus\030\001 \001(\0132\020.grpc_cli.Status\"\217\001\n\022DeleteA"
-  "rrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001("
-  "\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".gr"
-  "pc_cli.DeleteArrayRequest.Param\032\025\n\005Param"
-  "\022\014\n\004name\030\001 \001(\t\"\266\001\n\023DeleteArrayResponse\022\017"
-  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003"
-  " \001(\0132$.grpc_cli.DeleteArrayResponse.Resu"
-  "lt\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006R"
-  "esult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\""
-  "\305\001\n\021MountArrayRequest\022\017\n\007command\030\001 \001(\t\022\013"
-  "\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0220\n\005param\030"
-  "\004 \001(\0132!.grpc_cli.MountArrayRequest.Param"
-  "\032M\n\005Param\022\014\n\004name\030\001 \001(\t\022\037\n\022enableWriteTh"
-  "rough\030\002 \001(\010H\000\210\001\001B\025\n\023_enableWriteThrough\""
-  "\264\001\n\022MountArrayResponse\022\017\n\007command\030\001 \001(\t\022"
-  "\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cli."
-  "MountArrayResponse.Result\022\037\n\004info\030\004 \001(\0132"
-  "\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001"
-  " \001(\0132\020.grpc_cli.Status\"\221\001\n\023UnmountArrayR"
-  "equest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\t"
-  "requestor\030\003 \001(\t\0222\n\005param\030\004 \001(\0132#.grpc_cl"
-  "i.UnmountArrayRequest.Param\032\025\n\005Param\022\014\n\004"
-  "name\030\001 \001(\t\"\270\001\n\024UnmountArrayResponse\022\017\n\007c"
-  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001("
-  "\0132%.grpc_cli.UnmountArrayResponse.Result"
-  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Res"
-  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\314\002"
-  "\n\005Array\022\r\n\005index\030\001 \001(\005\022\021\n\tunique_id\030\002 \001("
-  "\005\022\014\n\004name\030\003 \001(\t\022\016\n\006status\030\004 \001(\t\022\r\n\005state"
-  "\030\005 \001(\t\022\021\n\tsituation\030\006 \001(\t\022\026\n\016createDatet"
-  "ime\030\007 \001(\t\022\026\n\016updateDatetime\030\010 \001(\t\022\032\n\022reb"
-  "uildingProgress\030\t \001(\t\022\020\n\010capacity\030\n \001(\004\022"
-  "\014\n\004used\030\013 \001(\004\022\016\n\006gcMode\030\014 \001(\t\022\020\n\010metaRai"
-  "d\030\r \001(\t\022\020\n\010dataRaid\030\016 \001(\t\022\033\n\023writeThroug"
-  "hEnabled\030\017 \001(\010\022$\n\ndevicelist\030\020 \003(\0132\020.grp"
-  "c_cli.Device\"C\n\020ListArrayRequest\022\017\n\007comm"
-  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001("
-  "\t\"\240\002\n\021ListArrayResponse\022\017\n\007command\030\001 \001(\t"
-  "\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003 \001(\0132\".grpc_cli"
-  ".ListArrayResponse.Result\022\037\n\004info\030\004 \001(\0132"
-  "\021.grpc_cli.PosInfo\032\227\001\n\006Result\022 \n\006status\030"
-  "\001 \001(\0132\020.grpc_cli.Status\022:\n\004data\030\002 \001(\0132,."
-  "grpc_cli.ListArrayResponse.Result.ArrayL"
-  "ist\032/\n\tArrayList\022\"\n\tarrayList\030\001 \003(\0132\017.gr"
-  "pc_cli.Array\"\213\001\n\020ArrayInfoRequest\022\017\n\007com"
-  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001"
-  "(\t\022/\n\005param\030\004 \001(\0132 .grpc_cli.ArrayInfoRe"
-  "quest.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\321\001\n\021A"
-  "rrayInfoResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
-  "\030\002 \001(\t\0222\n\006result\030\003 \001(\0132\".grpc_cli.ArrayI"
-  "nfoResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_"
-  "cli.PosInfo\032I\n\006Result\022 \n\006status\030\001 \001(\0132\020."
-  "grpc_cli.Status\022\035\n\004data\030\002 \001(\0132\017.grpc_cli"
-  ".Array\"B\n\017ListNodeRequest\022\017\n\007command\030\001 \001"
-  "(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\233\002\n\020L"
-  "istNodeResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cli.ListNod"
-  "eResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cl"
-  "i.PosInfo\032\224\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.g"
-  "rpc_cli.Status\0224\n\004data\030\002 \003(\0132&.grpc_cli."
-  "ListNodeResponse.Result.Node\0322\n\004Node\022\014\n\004"
-  "name\030\001 \001(\t\022\n\n\002ip\030\002 \001(\t\022\020\n\010lastseen\030\003 \001(\t"
-  "\"F\n\023ListHaVolumeRequest\022\017\n\007command\030\001 \001(\t"
-  "\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\336\002\n\024Lis"
-  "tHaVolumeResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
-  "d\030\002 \001(\t\0225\n\006result\030\003 \001(\0132%.grpc_cli.ListH"
-  "aVolumeResponse.Result\022\037\n\004info\030\004 \001(\0132\021.g"
-  "rpc_cli.PosInfo\032\317\001\n\006Result\022 \n\006status\030\001 \001"
-  "(\0132\020.grpc_cli.Status\022:\n\004data\030\002 \003(\0132,.grp"
-  "c_cli.ListHaVolumeResponse.Result.Volume"
-  "\032g\n\006Volume\022\n\n\002id\030\001 \001(\005\022\014\n\004name\030\002 \001(\t\022\020\n\010"
-  "nodeName\030\003 \001(\t\022\021\n\tarrayName\030\004 \001(\t\022\014\n\004siz"
-  "e\030\005 \001(\003\022\020\n\010lastseen\030\006 \001(\t\"\220\001\n\022SetLogLeve"
-  "lRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021"
-  "\n\trequestor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_"
-  "cli.SetLogLevelRequest.Param\032\026\n\005Param\022\r\n"
-  "\005level\030\001 \001(\t\"\266\001\n\023SetLogLevelResponse\022\017\n\007"
-  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001"
-  "(\0132$.grpc_cli.SetLogLevelResponse.Result"
-  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Res"
-  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\246\001"
-  "\n\027SetLogPreferenceRequest\022\017\n\007command\030\001 \001"
-  "(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0226\n\005pa"
-  "ram\030\004 \001(\0132\'.grpc_cli.SetLogPreferenceReq"
-  "uest.Param\032\"\n\005Param\022\031\n\021structuredLogging"
-  "\030\001 \001(\t\"\300\001\n\030SetLogPreferenceResponse\022\017\n\007c"
-  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0229\n\006result\030\003 \001("
-  "\0132).grpc_cli.SetLogPreferenceResponse.Re"
-  "sult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n"
-  "\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Statu"
-  "s\"D\n\021LoggerInfoRequest\022\017\n\007command\030\001 \001(\t\022"
-  "\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\345\003\n\022Logg"
-  "erInfoResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
-  " \001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.LoggerIn"
-  "foResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_c"
-  "li.PosInfo\032\332\002\n\006Result\022 \n\006status\030\001 \001(\0132\020."
-  "grpc_cli.Status\022<\n\004data\030\002 \001(\0132..grpc_cli"
-  ".LoggerInfoResponse.Result.LoggerInfo\032\357\001"
-  "\n\nLoggerInfo\022\024\n\014minorLogPath\030\001 \001(\t\022\024\n\014ma"
-  "jorLogPath\030\002 \001(\t\022\027\n\017logfileSizeInMb\030\003 \001("
-  "\t\022\034\n\024logfileRotationCount\030\004 \001(\005\022\034\n\024minAl"
-  "lowableLogLevel\030\005 \001(\t\022\025\n\rfilterEnabled\030\006"
-  " \001(\005\022\026\n\016filterIncluded\030\007 \001(\t\022\026\n\016filterEx"
-  "cluded\030\010 \001(\t\022\031\n\021structuredLogging\030\t \001(\010\""
-  "E\n\022GetLogLevelRequest\022\017\n\007command\030\001 \001(\t\022\013"
-  "\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\217\002\n\023GetLo"
-  "gLevelResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
-  " \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.GetLogLe"
-  "velResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_"
-  "cli.PosInfo\032\202\001\n\006Result\022 \n\006status\030\001 \001(\0132\020"
-  ".grpc_cli.Status\022;\n\004data\030\002 \001(\0132-.grpc_cl"
-  "i.GetLogLevelResponse.Result.LogLevel\032\031\n"
-  "\010LogLevel\022\r\n\005level\030\001 \001(\t\"H\n\025ApplyLogFilt"
-  "erRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022"
-  "\021\n\trequestor\030\003 \001(\t\"\274\001\n\026ApplyLogFilterRes"
+  "us\030\001 \001(\0132\020.grpc_cli.Status\"\225\001\n\025StopRebui"
+  "ldingRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001"
+  "(\t\022\021\n\trequestor\030\003 \001(\t\0224\n\005param\030\004 \001(\0132%.g"
+  "rpc_cli.StopRebuildingRequest.Param\032\025\n\005P"
+  "aram\022\014\n\004name\030\001 \001(\t\"\274\001\n\026StopRebuildingRes"
   "ponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006r"
-  "esult\030\003 \001(\0132\'.grpc_cli.ApplyLogFilterRes"
+  "esult\030\003 \001(\0132\'.grpc_cli.StopRebuildingRes"
   "ponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Po"
   "sInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_c"
-  "li.Status\"\326\001\n\023CreateDeviceRequest\022\017\n\007com"
+  "li.Status\"\245\001\n\025UpdateEventWrrRequest\022\017\n\007c"
+  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003"
+  " \001(\t\0224\n\005param\030\004 \001(\0132%.grpc_cli.UpdateEve"
+  "ntWrrRequest.Param\032%\n\005Param\022\014\n\004name\030\001 \001("
+  "\t\022\016\n\006weight\030\002 \001(\003\"\274\001\n\026UpdateEventWrrResp"
+  "onse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006re"
+  "sult\030\003 \001(\0132\'.grpc_cli.UpdateEventWrrResp"
+  "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
+  "Info\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
+  "i.Status\"\353\001\n\017AddSpareRequest\022\017\n\007command\030"
+  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022.\n"
+  "\005param\030\004 \001(\0132\037.grpc_cli.AddSpareRequest."
+  "Param\032%\n\017SpareDeviceName\022\022\n\ndeviceName\030\001"
+  " \001(\t\032P\n\005Param\022\r\n\005array\030\001 \001(\t\0228\n\005spare\030\003 "
+  "\003(\0132).grpc_cli.AddSpareRequest.SpareDevi"
+  "ceName\"\260\001\n\020AddSpareResponse\022\017\n\007command\030\001"
+  " \001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc"
+  "_cli.AddSpareResponse.Result\022\037\n\004info\030\004 \001"
+  "(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006statu"
+  "s\030\001 \001(\0132\020.grpc_cli.Status\"$\n\016DeviceNameL"
+  "ist\022\022\n\ndeviceName\030\001 \001(\t\"\364\001\n\022RemoveSpareR"
+  "equest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\t"
+  "requestor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cl"
+  "i.RemoveSpareRequest.Param\032%\n\017SpareDevic"
+  "eName\022\022\n\ndeviceName\030\001 \001(\t\032S\n\005Param\022\r\n\005ar"
+  "ray\030\001 \001(\t\022;\n\005spare\030\002 \003(\0132,.grpc_cli.Remo"
+  "veSpareRequest.SpareDeviceName\"\266\001\n\023Remov"
+  "eSpareResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
+  " \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.RemoveSp"
+  "areResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_"
+  "cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020."
+  "grpc_cli.Status\"\235\002\n\022CreateArrayRequest\022\017"
+  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequesto"
+  "r\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.Create"
+  "ArrayRequest.Param\032\242\001\n\005Param\022\014\n\004name\030\001 \001"
+  "(\t\022(\n\006buffer\030\002 \003(\0132\030.grpc_cli.DeviceName"
+  "List\022&\n\004data\030\003 \003(\0132\030.grpc_cli.DeviceName"
+  "List\022\'\n\005spare\030\004 \003(\0132\030.grpc_cli.DeviceNam"
+  "eList\022\020\n\010raidtype\030\005 \001(\t\"\266\001\n\023CreateArrayR"
+  "esponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n"
+  "\006result\030\003 \001(\0132$.grpc_cli.CreateArrayResp"
+  "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
+  "Info\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
+  "i.Status\"\366\001\n\026AutocreateArrayRequest\022\017\n\007c"
+  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003"
+  " \001(\t\0225\n\005param\030\004 \001(\0132&.grpc_cli.Autocreat"
+  "eArrayRequest.Param\032t\n\005Param\022\014\n\004name\030\001 \001"
+  "(\t\022(\n\006buffer\030\002 \003(\0132\030.grpc_cli.DeviceName"
+  "List\022\017\n\007numData\030\003 \001(\005\022\020\n\010numSpare\030\004 \001(\005\022"
+  "\020\n\010raidtype\030\005 \001(\t\"\276\001\n\027AutocreateArrayRes"
+  "ponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0228\n\006r"
+  "esult\030\003 \001(\0132(.grpc_cli.AutocreateArrayRe"
+  "sponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.P"
+  "osInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_"
+  "cli.Status\"\217\001\n\022DeleteArrayRequest\022\017\n\007com"
   "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001"
-  "(\t\0222\n\005param\030\004 \001(\0132#.grpc_cli.CreateDevic"
-  "eRequest.Param\032Z\n\005Param\022\014\n\004name\030\001 \001(\t\022\021\n"
-  "\tnumBlocks\030\002 \001(\r\022\021\n\tblockSize\030\003 \001(\r\022\017\n\007d"
-  "evType\030\004 \001(\t\022\014\n\004numa\030\005 \001(\r\"\270\001\n\024CreateDev"
-  "iceResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001("
-  "\t\0225\n\006result\030\003 \001(\0132%.grpc_cli.CreateDevic"
-  "eResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cl"
-  "i.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.gr"
-  "pc_cli.Status\"D\n\021ScanDeviceRequest\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 "
-  "\001(\t\"\264\001\n\022ScanDeviceResponse\022\017\n\007command\030\001 "
-  "\001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grpc_"
-  "cli.ScanDeviceResponse.Result\022\037\n\004info\030\004 "
-  "\001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006stat"
-  "us\030\001 \001(\0132\020.grpc_cli.Status\"\213\001\n\006Device\022\014\n"
-  "\004name\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\022\017\n\007address\030\003 \001"
-  "(\t\022\r\n\005class\030\004 \001(\t\022\023\n\013modelNumber\030\005 \001(\t\022\014"
-  "\n\004numa\030\006 \001(\t\022\014\n\004size\030\007 \001(\004\022\024\n\014serialNumb"
-  "er\030\010 \001(\t\"D\n\021ListDeviceRequest\022\017\n\007command"
-  "\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\247"
-  "\002\n\022ListDeviceResponse\022\017\n\007command\030\001 \001(\t\022\013"
-  "\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.L"
-  "istDeviceResponse.Result\022\037\n\004info\030\004 \001(\0132\021"
-  ".grpc_cli.PosInfo\032\234\001\n\006Result\022 \n\006status\030\001"
-  " \001(\0132\020.grpc_cli.Status\022<\n\004data\030\002 \001(\0132..g"
-  "rpc_cli.ListDeviceResponse.Result.Device"
-  "List\0322\n\nDeviceList\022$\n\ndevicelist\030\001 \003(\0132\020"
-  ".grpc_cli.Device\"\335\004\n\010SmartLog\022\033\n\023availab"
-  "leSpareSpace\030\001 \001(\t\022\023\n\013temperature\030\002 \001(\t\022"
-  "\031\n\021deviceReliability\030\003 \001(\t\022\020\n\010readOnly\030\004"
-  " \001(\t\022\034\n\024volatileMemoryBackup\030\005 \001(\t\022\032\n\022cu"
-  "rrentTemperature\030\006 \001(\t\022\026\n\016availableSpare"
-  "\030\007 \001(\t\022\037\n\027availableSpareThreshold\030\010 \001(\t\022"
-  "\032\n\022lifePercentageUsed\030\t \001(\t\022\025\n\rdataUnits"
-  "Read\030\n \001(\t\022\030\n\020dataUnitsWritten\030\013 \001(\t\022\030\n\020"
-  "hostReadCommands\030\014 \001(\t\022\031\n\021hostWriteComma"
-  "nds\030\r \001(\t\022\032\n\022controllerBusyTime\030\016 \001(\t\022\023\n"
-  "\013powerCycles\030\017 \001(\t\022\024\n\014powerOnHours\030\020 \001(\t"
-  "\022\027\n\017unsafeShutdowns\030\021 \001(\t\022 \n\030unrecoverab"
-  "leMediaErrors\030\022 \001(\t\022\037\n\027lifetimeErrorLogE"
-  "ntries\030\023 \001(\t\022\036\n\026warningTemperatureTime\030\024"
-  " \001(\t\022\037\n\027criticalTemperatureTime\030\025 \001(\t\022\031\n"
-  "\021temperatureSensor\030\026 \003(\t\"\217\001\n\022GetSmartLog"
+  "(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.DeleteArray"
+  "Request.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\266\001\n"
+  "\023DeleteArrayResponse\022\017\n\007command\030\001 \001(\t\022\013\n"
+  "\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.De"
+  "leteArrayResponse.Result\022\037\n\004info\030\004 \001(\0132\021"
+  ".grpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 "
+  "\001(\0132\020.grpc_cli.Status\"\305\001\n\021MountArrayRequ"
+  "est\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treq"
+  "uestor\030\003 \001(\t\0220\n\005param\030\004 \001(\0132!.grpc_cli.M"
+  "ountArrayRequest.Param\032M\n\005Param\022\014\n\004name\030"
+  "\001 \001(\t\022\037\n\022enableWriteThrough\030\002 \001(\010H\000\210\001\001B\025"
+  "\n\023_enableWriteThrough\"\264\001\n\022MountArrayResp"
+  "onse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006re"
+  "sult\030\003 \001(\0132#.grpc_cli.MountArrayResponse"
+  ".Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo"
+  "\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.St"
+  "atus\"\221\001\n\023UnmountArrayRequest\022\017\n\007command\030"
+  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n"
+  "\005param\030\004 \001(\0132#.grpc_cli.UnmountArrayRequ"
+  "est.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\270\001\n\024Unm"
+  "ountArrayResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
+  "d\030\002 \001(\t\0225\n\006result\030\003 \001(\0132%.grpc_cli.Unmou"
+  "ntArrayResponse.Result\022\037\n\004info\030\004 \001(\0132\021.g"
+  "rpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001("
+  "\0132\020.grpc_cli.Status\"\314\002\n\005Array\022\r\n\005index\030\001"
+  " \001(\005\022\021\n\tunique_id\030\002 \001(\005\022\014\n\004name\030\003 \001(\t\022\016\n"
+  "\006status\030\004 \001(\t\022\r\n\005state\030\005 \001(\t\022\021\n\tsituatio"
+  "n\030\006 \001(\t\022\026\n\016createDatetime\030\007 \001(\t\022\026\n\016updat"
+  "eDatetime\030\010 \001(\t\022\032\n\022rebuildingProgress\030\t "
+  "\001(\t\022\020\n\010capacity\030\n \001(\004\022\014\n\004used\030\013 \001(\004\022\016\n\006g"
+  "cMode\030\014 \001(\t\022\020\n\010metaRaid\030\r \001(\t\022\020\n\010dataRai"
+  "d\030\016 \001(\t\022\033\n\023writeThroughEnabled\030\017 \001(\010\022$\n\n"
+  "devicelist\030\020 \003(\0132\020.grpc_cli.Device\"C\n\020Li"
+  "stArrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
+  " \001(\t\022\021\n\trequestor\030\003 \001(\t\"\240\002\n\021ListArrayRes"
+  "ponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006r"
+  "esult\030\003 \001(\0132\".grpc_cli.ListArrayResponse"
+  ".Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo"
+  "\032\227\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.S"
+  "tatus\022:\n\004data\030\002 \001(\0132,.grpc_cli.ListArray"
+  "Response.Result.ArrayList\032/\n\tArrayList\022\""
+  "\n\tarrayList\030\001 \003(\0132\017.grpc_cli.Array\"\213\001\n\020A"
+  "rrayInfoRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
+  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022/\n\005param\030\004 \001(\0132"
+  " .grpc_cli.ArrayInfoRequest.Param\032\025\n\005Par"
+  "am\022\014\n\004name\030\001 \001(\t\"\321\001\n\021ArrayInfoResponse\022\017"
+  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003"
+  " \001(\0132\".grpc_cli.ArrayInfoResponse.Result"
+  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032I\n\006Res"
+  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022\035\n"
+  "\004data\030\002 \001(\0132\017.grpc_cli.Array\"B\n\017ListNode"
   "Request\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n"
-  "\trequestor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_c"
-  "li.GetSmartLogRequest.Param\032\025\n\005Param\022\014\n\004"
-  "name\030\001 \001(\t\"\330\001\n\023GetSmartLogResponse\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\013"
-  "2$.grpc_cli.GetSmartLogResponse.Result\022\037"
-  "\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032L\n\006Resul"
-  "t\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022 \n\004d"
-  "ata\030\002 \001(\0132\022.grpc_cli.SmartLog2\221\026\n\006PosCli"
-  "\022_\n\nSystemInfo\022\033.grpc_cli.SystemInfoRequ"
-  "est\032\034.grpc_cli.SystemInfoResponse\"\026\202\323\344\223\002"
-  "\020\022\016/v1/systeminfo\022_\n\nSystemStop\022\033.grpc_c"
-  "li.SystemStopRequest\032\034.grpc_cli.SystemSt"
-  "opResponse\"\026\202\323\344\223\002\020\022\016/v1/systemstop\022}\n\021Ge"
-  "tSystemProperty\022\".grpc_cli.GetSystemProp"
-  "ertyRequest\032#.grpc_cli.GetSystemProperty"
-  "Response\"\037\202\323\344\223\002\031\022\027/v1/get_system_propert"
-  "y\022\205\001\n\021SetSystemProperty\022\".grpc_cli.SetSy"
-  "stemPropertyRequest\032#.grpc_cli.SetSystem"
-  "PropertyResponse\"\'\202\323\344\223\002!\022\037/v1/set_system"
-  "_property/{level}\022p\n\016StartTelemetry\022\037.gr"
-  "pc_cli.StartTelemetryRequest\032 .grpc_cli."
-  "StartTelemetryResponse\"\033\202\323\344\223\002\025\022\023/v1/star"
-  "t_telemetry\022l\n\rStopTelemetry\022\036.grpc_cli."
-  "StopTelemetryRequest\032\037.grpc_cli.StopTele"
-  "metryResponse\"\032\202\323\344\223\002\024\022\022/v1/stop_telemetr"
-  "y\022P\n\rResetEventWrr\022\036.grpc_cli.ResetEvent"
-  "WrrRequest\032\037.grpc_cli.ResetEventWrrRespo"
-  "nse\022A\n\010ResetMbr\022\031.grpc_cli.ResetMbrReque"
-  "st\032\032.grpc_cli.ResetMbrResponse\022S\n\016StopRe"
-  "building\022\037.grpc_cli.StopRebuildingReques"
-  "t\032 .grpc_cli.StopRebuildingResponse\022S\n\016U"
-  "pdateEventWrr\022\037.grpc_cli.UpdateEventWrrR"
-  "equest\032 .grpc_cli.UpdateEventWrrResponse"
-  "\022W\n\010AddSpare\022\031.grpc_cli.AddSpareRequest\032"
-  "\032.grpc_cli.AddSpareResponse\"\024\202\323\344\223\002\016\"\014/v1"
-  "/addspare\022c\n\013RemoveSpare\022\034.grpc_cli.Remo"
-  "veSpareRequest\032\035.grpc_cli.RemoveSpareRes"
-  "ponse\"\027\202\323\344\223\002\021\"\017/v1/removespare\022c\n\013Create"
-  "Array\022\034.grpc_cli.CreateArrayRequest\032\035.gr"
-  "pc_cli.CreateArrayResponse\"\027\202\323\344\223\002\021\"\017/v1/"
-  "createarray\022s\n\017AutocreateArray\022 .grpc_cl"
-  "i.AutocreateArrayRequest\032!.grpc_cli.Auto"
-  "createArrayResponse\"\033\202\323\344\223\002\025\"\023/v1/autocre"
-  "atearray\022d\n\013DeleteArray\022\034.grpc_cli.Delet"
-  "eArrayRequest\032\035.grpc_cli.DeleteArrayResp"
-  "onse\"\030\202\323\344\223\002\022\"\020/v1/deletearray/\022_\n\nMountA"
-  "rray\022\033.grpc_cli.MountArrayRequest\032\034.grpc"
-  "_cli.MountArrayResponse\"\026\202\323\344\223\002\020\"\016/v1/mou"
-  "ntarray\022g\n\014UnmountArray\022\035.grpc_cli.Unmou"
-  "ntArrayRequest\032\036.grpc_cli.UnmountArrayRe"
-  "sponse\"\030\202\323\344\223\002\022\"\020/v1/unmountarray\022[\n\tList"
-  "Array\022\032.grpc_cli.ListArrayRequest\032\033.grpc"
-  "_cli.ListArrayResponse\"\025\202\323\344\223\002\017\"\r/v1/list"
-  "array\022[\n\tArrayInfo\022\032.grpc_cli.ArrayInfoR"
-  "equest\032\033.grpc_cli.ArrayInfoResponse\"\025\202\323\344"
-  "\223\002\017\"\r/v1/arrayinfo\022w\n\020SetLogPreference\022!"
-  ".grpc_cli.SetLogPreferenceRequest\032\".grpc"
-  "_cli.SetLogPreferenceResponse\"\034\202\323\344\223\002\026\"\024/"
-  "v1/setlogpreference\022c\n\013SetLogLevel\022\034.grp"
-  "c_cli.SetLogLevelRequest\032\035.grpc_cli.SetL"
-  "ogLevelResponse\"\027\202\323\344\223\002\021\"\017/v1/setloglevel"
-  "\022_\n\nLoggerInfo\022\033.grpc_cli.LoggerInfoRequ"
-  "est\032\034.grpc_cli.LoggerInfoResponse\"\026\202\323\344\223\002"
-  "\020\"\016/v1/loggerinfo\022c\n\013GetLogLevel\022\034.grpc_"
-  "cli.GetLogLevelRequest\032\035.grpc_cli.GetLog"
-  "LevelResponse\"\027\202\323\344\223\002\021\"\017/v1/getloglevel\022l"
-  "\n\016ApplyLogFilter\022\037.grpc_cli.ApplyLogFilt"
-  "erRequest\032 .grpc_cli.ApplyLogFilterRespo"
-  "nse\"\027\202\323\344\223\002\021\"\017/v1/applyfilter\022g\n\014CreateDe"
-  "vice\022\035.grpc_cli.CreateDeviceRequest\032\036.gr"
-  "pc_cli.CreateDeviceResponse\"\030\202\323\344\223\002\022\"\020/v1"
-  "/createdevice\022_\n\nScanDevice\022\033.grpc_cli.S"
-  "canDeviceRequest\032\034.grpc_cli.ScanDeviceRe"
-  "sponse\"\026\202\323\344\223\002\020\"\016/v1/scandevice\022_\n\nListDe"
-  "vice\022\033.grpc_cli.ListDeviceRequest\032\034.grpc"
-  "_cli.ListDeviceResponse\"\026\202\323\344\223\002\020\"\016/v1/lis"
-  "tdevice\022`\n\013GetSmartLog\022\034.grpc_cli.GetSma"
-  "rtLogRequest\032\035.grpc_cli.GetSmartLogRespo"
-  "nse\"\024\202\323\344\223\002\016\"\014/v1/smartlogB\tZ\007cli/apib\006pr"
-  "oto3"
+  "\trequestor\030\003 \001(\t\"\233\002\n\020ListNodeResponse\022\017\n"
+  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006result\030\003 "
+  "\001(\0132!.grpc_cli.ListNodeResponse.Result\022\037"
+  "\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\224\001\n\006Resu"
+  "lt\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\0224\n\004"
+  "data\030\002 \003(\0132&.grpc_cli.ListNodeResponse.R"
+  "esult.Node\0322\n\004Node\022\014\n\004name\030\001 \001(\t\022\n\n\002ip\030\002"
+  " \001(\t\022\020\n\010lastseen\030\003 \001(\t\"F\n\023ListHaVolumeRe"
+  "quest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tr"
+  "equestor\030\003 \001(\t\"\336\002\n\024ListHaVolumeResponse\022"
+  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030"
+  "\003 \001(\0132%.grpc_cli.ListHaVolumeResponse.Re"
+  "sult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\317\001"
+  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
+  "us\022:\n\004data\030\002 \003(\0132,.grpc_cli.ListHaVolume"
+  "Response.Result.Volume\032g\n\006Volume\022\n\n\002id\030\001"
+  " \001(\005\022\014\n\004name\030\002 \001(\t\022\020\n\010nodeName\030\003 \001(\t\022\021\n\t"
+  "arrayName\030\004 \001(\t\022\014\n\004size\030\005 \001(\003\022\020\n\010lastsee"
+  "n\030\006 \001(\t\"K\n\030ListHaReplicationRequest\022\017\n\007c"
+  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003"
+  " \001(\t\"\226\003\n\031ListHaReplicationResponse\022\017\n\007co"
+  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022:\n\006result\030\003 \001(\013"
+  "2*.grpc_cli.ListHaReplicationResponse.Re"
+  "sult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\375\001"
+  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
+  "us\022D\n\004data\030\002 \003(\01326.grpc_cli.ListHaReplic"
+  "ationResponse.Result.Replication\032\212\001\n\013Rep"
+  "lication\022\n\n\002id\030\001 \001(\005\022\026\n\016sourceVolumeId\030\002"
+  " \001(\005\022\032\n\022sourceWalVolume_id\030\003 \001(\005\022\033\n\023dest"
+  "inationVolumeId\030\004 \001(\005\022\036\n\026destinationWalV"
+  "olumeId\030\005 \001(\005\"\223\003\n\031StartHaReplicationRequ"
+  "est\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treq"
+  "uestor\030\003 \001(\t\0228\n\005param\030\004 \001(\0132).grpc_cli.S"
+  "tartHaReplicationRequest.Param\032\212\002\n\005Param"
+  "\022\027\n\017primaryNodeName\030\001 \001(\t\022\030\n\020primaryArra"
+  "yName\030\002 \001(\t\022\031\n\021primaryVolumeName\030\003 \001(\t\022\034"
+  "\n\024primaryWalVolumeName\030\004 \001(\t\022\031\n\021secondar"
+  "yNodeName\030\005 \001(\t\022\032\n\022secondaryArrayName\030\006 "
+  "\001(\t\022\033\n\023secondaryVolumeName\030\007 \001(\t\022\036\n\026seco"
+  "ndaryWalVolumeName\030\010 \001(\t\022\016\n\006stuats\030\t \001(\t"
+  "\022\021\n\ttimestamp\030\n \001(\t\"\304\001\n\032StartHaReplicati"
+  "onResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t"
+  "\022;\n\006result\030\003 \001(\0132+.grpc_cli.StartHaRepli"
+  "cationResponse.Result\022\037\n\004info\030\004 \001(\0132\021.gr"
+  "pc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\013"
+  "2\020.grpc_cli.Status\"\220\001\n\022SetLogLevelReques"
+  "t\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treque"
+  "stor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.Set"
+  "LogLevelRequest.Param\032\026\n\005Param\022\r\n\005level\030"
+  "\001 \001(\t\"\266\001\n\023SetLogLevelResponse\022\017\n\007command"
+  "\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.gr"
+  "pc_cli.SetLogLevelResponse.Result\022\037\n\004inf"
+  "o\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006"
+  "status\030\001 \001(\0132\020.grpc_cli.Status\"\246\001\n\027SetLo"
+  "gPreferenceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003r"
+  "id\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0226\n\005param\030\004 \001"
+  "(\0132\'.grpc_cli.SetLogPreferenceRequest.Pa"
+  "ram\032\"\n\005Param\022\031\n\021structuredLogging\030\001 \001(\t\""
+  "\300\001\n\030SetLogPreferenceResponse\022\017\n\007command\030"
+  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0229\n\006result\030\003 \001(\0132).grp"
+  "c_cli.SetLogPreferenceResponse.Result\022\037\n"
+  "\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result"
+  "\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"D\n\021Lo"
+  "ggerInfoRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
+  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\345\003\n\022LoggerInfoR"
+  "esponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n"
+  "\006result\030\003 \001(\0132#.grpc_cli.LoggerInfoRespo"
+  "nse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosI"
+  "nfo\032\332\002\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
+  "i.Status\022<\n\004data\030\002 \001(\0132..grpc_cli.Logger"
+  "InfoResponse.Result.LoggerInfo\032\357\001\n\nLogge"
+  "rInfo\022\024\n\014minorLogPath\030\001 \001(\t\022\024\n\014majorLogP"
+  "ath\030\002 \001(\t\022\027\n\017logfileSizeInMb\030\003 \001(\t\022\034\n\024lo"
+  "gfileRotationCount\030\004 \001(\005\022\034\n\024minAllowable"
+  "LogLevel\030\005 \001(\t\022\025\n\rfilterEnabled\030\006 \001(\005\022\026\n"
+  "\016filterIncluded\030\007 \001(\t\022\026\n\016filterExcluded\030"
+  "\010 \001(\t\022\031\n\021structuredLogging\030\t \001(\010\"E\n\022GetL"
+  "ogLevelRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
+  " \001(\t\022\021\n\trequestor\030\003 \001(\t\"\217\002\n\023GetLogLevelR"
+  "esponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n"
+  "\006result\030\003 \001(\0132$.grpc_cli.GetLogLevelResp"
+  "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
+  "Info\032\202\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_c"
+  "li.Status\022;\n\004data\030\002 \001(\0132-.grpc_cli.GetLo"
+  "gLevelResponse.Result.LogLevel\032\031\n\010LogLev"
+  "el\022\r\n\005level\030\001 \001(\t\"H\n\025ApplyLogFilterReque"
+  "st\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequ"
+  "estor\030\003 \001(\t\"\274\001\n\026ApplyLogFilterResponse\022\017"
+  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003"
+  " \001(\0132\'.grpc_cli.ApplyLogFilterResponse.R"
+  "esult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*"
+  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
+  "us\"\326\001\n\023CreateDeviceRequest\022\017\n\007command\030\001 "
+  "\001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005p"
+  "aram\030\004 \001(\0132#.grpc_cli.CreateDeviceReques"
+  "t.Param\032Z\n\005Param\022\014\n\004name\030\001 \001(\t\022\021\n\tnumBlo"
+  "cks\030\002 \001(\r\022\021\n\tblockSize\030\003 \001(\r\022\017\n\007devType\030"
+  "\004 \001(\t\022\014\n\004numa\030\005 \001(\r\"\270\001\n\024CreateDeviceResp"
+  "onse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006re"
+  "sult\030\003 \001(\0132%.grpc_cli.CreateDeviceRespon"
+  "se.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosIn"
+  "fo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli."
+  "Status\"D\n\021ScanDeviceRequest\022\017\n\007command\030\001"
+  " \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\264\001\n"
+  "\022ScanDeviceResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003"
+  "rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.Sca"
+  "nDeviceResponse.Result\022\037\n\004info\030\004 \001(\0132\021.g"
+  "rpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001("
+  "\0132\020.grpc_cli.Status\"\213\001\n\006Device\022\014\n\004name\030\001"
+  " \001(\t\022\014\n\004type\030\002 \001(\t\022\017\n\007address\030\003 \001(\t\022\r\n\005c"
+  "lass\030\004 \001(\t\022\023\n\013modelNumber\030\005 \001(\t\022\014\n\004numa\030"
+  "\006 \001(\t\022\014\n\004size\030\007 \001(\004\022\024\n\014serialNumber\030\010 \001("
+  "\t\"D\n\021ListDeviceRequest\022\017\n\007command\030\001 \001(\t\022"
+  "\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\247\002\n\022List"
+  "DeviceResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
+  " \001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.ListDevi"
+  "ceResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_c"
+  "li.PosInfo\032\234\001\n\006Result\022 \n\006status\030\001 \001(\0132\020."
+  "grpc_cli.Status\022<\n\004data\030\002 \001(\0132..grpc_cli"
+  ".ListDeviceResponse.Result.DeviceList\0322\n"
+  "\nDeviceList\022$\n\ndevicelist\030\001 \003(\0132\020.grpc_c"
+  "li.Device\"\335\004\n\010SmartLog\022\033\n\023availableSpare"
+  "Space\030\001 \001(\t\022\023\n\013temperature\030\002 \001(\t\022\031\n\021devi"
+  "ceReliability\030\003 \001(\t\022\020\n\010readOnly\030\004 \001(\t\022\034\n"
+  "\024volatileMemoryBackup\030\005 \001(\t\022\032\n\022currentTe"
+  "mperature\030\006 \001(\t\022\026\n\016availableSpare\030\007 \001(\t\022"
+  "\037\n\027availableSpareThreshold\030\010 \001(\t\022\032\n\022life"
+  "PercentageUsed\030\t \001(\t\022\025\n\rdataUnitsRead\030\n "
+  "\001(\t\022\030\n\020dataUnitsWritten\030\013 \001(\t\022\030\n\020hostRea"
+  "dCommands\030\014 \001(\t\022\031\n\021hostWriteCommands\030\r \001"
+  "(\t\022\032\n\022controllerBusyTime\030\016 \001(\t\022\023\n\013powerC"
+  "ycles\030\017 \001(\t\022\024\n\014powerOnHours\030\020 \001(\t\022\027\n\017uns"
+  "afeShutdowns\030\021 \001(\t\022 \n\030unrecoverableMedia"
+  "Errors\030\022 \001(\t\022\037\n\027lifetimeErrorLogEntries\030"
+  "\023 \001(\t\022\036\n\026warningTemperatureTime\030\024 \001(\t\022\037\n"
+  "\027criticalTemperatureTime\030\025 \001(\t\022\031\n\021temper"
+  "atureSensor\030\026 \003(\t\"\217\001\n\022GetSmartLogRequest"
+  "\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treques"
+  "tor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.GetS"
+  "martLogRequest.Param\032\025\n\005Param\022\014\n\004name\030\001 "
+  "\001(\t\"\330\001\n\023GetSmartLogResponse\022\017\n\007command\030\001"
+  " \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc"
+  "_cli.GetSmartLogResponse.Result\022\037\n\004info\030"
+  "\004 \001(\0132\021.grpc_cli.PosInfo\032L\n\006Result\022 \n\006st"
+  "atus\030\001 \001(\0132\020.grpc_cli.Status\022 \n\004data\030\002 \001"
+  "(\0132\022.grpc_cli.SmartLog2\221\026\n\006PosCli\022_\n\nSys"
+  "temInfo\022\033.grpc_cli.SystemInfoRequest\032\034.g"
+  "rpc_cli.SystemInfoResponse\"\026\202\323\344\223\002\020\022\016/v1/"
+  "systeminfo\022_\n\nSystemStop\022\033.grpc_cli.Syst"
+  "emStopRequest\032\034.grpc_cli.SystemStopRespo"
+  "nse\"\026\202\323\344\223\002\020\022\016/v1/systemstop\022}\n\021GetSystem"
+  "Property\022\".grpc_cli.GetSystemPropertyReq"
+  "uest\032#.grpc_cli.GetSystemPropertyRespons"
+  "e\"\037\202\323\344\223\002\031\022\027/v1/get_system_property\022\205\001\n\021S"
+  "etSystemProperty\022\".grpc_cli.SetSystemPro"
+  "pertyRequest\032#.grpc_cli.SetSystemPropert"
+  "yResponse\"\'\202\323\344\223\002!\022\037/v1/set_system_proper"
+  "ty/{level}\022p\n\016StartTelemetry\022\037.grpc_cli."
+  "StartTelemetryRequest\032 .grpc_cli.StartTe"
+  "lemetryResponse\"\033\202\323\344\223\002\025\022\023/v1/start_telem"
+  "etry\022l\n\rStopTelemetry\022\036.grpc_cli.StopTel"
+  "emetryRequest\032\037.grpc_cli.StopTelemetryRe"
+  "sponse\"\032\202\323\344\223\002\024\022\022/v1/stop_telemetry\022P\n\rRe"
+  "setEventWrr\022\036.grpc_cli.ResetEventWrrRequ"
+  "est\032\037.grpc_cli.ResetEventWrrResponse\022A\n\010"
+  "ResetMbr\022\031.grpc_cli.ResetMbrRequest\032\032.gr"
+  "pc_cli.ResetMbrResponse\022S\n\016StopRebuildin"
+  "g\022\037.grpc_cli.StopRebuildingRequest\032 .grp"
+  "c_cli.StopRebuildingResponse\022S\n\016UpdateEv"
+  "entWrr\022\037.grpc_cli.UpdateEventWrrRequest\032"
+  " .grpc_cli.UpdateEventWrrResponse\022W\n\010Add"
+  "Spare\022\031.grpc_cli.AddSpareRequest\032\032.grpc_"
+  "cli.AddSpareResponse\"\024\202\323\344\223\002\016\"\014/v1/addspa"
+  "re\022c\n\013RemoveSpare\022\034.grpc_cli.RemoveSpare"
+  "Request\032\035.grpc_cli.RemoveSpareResponse\"\027"
+  "\202\323\344\223\002\021\"\017/v1/removespare\022c\n\013CreateArray\022\034"
+  ".grpc_cli.CreateArrayRequest\032\035.grpc_cli."
+  "CreateArrayResponse\"\027\202\323\344\223\002\021\"\017/v1/createa"
+  "rray\022s\n\017AutocreateArray\022 .grpc_cli.Autoc"
+  "reateArrayRequest\032!.grpc_cli.AutocreateA"
+  "rrayResponse\"\033\202\323\344\223\002\025\"\023/v1/autocreatearra"
+  "y\022d\n\013DeleteArray\022\034.grpc_cli.DeleteArrayR"
+  "equest\032\035.grpc_cli.DeleteArrayResponse\"\030\202"
+  "\323\344\223\002\022\"\020/v1/deletearray/\022_\n\nMountArray\022\033."
+  "grpc_cli.MountArrayRequest\032\034.grpc_cli.Mo"
+  "untArrayResponse\"\026\202\323\344\223\002\020\"\016/v1/mountarray"
+  "\022g\n\014UnmountArray\022\035.grpc_cli.UnmountArray"
+  "Request\032\036.grpc_cli.UnmountArrayResponse\""
+  "\030\202\323\344\223\002\022\"\020/v1/unmountarray\022[\n\tListArray\022\032"
+  ".grpc_cli.ListArrayRequest\032\033.grpc_cli.Li"
+  "stArrayResponse\"\025\202\323\344\223\002\017\"\r/v1/listarray\022["
+  "\n\tArrayInfo\022\032.grpc_cli.ArrayInfoRequest\032"
+  "\033.grpc_cli.ArrayInfoResponse\"\025\202\323\344\223\002\017\"\r/v"
+  "1/arrayinfo\022w\n\020SetLogPreference\022!.grpc_c"
+  "li.SetLogPreferenceRequest\032\".grpc_cli.Se"
+  "tLogPreferenceResponse\"\034\202\323\344\223\002\026\"\024/v1/setl"
+  "ogpreference\022c\n\013SetLogLevel\022\034.grpc_cli.S"
+  "etLogLevelRequest\032\035.grpc_cli.SetLogLevel"
+  "Response\"\027\202\323\344\223\002\021\"\017/v1/setloglevel\022_\n\nLog"
+  "gerInfo\022\033.grpc_cli.LoggerInfoRequest\032\034.g"
+  "rpc_cli.LoggerInfoResponse\"\026\202\323\344\223\002\020\"\016/v1/"
+  "loggerinfo\022c\n\013GetLogLevel\022\034.grpc_cli.Get"
+  "LogLevelRequest\032\035.grpc_cli.GetLogLevelRe"
+  "sponse\"\027\202\323\344\223\002\021\"\017/v1/getloglevel\022l\n\016Apply"
+  "LogFilter\022\037.grpc_cli.ApplyLogFilterReque"
+  "st\032 .grpc_cli.ApplyLogFilterResponse\"\027\202\323"
+  "\344\223\002\021\"\017/v1/applyfilter\022g\n\014CreateDevice\022\035."
+  "grpc_cli.CreateDeviceRequest\032\036.grpc_cli."
+  "CreateDeviceResponse\"\030\202\323\344\223\002\022\"\020/v1/create"
+  "device\022_\n\nScanDevice\022\033.grpc_cli.ScanDevi"
+  "ceRequest\032\034.grpc_cli.ScanDeviceResponse\""
+  "\026\202\323\344\223\002\020\"\016/v1/scandevice\022_\n\nListDevice\022\033."
+  "grpc_cli.ListDeviceRequest\032\034.grpc_cli.Li"
+  "stDeviceResponse\"\026\202\323\344\223\002\020\"\016/v1/listdevice"
+  "\022`\n\013GetSmartLog\022\034.grpc_cli.GetSmartLogRe"
+  "quest\032\035.grpc_cli.GetSmartLogResponse\"\024\202\323"
+  "\344\223\002\016\"\014/v1/smartlogB\tZ\007cli/apib\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_cli_2eproto_deps[1] = {
   &::descriptor_table_annotations_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_cli_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_cli_2eproto = {
-  false, false, 14844, descriptor_table_protodef_cli_2eproto, "cli.proto", 
-  &descriptor_table_cli_2eproto_once, descriptor_table_cli_2eproto_deps, 1, 121,
+  false, false, 15957, descriptor_table_protodef_cli_2eproto, "cli.proto", 
+  &descriptor_table_cli_2eproto_once, descriptor_table_cli_2eproto_deps, 1, 129,
   schemas, file_default_instances, TableStruct_cli_2eproto::offsets,
   file_level_metadata_cli_2eproto, file_level_enum_descriptors_cli_2eproto, file_level_service_descriptors_cli_2eproto,
 };
@@ -4234,11 +4473,17 @@ SystemInfoResponse_Result_Data::SystemInfoResponse_Result_Data(const SystemInfoR
     version_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_version(), 
       GetArena());
   }
+  biosversion_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_biosversion().empty()) {
+    biosversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_biosversion(), 
+      GetArena());
+  }
   // @@protoc_insertion_point(copy_constructor:grpc_cli.SystemInfoResponse.Result.Data)
 }
 
 void SystemInfoResponse_Result_Data::SharedCtor() {
 version_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+biosversion_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 }
 
 SystemInfoResponse_Result_Data::~SystemInfoResponse_Result_Data() {
@@ -4250,6 +4495,7 @@ SystemInfoResponse_Result_Data::~SystemInfoResponse_Result_Data() {
 void SystemInfoResponse_Result_Data::SharedDtor() {
   GOOGLE_DCHECK(GetArena() == nullptr);
   version_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  biosversion_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 }
 
 void SystemInfoResponse_Result_Data::ArenaDtor(void* object) {
@@ -4269,6 +4515,7 @@ void SystemInfoResponse_Result_Data::Clear() {
   (void) cached_has_bits;
 
   version_.ClearToEmpty();
+  biosversion_.ClearToEmpty();
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -4285,6 +4532,15 @@ const char* SystemInfoResponse_Result_Data::_InternalParse(const char* ptr, ::PR
           auto str = _internal_mutable_version();
           ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.version"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string biosVersion = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_biosversion();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.biosVersion"));
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -4326,6 +4582,16 @@ failure:
         1, this->_internal_version(), target);
   }
 
+  // string biosVersion = 2;
+  if (this->biosversion().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_biosversion().data(), static_cast<int>(this->_internal_biosversion().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.biosVersion");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_biosversion(), target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -4347,6 +4613,13 @@ size_t SystemInfoResponse_Result_Data::ByteSizeLong() const {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
         this->_internal_version());
+  }
+
+  // string biosVersion = 2;
+  if (this->biosversion().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_biosversion());
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -4383,6 +4656,9 @@ void SystemInfoResponse_Result_Data::MergeFrom(const SystemInfoResponse_Result_D
   if (from.version().size() > 0) {
     _internal_set_version(from._internal_version());
   }
+  if (from.biosversion().size() > 0) {
+    _internal_set_biosversion(from._internal_biosversion());
+  }
 }
 
 void SystemInfoResponse_Result_Data::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
@@ -4407,6 +4683,7 @@ void SystemInfoResponse_Result_Data::InternalSwap(SystemInfoResponse_Result_Data
   using std::swap;
   _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
   version_.Swap(&other->version_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  biosversion_.Swap(&other->biosversion_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata SystemInfoResponse_Result_Data::GetMetadata() const {
@@ -26768,6 +27045,2531 @@ void ListHaVolumeResponse::InternalSwap(ListHaVolumeResponse* other) {
 
 // ===================================================================
 
+class ListHaReplicationRequest::_Internal {
+ public:
+};
+
+ListHaReplicationRequest::ListHaReplicationRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.ListHaReplicationRequest)
+}
+ListHaReplicationRequest::ListHaReplicationRequest(const ListHaReplicationRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_command().empty()) {
+    command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_command(), 
+      GetArena());
+  }
+  rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_rid().empty()) {
+    rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_rid(), 
+      GetArena());
+  }
+  requestor_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_requestor().empty()) {
+    requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_requestor(), 
+      GetArena());
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.ListHaReplicationRequest)
+}
+
+void ListHaReplicationRequest::SharedCtor() {
+command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+requestor_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+ListHaReplicationRequest::~ListHaReplicationRequest() {
+  // @@protoc_insertion_point(destructor:grpc_cli.ListHaReplicationRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void ListHaReplicationRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  command_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  rid_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  requestor_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+void ListHaReplicationRequest::ArenaDtor(void* object) {
+  ListHaReplicationRequest* _this = reinterpret_cast< ListHaReplicationRequest* >(object);
+  (void)_this;
+}
+void ListHaReplicationRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void ListHaReplicationRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void ListHaReplicationRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.ListHaReplicationRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  command_.ClearToEmpty();
+  rid_.ClearToEmpty();
+  requestor_.ClearToEmpty();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ListHaReplicationRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // string command = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          auto str = _internal_mutable_command();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaReplicationRequest.command"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string rid = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_rid();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaReplicationRequest.rid"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string requestor = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          auto str = _internal_mutable_requestor();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaReplicationRequest.requestor"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* ListHaReplicationRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.ListHaReplicationRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_command().data(), static_cast<int>(this->_internal_command().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaReplicationRequest.command");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_command(), target);
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_rid().data(), static_cast<int>(this->_internal_rid().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaReplicationRequest.rid");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_rid(), target);
+  }
+
+  // string requestor = 3;
+  if (this->requestor().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_requestor().data(), static_cast<int>(this->_internal_requestor().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaReplicationRequest.requestor");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_requestor(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.ListHaReplicationRequest)
+  return target;
+}
+
+size_t ListHaReplicationRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.ListHaReplicationRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_command());
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_rid());
+  }
+
+  // string requestor = 3;
+  if (this->requestor().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_requestor());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ListHaReplicationRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.ListHaReplicationRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ListHaReplicationRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<ListHaReplicationRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.ListHaReplicationRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.ListHaReplicationRequest)
+    MergeFrom(*source);
+  }
+}
+
+void ListHaReplicationRequest::MergeFrom(const ListHaReplicationRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.ListHaReplicationRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.command().size() > 0) {
+    _internal_set_command(from._internal_command());
+  }
+  if (from.rid().size() > 0) {
+    _internal_set_rid(from._internal_rid());
+  }
+  if (from.requestor().size() > 0) {
+    _internal_set_requestor(from._internal_requestor());
+  }
+}
+
+void ListHaReplicationRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.ListHaReplicationRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ListHaReplicationRequest::CopyFrom(const ListHaReplicationRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.ListHaReplicationRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ListHaReplicationRequest::IsInitialized() const {
+  return true;
+}
+
+void ListHaReplicationRequest::InternalSwap(ListHaReplicationRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  command_.Swap(&other->command_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  rid_.Swap(&other->rid_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  requestor_.Swap(&other->requestor_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ListHaReplicationRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class ListHaReplicationResponse_Result_Replication::_Internal {
+ public:
+};
+
+ListHaReplicationResponse_Result_Replication::ListHaReplicationResponse_Result_Replication(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.ListHaReplicationResponse.Result.Replication)
+}
+ListHaReplicationResponse_Result_Replication::ListHaReplicationResponse_Result_Replication(const ListHaReplicationResponse_Result_Replication& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::memcpy(&id_, &from.id_,
+    static_cast<size_t>(reinterpret_cast<char*>(&destinationwalvolumeid_) -
+    reinterpret_cast<char*>(&id_)) + sizeof(destinationwalvolumeid_));
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.ListHaReplicationResponse.Result.Replication)
+}
+
+void ListHaReplicationResponse_Result_Replication::SharedCtor() {
+::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+    reinterpret_cast<char*>(&id_) - reinterpret_cast<char*>(this)),
+    0, static_cast<size_t>(reinterpret_cast<char*>(&destinationwalvolumeid_) -
+    reinterpret_cast<char*>(&id_)) + sizeof(destinationwalvolumeid_));
+}
+
+ListHaReplicationResponse_Result_Replication::~ListHaReplicationResponse_Result_Replication() {
+  // @@protoc_insertion_point(destructor:grpc_cli.ListHaReplicationResponse.Result.Replication)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void ListHaReplicationResponse_Result_Replication::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void ListHaReplicationResponse_Result_Replication::ArenaDtor(void* object) {
+  ListHaReplicationResponse_Result_Replication* _this = reinterpret_cast< ListHaReplicationResponse_Result_Replication* >(object);
+  (void)_this;
+}
+void ListHaReplicationResponse_Result_Replication::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void ListHaReplicationResponse_Result_Replication::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void ListHaReplicationResponse_Result_Replication::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.ListHaReplicationResponse.Result.Replication)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&id_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&destinationwalvolumeid_) -
+      reinterpret_cast<char*>(&id_)) + sizeof(destinationwalvolumeid_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ListHaReplicationResponse_Result_Replication::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // int32 id = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
+          id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // int32 sourceVolumeId = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 16)) {
+          sourcevolumeid_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // int32 sourceWalVolume_id = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 24)) {
+          sourcewalvolume_id_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // int32 destinationVolumeId = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 32)) {
+          destinationvolumeid_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // int32 destinationWalVolumeId = 5;
+      case 5:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 40)) {
+          destinationwalvolumeid_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* ListHaReplicationResponse_Result_Replication::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.ListHaReplicationResponse.Result.Replication)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // int32 id = 1;
+  if (this->id() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(1, this->_internal_id(), target);
+  }
+
+  // int32 sourceVolumeId = 2;
+  if (this->sourcevolumeid() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(2, this->_internal_sourcevolumeid(), target);
+  }
+
+  // int32 sourceWalVolume_id = 3;
+  if (this->sourcewalvolume_id() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(3, this->_internal_sourcewalvolume_id(), target);
+  }
+
+  // int32 destinationVolumeId = 4;
+  if (this->destinationvolumeid() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(4, this->_internal_destinationvolumeid(), target);
+  }
+
+  // int32 destinationWalVolumeId = 5;
+  if (this->destinationwalvolumeid() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(5, this->_internal_destinationwalvolumeid(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.ListHaReplicationResponse.Result.Replication)
+  return target;
+}
+
+size_t ListHaReplicationResponse_Result_Replication::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.ListHaReplicationResponse.Result.Replication)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // int32 id = 1;
+  if (this->id() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
+        this->_internal_id());
+  }
+
+  // int32 sourceVolumeId = 2;
+  if (this->sourcevolumeid() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
+        this->_internal_sourcevolumeid());
+  }
+
+  // int32 sourceWalVolume_id = 3;
+  if (this->sourcewalvolume_id() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
+        this->_internal_sourcewalvolume_id());
+  }
+
+  // int32 destinationVolumeId = 4;
+  if (this->destinationvolumeid() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
+        this->_internal_destinationvolumeid());
+  }
+
+  // int32 destinationWalVolumeId = 5;
+  if (this->destinationwalvolumeid() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
+        this->_internal_destinationwalvolumeid());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ListHaReplicationResponse_Result_Replication::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.ListHaReplicationResponse.Result.Replication)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ListHaReplicationResponse_Result_Replication* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<ListHaReplicationResponse_Result_Replication>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.ListHaReplicationResponse.Result.Replication)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.ListHaReplicationResponse.Result.Replication)
+    MergeFrom(*source);
+  }
+}
+
+void ListHaReplicationResponse_Result_Replication::MergeFrom(const ListHaReplicationResponse_Result_Replication& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.ListHaReplicationResponse.Result.Replication)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.id() != 0) {
+    _internal_set_id(from._internal_id());
+  }
+  if (from.sourcevolumeid() != 0) {
+    _internal_set_sourcevolumeid(from._internal_sourcevolumeid());
+  }
+  if (from.sourcewalvolume_id() != 0) {
+    _internal_set_sourcewalvolume_id(from._internal_sourcewalvolume_id());
+  }
+  if (from.destinationvolumeid() != 0) {
+    _internal_set_destinationvolumeid(from._internal_destinationvolumeid());
+  }
+  if (from.destinationwalvolumeid() != 0) {
+    _internal_set_destinationwalvolumeid(from._internal_destinationwalvolumeid());
+  }
+}
+
+void ListHaReplicationResponse_Result_Replication::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.ListHaReplicationResponse.Result.Replication)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ListHaReplicationResponse_Result_Replication::CopyFrom(const ListHaReplicationResponse_Result_Replication& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.ListHaReplicationResponse.Result.Replication)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ListHaReplicationResponse_Result_Replication::IsInitialized() const {
+  return true;
+}
+
+void ListHaReplicationResponse_Result_Replication::InternalSwap(ListHaReplicationResponse_Result_Replication* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(ListHaReplicationResponse_Result_Replication, destinationwalvolumeid_)
+      + sizeof(ListHaReplicationResponse_Result_Replication::destinationwalvolumeid_)
+      - PROTOBUF_FIELD_OFFSET(ListHaReplicationResponse_Result_Replication, id_)>(
+          reinterpret_cast<char*>(&id_),
+          reinterpret_cast<char*>(&other->id_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ListHaReplicationResponse_Result_Replication::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class ListHaReplicationResponse_Result::_Internal {
+ public:
+  static const ::grpc_cli::Status& status(const ListHaReplicationResponse_Result* msg);
+};
+
+const ::grpc_cli::Status&
+ListHaReplicationResponse_Result::_Internal::status(const ListHaReplicationResponse_Result* msg) {
+  return *msg->status_;
+}
+ListHaReplicationResponse_Result::ListHaReplicationResponse_Result(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  data_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.ListHaReplicationResponse.Result)
+}
+ListHaReplicationResponse_Result::ListHaReplicationResponse_Result(const ListHaReplicationResponse_Result& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      data_(from.data_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_status()) {
+    status_ = new ::grpc_cli::Status(*from.status_);
+  } else {
+    status_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.ListHaReplicationResponse.Result)
+}
+
+void ListHaReplicationResponse_Result::SharedCtor() {
+status_ = nullptr;
+}
+
+ListHaReplicationResponse_Result::~ListHaReplicationResponse_Result() {
+  // @@protoc_insertion_point(destructor:grpc_cli.ListHaReplicationResponse.Result)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void ListHaReplicationResponse_Result::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete status_;
+}
+
+void ListHaReplicationResponse_Result::ArenaDtor(void* object) {
+  ListHaReplicationResponse_Result* _this = reinterpret_cast< ListHaReplicationResponse_Result* >(object);
+  (void)_this;
+}
+void ListHaReplicationResponse_Result::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void ListHaReplicationResponse_Result::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void ListHaReplicationResponse_Result::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.ListHaReplicationResponse.Result)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  data_.Clear();
+  if (GetArena() == nullptr && status_ != nullptr) {
+    delete status_;
+  }
+  status_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ListHaReplicationResponse_Result::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .grpc_cli.Status status = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_status(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // repeated .grpc_cli.ListHaReplicationResponse.Result.Replication data = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_data(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<18>(ptr));
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* ListHaReplicationResponse_Result::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.ListHaReplicationResponse.Result)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .grpc_cli.Status status = 1;
+  if (this->has_status()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::status(this), target, stream);
+  }
+
+  // repeated .grpc_cli.ListHaReplicationResponse.Result.Replication data = 2;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->_internal_data_size()); i < n; i++) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(2, this->_internal_data(i), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.ListHaReplicationResponse.Result)
+  return target;
+}
+
+size_t ListHaReplicationResponse_Result::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.ListHaReplicationResponse.Result)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .grpc_cli.ListHaReplicationResponse.Result.Replication data = 2;
+  total_size += 1UL * this->_internal_data_size();
+  for (const auto& msg : this->data_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // .grpc_cli.Status status = 1;
+  if (this->has_status()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *status_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ListHaReplicationResponse_Result::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.ListHaReplicationResponse.Result)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ListHaReplicationResponse_Result* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<ListHaReplicationResponse_Result>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.ListHaReplicationResponse.Result)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.ListHaReplicationResponse.Result)
+    MergeFrom(*source);
+  }
+}
+
+void ListHaReplicationResponse_Result::MergeFrom(const ListHaReplicationResponse_Result& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.ListHaReplicationResponse.Result)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  data_.MergeFrom(from.data_);
+  if (from.has_status()) {
+    _internal_mutable_status()->::grpc_cli::Status::MergeFrom(from._internal_status());
+  }
+}
+
+void ListHaReplicationResponse_Result::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.ListHaReplicationResponse.Result)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ListHaReplicationResponse_Result::CopyFrom(const ListHaReplicationResponse_Result& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.ListHaReplicationResponse.Result)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ListHaReplicationResponse_Result::IsInitialized() const {
+  return true;
+}
+
+void ListHaReplicationResponse_Result::InternalSwap(ListHaReplicationResponse_Result* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  data_.InternalSwap(&other->data_);
+  swap(status_, other->status_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ListHaReplicationResponse_Result::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class ListHaReplicationResponse::_Internal {
+ public:
+  static const ::grpc_cli::ListHaReplicationResponse_Result& result(const ListHaReplicationResponse* msg);
+  static const ::grpc_cli::PosInfo& info(const ListHaReplicationResponse* msg);
+};
+
+const ::grpc_cli::ListHaReplicationResponse_Result&
+ListHaReplicationResponse::_Internal::result(const ListHaReplicationResponse* msg) {
+  return *msg->result_;
+}
+const ::grpc_cli::PosInfo&
+ListHaReplicationResponse::_Internal::info(const ListHaReplicationResponse* msg) {
+  return *msg->info_;
+}
+ListHaReplicationResponse::ListHaReplicationResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.ListHaReplicationResponse)
+}
+ListHaReplicationResponse::ListHaReplicationResponse(const ListHaReplicationResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_command().empty()) {
+    command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_command(), 
+      GetArena());
+  }
+  rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_rid().empty()) {
+    rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_rid(), 
+      GetArena());
+  }
+  if (from._internal_has_result()) {
+    result_ = new ::grpc_cli::ListHaReplicationResponse_Result(*from.result_);
+  } else {
+    result_ = nullptr;
+  }
+  if (from._internal_has_info()) {
+    info_ = new ::grpc_cli::PosInfo(*from.info_);
+  } else {
+    info_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.ListHaReplicationResponse)
+}
+
+void ListHaReplicationResponse::SharedCtor() {
+command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+    reinterpret_cast<char*>(&result_) - reinterpret_cast<char*>(this)),
+    0, static_cast<size_t>(reinterpret_cast<char*>(&info_) -
+    reinterpret_cast<char*>(&result_)) + sizeof(info_));
+}
+
+ListHaReplicationResponse::~ListHaReplicationResponse() {
+  // @@protoc_insertion_point(destructor:grpc_cli.ListHaReplicationResponse)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void ListHaReplicationResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  command_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  rid_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (this != internal_default_instance()) delete result_;
+  if (this != internal_default_instance()) delete info_;
+}
+
+void ListHaReplicationResponse::ArenaDtor(void* object) {
+  ListHaReplicationResponse* _this = reinterpret_cast< ListHaReplicationResponse* >(object);
+  (void)_this;
+}
+void ListHaReplicationResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void ListHaReplicationResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void ListHaReplicationResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.ListHaReplicationResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  command_.ClearToEmpty();
+  rid_.ClearToEmpty();
+  if (GetArena() == nullptr && result_ != nullptr) {
+    delete result_;
+  }
+  result_ = nullptr;
+  if (GetArena() == nullptr && info_ != nullptr) {
+    delete info_;
+  }
+  info_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* ListHaReplicationResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // string command = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          auto str = _internal_mutable_command();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaReplicationResponse.command"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string rid = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_rid();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.ListHaReplicationResponse.rid"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .grpc_cli.ListHaReplicationResponse.Result result = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          ptr = ctx->ParseMessage(_internal_mutable_result(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .grpc_cli.PosInfo info = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 34)) {
+          ptr = ctx->ParseMessage(_internal_mutable_info(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* ListHaReplicationResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.ListHaReplicationResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_command().data(), static_cast<int>(this->_internal_command().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaReplicationResponse.command");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_command(), target);
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_rid().data(), static_cast<int>(this->_internal_rid().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.ListHaReplicationResponse.rid");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_rid(), target);
+  }
+
+  // .grpc_cli.ListHaReplicationResponse.Result result = 3;
+  if (this->has_result()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        3, _Internal::result(this), target, stream);
+  }
+
+  // .grpc_cli.PosInfo info = 4;
+  if (this->has_info()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        4, _Internal::info(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.ListHaReplicationResponse)
+  return target;
+}
+
+size_t ListHaReplicationResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.ListHaReplicationResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_command());
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_rid());
+  }
+
+  // .grpc_cli.ListHaReplicationResponse.Result result = 3;
+  if (this->has_result()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *result_);
+  }
+
+  // .grpc_cli.PosInfo info = 4;
+  if (this->has_info()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *info_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ListHaReplicationResponse::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.ListHaReplicationResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ListHaReplicationResponse* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<ListHaReplicationResponse>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.ListHaReplicationResponse)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.ListHaReplicationResponse)
+    MergeFrom(*source);
+  }
+}
+
+void ListHaReplicationResponse::MergeFrom(const ListHaReplicationResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.ListHaReplicationResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.command().size() > 0) {
+    _internal_set_command(from._internal_command());
+  }
+  if (from.rid().size() > 0) {
+    _internal_set_rid(from._internal_rid());
+  }
+  if (from.has_result()) {
+    _internal_mutable_result()->::grpc_cli::ListHaReplicationResponse_Result::MergeFrom(from._internal_result());
+  }
+  if (from.has_info()) {
+    _internal_mutable_info()->::grpc_cli::PosInfo::MergeFrom(from._internal_info());
+  }
+}
+
+void ListHaReplicationResponse::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.ListHaReplicationResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ListHaReplicationResponse::CopyFrom(const ListHaReplicationResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.ListHaReplicationResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ListHaReplicationResponse::IsInitialized() const {
+  return true;
+}
+
+void ListHaReplicationResponse::InternalSwap(ListHaReplicationResponse* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  command_.Swap(&other->command_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  rid_.Swap(&other->rid_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(ListHaReplicationResponse, info_)
+      + sizeof(ListHaReplicationResponse::info_)
+      - PROTOBUF_FIELD_OFFSET(ListHaReplicationResponse, result_)>(
+          reinterpret_cast<char*>(&result_),
+          reinterpret_cast<char*>(&other->result_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata ListHaReplicationResponse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class StartHaReplicationRequest_Param::_Internal {
+ public:
+};
+
+StartHaReplicationRequest_Param::StartHaReplicationRequest_Param(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.StartHaReplicationRequest.Param)
+}
+StartHaReplicationRequest_Param::StartHaReplicationRequest_Param(const StartHaReplicationRequest_Param& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  primarynodename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_primarynodename().empty()) {
+    primarynodename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_primarynodename(), 
+      GetArena());
+  }
+  primaryarrayname_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_primaryarrayname().empty()) {
+    primaryarrayname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_primaryarrayname(), 
+      GetArena());
+  }
+  primaryvolumename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_primaryvolumename().empty()) {
+    primaryvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_primaryvolumename(), 
+      GetArena());
+  }
+  primarywalvolumename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_primarywalvolumename().empty()) {
+    primarywalvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_primarywalvolumename(), 
+      GetArena());
+  }
+  secondarynodename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_secondarynodename().empty()) {
+    secondarynodename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_secondarynodename(), 
+      GetArena());
+  }
+  secondaryarrayname_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_secondaryarrayname().empty()) {
+    secondaryarrayname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_secondaryarrayname(), 
+      GetArena());
+  }
+  secondaryvolumename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_secondaryvolumename().empty()) {
+    secondaryvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_secondaryvolumename(), 
+      GetArena());
+  }
+  secondarywalvolumename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_secondarywalvolumename().empty()) {
+    secondarywalvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_secondarywalvolumename(), 
+      GetArena());
+  }
+  stuats_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_stuats().empty()) {
+    stuats_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_stuats(), 
+      GetArena());
+  }
+  timestamp_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_timestamp().empty()) {
+    timestamp_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_timestamp(), 
+      GetArena());
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.StartHaReplicationRequest.Param)
+}
+
+void StartHaReplicationRequest_Param::SharedCtor() {
+primarynodename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+primaryarrayname_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+primaryvolumename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+primarywalvolumename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+secondarynodename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+secondaryarrayname_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+secondaryvolumename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+secondarywalvolumename_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+stuats_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+timestamp_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+StartHaReplicationRequest_Param::~StartHaReplicationRequest_Param() {
+  // @@protoc_insertion_point(destructor:grpc_cli.StartHaReplicationRequest.Param)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void StartHaReplicationRequest_Param::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  primarynodename_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  primaryarrayname_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  primaryvolumename_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  primarywalvolumename_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  secondarynodename_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  secondaryarrayname_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  secondaryvolumename_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  secondarywalvolumename_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  stuats_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  timestamp_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+void StartHaReplicationRequest_Param::ArenaDtor(void* object) {
+  StartHaReplicationRequest_Param* _this = reinterpret_cast< StartHaReplicationRequest_Param* >(object);
+  (void)_this;
+}
+void StartHaReplicationRequest_Param::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void StartHaReplicationRequest_Param::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void StartHaReplicationRequest_Param::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.StartHaReplicationRequest.Param)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  primarynodename_.ClearToEmpty();
+  primaryarrayname_.ClearToEmpty();
+  primaryvolumename_.ClearToEmpty();
+  primarywalvolumename_.ClearToEmpty();
+  secondarynodename_.ClearToEmpty();
+  secondaryarrayname_.ClearToEmpty();
+  secondaryvolumename_.ClearToEmpty();
+  secondarywalvolumename_.ClearToEmpty();
+  stuats_.ClearToEmpty();
+  timestamp_.ClearToEmpty();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* StartHaReplicationRequest_Param::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // string primaryNodeName = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          auto str = _internal_mutable_primarynodename();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationRequest.Param.primaryNodeName"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string primaryArrayName = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_primaryarrayname();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationRequest.Param.primaryArrayName"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string primaryVolumeName = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          auto str = _internal_mutable_primaryvolumename();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationRequest.Param.primaryVolumeName"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string primaryWalVolumeName = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 34)) {
+          auto str = _internal_mutable_primarywalvolumename();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationRequest.Param.primaryWalVolumeName"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string secondaryNodeName = 5;
+      case 5:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 42)) {
+          auto str = _internal_mutable_secondarynodename();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationRequest.Param.secondaryNodeName"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string secondaryArrayName = 6;
+      case 6:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 50)) {
+          auto str = _internal_mutable_secondaryarrayname();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationRequest.Param.secondaryArrayName"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string secondaryVolumeName = 7;
+      case 7:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 58)) {
+          auto str = _internal_mutable_secondaryvolumename();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationRequest.Param.secondaryVolumeName"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string secondaryWalVolumeName = 8;
+      case 8:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 66)) {
+          auto str = _internal_mutable_secondarywalvolumename();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationRequest.Param.secondaryWalVolumeName"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string stuats = 9;
+      case 9:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 74)) {
+          auto str = _internal_mutable_stuats();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationRequest.Param.stuats"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string timestamp = 10;
+      case 10:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 82)) {
+          auto str = _internal_mutable_timestamp();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationRequest.Param.timestamp"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* StartHaReplicationRequest_Param::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.StartHaReplicationRequest.Param)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string primaryNodeName = 1;
+  if (this->primarynodename().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_primarynodename().data(), static_cast<int>(this->_internal_primarynodename().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationRequest.Param.primaryNodeName");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_primarynodename(), target);
+  }
+
+  // string primaryArrayName = 2;
+  if (this->primaryarrayname().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_primaryarrayname().data(), static_cast<int>(this->_internal_primaryarrayname().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationRequest.Param.primaryArrayName");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_primaryarrayname(), target);
+  }
+
+  // string primaryVolumeName = 3;
+  if (this->primaryvolumename().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_primaryvolumename().data(), static_cast<int>(this->_internal_primaryvolumename().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationRequest.Param.primaryVolumeName");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_primaryvolumename(), target);
+  }
+
+  // string primaryWalVolumeName = 4;
+  if (this->primarywalvolumename().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_primarywalvolumename().data(), static_cast<int>(this->_internal_primarywalvolumename().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationRequest.Param.primaryWalVolumeName");
+    target = stream->WriteStringMaybeAliased(
+        4, this->_internal_primarywalvolumename(), target);
+  }
+
+  // string secondaryNodeName = 5;
+  if (this->secondarynodename().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_secondarynodename().data(), static_cast<int>(this->_internal_secondarynodename().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationRequest.Param.secondaryNodeName");
+    target = stream->WriteStringMaybeAliased(
+        5, this->_internal_secondarynodename(), target);
+  }
+
+  // string secondaryArrayName = 6;
+  if (this->secondaryarrayname().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_secondaryarrayname().data(), static_cast<int>(this->_internal_secondaryarrayname().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationRequest.Param.secondaryArrayName");
+    target = stream->WriteStringMaybeAliased(
+        6, this->_internal_secondaryarrayname(), target);
+  }
+
+  // string secondaryVolumeName = 7;
+  if (this->secondaryvolumename().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_secondaryvolumename().data(), static_cast<int>(this->_internal_secondaryvolumename().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationRequest.Param.secondaryVolumeName");
+    target = stream->WriteStringMaybeAliased(
+        7, this->_internal_secondaryvolumename(), target);
+  }
+
+  // string secondaryWalVolumeName = 8;
+  if (this->secondarywalvolumename().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_secondarywalvolumename().data(), static_cast<int>(this->_internal_secondarywalvolumename().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationRequest.Param.secondaryWalVolumeName");
+    target = stream->WriteStringMaybeAliased(
+        8, this->_internal_secondarywalvolumename(), target);
+  }
+
+  // string stuats = 9;
+  if (this->stuats().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_stuats().data(), static_cast<int>(this->_internal_stuats().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationRequest.Param.stuats");
+    target = stream->WriteStringMaybeAliased(
+        9, this->_internal_stuats(), target);
+  }
+
+  // string timestamp = 10;
+  if (this->timestamp().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_timestamp().data(), static_cast<int>(this->_internal_timestamp().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationRequest.Param.timestamp");
+    target = stream->WriteStringMaybeAliased(
+        10, this->_internal_timestamp(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.StartHaReplicationRequest.Param)
+  return target;
+}
+
+size_t StartHaReplicationRequest_Param::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.StartHaReplicationRequest.Param)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string primaryNodeName = 1;
+  if (this->primarynodename().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_primarynodename());
+  }
+
+  // string primaryArrayName = 2;
+  if (this->primaryarrayname().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_primaryarrayname());
+  }
+
+  // string primaryVolumeName = 3;
+  if (this->primaryvolumename().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_primaryvolumename());
+  }
+
+  // string primaryWalVolumeName = 4;
+  if (this->primarywalvolumename().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_primarywalvolumename());
+  }
+
+  // string secondaryNodeName = 5;
+  if (this->secondarynodename().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_secondarynodename());
+  }
+
+  // string secondaryArrayName = 6;
+  if (this->secondaryarrayname().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_secondaryarrayname());
+  }
+
+  // string secondaryVolumeName = 7;
+  if (this->secondaryvolumename().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_secondaryvolumename());
+  }
+
+  // string secondaryWalVolumeName = 8;
+  if (this->secondarywalvolumename().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_secondarywalvolumename());
+  }
+
+  // string stuats = 9;
+  if (this->stuats().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_stuats());
+  }
+
+  // string timestamp = 10;
+  if (this->timestamp().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_timestamp());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void StartHaReplicationRequest_Param::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.StartHaReplicationRequest.Param)
+  GOOGLE_DCHECK_NE(&from, this);
+  const StartHaReplicationRequest_Param* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<StartHaReplicationRequest_Param>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.StartHaReplicationRequest.Param)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.StartHaReplicationRequest.Param)
+    MergeFrom(*source);
+  }
+}
+
+void StartHaReplicationRequest_Param::MergeFrom(const StartHaReplicationRequest_Param& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.StartHaReplicationRequest.Param)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.primarynodename().size() > 0) {
+    _internal_set_primarynodename(from._internal_primarynodename());
+  }
+  if (from.primaryarrayname().size() > 0) {
+    _internal_set_primaryarrayname(from._internal_primaryarrayname());
+  }
+  if (from.primaryvolumename().size() > 0) {
+    _internal_set_primaryvolumename(from._internal_primaryvolumename());
+  }
+  if (from.primarywalvolumename().size() > 0) {
+    _internal_set_primarywalvolumename(from._internal_primarywalvolumename());
+  }
+  if (from.secondarynodename().size() > 0) {
+    _internal_set_secondarynodename(from._internal_secondarynodename());
+  }
+  if (from.secondaryarrayname().size() > 0) {
+    _internal_set_secondaryarrayname(from._internal_secondaryarrayname());
+  }
+  if (from.secondaryvolumename().size() > 0) {
+    _internal_set_secondaryvolumename(from._internal_secondaryvolumename());
+  }
+  if (from.secondarywalvolumename().size() > 0) {
+    _internal_set_secondarywalvolumename(from._internal_secondarywalvolumename());
+  }
+  if (from.stuats().size() > 0) {
+    _internal_set_stuats(from._internal_stuats());
+  }
+  if (from.timestamp().size() > 0) {
+    _internal_set_timestamp(from._internal_timestamp());
+  }
+}
+
+void StartHaReplicationRequest_Param::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.StartHaReplicationRequest.Param)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void StartHaReplicationRequest_Param::CopyFrom(const StartHaReplicationRequest_Param& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.StartHaReplicationRequest.Param)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool StartHaReplicationRequest_Param::IsInitialized() const {
+  return true;
+}
+
+void StartHaReplicationRequest_Param::InternalSwap(StartHaReplicationRequest_Param* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  primarynodename_.Swap(&other->primarynodename_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  primaryarrayname_.Swap(&other->primaryarrayname_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  primaryvolumename_.Swap(&other->primaryvolumename_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  primarywalvolumename_.Swap(&other->primarywalvolumename_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  secondarynodename_.Swap(&other->secondarynodename_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  secondaryarrayname_.Swap(&other->secondaryarrayname_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  secondaryvolumename_.Swap(&other->secondaryvolumename_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  secondarywalvolumename_.Swap(&other->secondarywalvolumename_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  stuats_.Swap(&other->stuats_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  timestamp_.Swap(&other->timestamp_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata StartHaReplicationRequest_Param::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class StartHaReplicationRequest::_Internal {
+ public:
+  static const ::grpc_cli::StartHaReplicationRequest_Param& param(const StartHaReplicationRequest* msg);
+};
+
+const ::grpc_cli::StartHaReplicationRequest_Param&
+StartHaReplicationRequest::_Internal::param(const StartHaReplicationRequest* msg) {
+  return *msg->param_;
+}
+StartHaReplicationRequest::StartHaReplicationRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.StartHaReplicationRequest)
+}
+StartHaReplicationRequest::StartHaReplicationRequest(const StartHaReplicationRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_command().empty()) {
+    command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_command(), 
+      GetArena());
+  }
+  rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_rid().empty()) {
+    rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_rid(), 
+      GetArena());
+  }
+  requestor_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_requestor().empty()) {
+    requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_requestor(), 
+      GetArena());
+  }
+  if (from._internal_has_param()) {
+    param_ = new ::grpc_cli::StartHaReplicationRequest_Param(*from.param_);
+  } else {
+    param_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.StartHaReplicationRequest)
+}
+
+void StartHaReplicationRequest::SharedCtor() {
+command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+requestor_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+param_ = nullptr;
+}
+
+StartHaReplicationRequest::~StartHaReplicationRequest() {
+  // @@protoc_insertion_point(destructor:grpc_cli.StartHaReplicationRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void StartHaReplicationRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  command_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  rid_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  requestor_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (this != internal_default_instance()) delete param_;
+}
+
+void StartHaReplicationRequest::ArenaDtor(void* object) {
+  StartHaReplicationRequest* _this = reinterpret_cast< StartHaReplicationRequest* >(object);
+  (void)_this;
+}
+void StartHaReplicationRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void StartHaReplicationRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void StartHaReplicationRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.StartHaReplicationRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  command_.ClearToEmpty();
+  rid_.ClearToEmpty();
+  requestor_.ClearToEmpty();
+  if (GetArena() == nullptr && param_ != nullptr) {
+    delete param_;
+  }
+  param_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* StartHaReplicationRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // string command = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          auto str = _internal_mutable_command();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationRequest.command"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string rid = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_rid();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationRequest.rid"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string requestor = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          auto str = _internal_mutable_requestor();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationRequest.requestor"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .grpc_cli.StartHaReplicationRequest.Param param = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 34)) {
+          ptr = ctx->ParseMessage(_internal_mutable_param(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* StartHaReplicationRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.StartHaReplicationRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_command().data(), static_cast<int>(this->_internal_command().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationRequest.command");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_command(), target);
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_rid().data(), static_cast<int>(this->_internal_rid().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationRequest.rid");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_rid(), target);
+  }
+
+  // string requestor = 3;
+  if (this->requestor().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_requestor().data(), static_cast<int>(this->_internal_requestor().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationRequest.requestor");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_requestor(), target);
+  }
+
+  // .grpc_cli.StartHaReplicationRequest.Param param = 4;
+  if (this->has_param()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        4, _Internal::param(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.StartHaReplicationRequest)
+  return target;
+}
+
+size_t StartHaReplicationRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.StartHaReplicationRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_command());
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_rid());
+  }
+
+  // string requestor = 3;
+  if (this->requestor().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_requestor());
+  }
+
+  // .grpc_cli.StartHaReplicationRequest.Param param = 4;
+  if (this->has_param()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *param_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void StartHaReplicationRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.StartHaReplicationRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const StartHaReplicationRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<StartHaReplicationRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.StartHaReplicationRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.StartHaReplicationRequest)
+    MergeFrom(*source);
+  }
+}
+
+void StartHaReplicationRequest::MergeFrom(const StartHaReplicationRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.StartHaReplicationRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.command().size() > 0) {
+    _internal_set_command(from._internal_command());
+  }
+  if (from.rid().size() > 0) {
+    _internal_set_rid(from._internal_rid());
+  }
+  if (from.requestor().size() > 0) {
+    _internal_set_requestor(from._internal_requestor());
+  }
+  if (from.has_param()) {
+    _internal_mutable_param()->::grpc_cli::StartHaReplicationRequest_Param::MergeFrom(from._internal_param());
+  }
+}
+
+void StartHaReplicationRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.StartHaReplicationRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void StartHaReplicationRequest::CopyFrom(const StartHaReplicationRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.StartHaReplicationRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool StartHaReplicationRequest::IsInitialized() const {
+  return true;
+}
+
+void StartHaReplicationRequest::InternalSwap(StartHaReplicationRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  command_.Swap(&other->command_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  rid_.Swap(&other->rid_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  requestor_.Swap(&other->requestor_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  swap(param_, other->param_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata StartHaReplicationRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class StartHaReplicationResponse_Result::_Internal {
+ public:
+  static const ::grpc_cli::Status& status(const StartHaReplicationResponse_Result* msg);
+};
+
+const ::grpc_cli::Status&
+StartHaReplicationResponse_Result::_Internal::status(const StartHaReplicationResponse_Result* msg) {
+  return *msg->status_;
+}
+StartHaReplicationResponse_Result::StartHaReplicationResponse_Result(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.StartHaReplicationResponse.Result)
+}
+StartHaReplicationResponse_Result::StartHaReplicationResponse_Result(const StartHaReplicationResponse_Result& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_status()) {
+    status_ = new ::grpc_cli::Status(*from.status_);
+  } else {
+    status_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.StartHaReplicationResponse.Result)
+}
+
+void StartHaReplicationResponse_Result::SharedCtor() {
+status_ = nullptr;
+}
+
+StartHaReplicationResponse_Result::~StartHaReplicationResponse_Result() {
+  // @@protoc_insertion_point(destructor:grpc_cli.StartHaReplicationResponse.Result)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void StartHaReplicationResponse_Result::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete status_;
+}
+
+void StartHaReplicationResponse_Result::ArenaDtor(void* object) {
+  StartHaReplicationResponse_Result* _this = reinterpret_cast< StartHaReplicationResponse_Result* >(object);
+  (void)_this;
+}
+void StartHaReplicationResponse_Result::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void StartHaReplicationResponse_Result::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void StartHaReplicationResponse_Result::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.StartHaReplicationResponse.Result)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArena() == nullptr && status_ != nullptr) {
+    delete status_;
+  }
+  status_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* StartHaReplicationResponse_Result::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .grpc_cli.Status status = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_status(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* StartHaReplicationResponse_Result::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.StartHaReplicationResponse.Result)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .grpc_cli.Status status = 1;
+  if (this->has_status()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::status(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.StartHaReplicationResponse.Result)
+  return target;
+}
+
+size_t StartHaReplicationResponse_Result::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.StartHaReplicationResponse.Result)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .grpc_cli.Status status = 1;
+  if (this->has_status()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *status_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void StartHaReplicationResponse_Result::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.StartHaReplicationResponse.Result)
+  GOOGLE_DCHECK_NE(&from, this);
+  const StartHaReplicationResponse_Result* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<StartHaReplicationResponse_Result>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.StartHaReplicationResponse.Result)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.StartHaReplicationResponse.Result)
+    MergeFrom(*source);
+  }
+}
+
+void StartHaReplicationResponse_Result::MergeFrom(const StartHaReplicationResponse_Result& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.StartHaReplicationResponse.Result)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_status()) {
+    _internal_mutable_status()->::grpc_cli::Status::MergeFrom(from._internal_status());
+  }
+}
+
+void StartHaReplicationResponse_Result::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.StartHaReplicationResponse.Result)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void StartHaReplicationResponse_Result::CopyFrom(const StartHaReplicationResponse_Result& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.StartHaReplicationResponse.Result)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool StartHaReplicationResponse_Result::IsInitialized() const {
+  return true;
+}
+
+void StartHaReplicationResponse_Result::InternalSwap(StartHaReplicationResponse_Result* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  swap(status_, other->status_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata StartHaReplicationResponse_Result::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class StartHaReplicationResponse::_Internal {
+ public:
+  static const ::grpc_cli::StartHaReplicationResponse_Result& result(const StartHaReplicationResponse* msg);
+  static const ::grpc_cli::PosInfo& info(const StartHaReplicationResponse* msg);
+};
+
+const ::grpc_cli::StartHaReplicationResponse_Result&
+StartHaReplicationResponse::_Internal::result(const StartHaReplicationResponse* msg) {
+  return *msg->result_;
+}
+const ::grpc_cli::PosInfo&
+StartHaReplicationResponse::_Internal::info(const StartHaReplicationResponse* msg) {
+  return *msg->info_;
+}
+StartHaReplicationResponse::StartHaReplicationResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.StartHaReplicationResponse)
+}
+StartHaReplicationResponse::StartHaReplicationResponse(const StartHaReplicationResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_command().empty()) {
+    command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_command(), 
+      GetArena());
+  }
+  rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_rid().empty()) {
+    rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_rid(), 
+      GetArena());
+  }
+  if (from._internal_has_result()) {
+    result_ = new ::grpc_cli::StartHaReplicationResponse_Result(*from.result_);
+  } else {
+    result_ = nullptr;
+  }
+  if (from._internal_has_info()) {
+    info_ = new ::grpc_cli::PosInfo(*from.info_);
+  } else {
+    info_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.StartHaReplicationResponse)
+}
+
+void StartHaReplicationResponse::SharedCtor() {
+command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+    reinterpret_cast<char*>(&result_) - reinterpret_cast<char*>(this)),
+    0, static_cast<size_t>(reinterpret_cast<char*>(&info_) -
+    reinterpret_cast<char*>(&result_)) + sizeof(info_));
+}
+
+StartHaReplicationResponse::~StartHaReplicationResponse() {
+  // @@protoc_insertion_point(destructor:grpc_cli.StartHaReplicationResponse)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void StartHaReplicationResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  command_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  rid_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (this != internal_default_instance()) delete result_;
+  if (this != internal_default_instance()) delete info_;
+}
+
+void StartHaReplicationResponse::ArenaDtor(void* object) {
+  StartHaReplicationResponse* _this = reinterpret_cast< StartHaReplicationResponse* >(object);
+  (void)_this;
+}
+void StartHaReplicationResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void StartHaReplicationResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void StartHaReplicationResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.StartHaReplicationResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  command_.ClearToEmpty();
+  rid_.ClearToEmpty();
+  if (GetArena() == nullptr && result_ != nullptr) {
+    delete result_;
+  }
+  result_ = nullptr;
+  if (GetArena() == nullptr && info_ != nullptr) {
+    delete info_;
+  }
+  info_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* StartHaReplicationResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // string command = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          auto str = _internal_mutable_command();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationResponse.command"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string rid = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_rid();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.StartHaReplicationResponse.rid"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .grpc_cli.StartHaReplicationResponse.Result result = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          ptr = ctx->ParseMessage(_internal_mutable_result(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .grpc_cli.PosInfo info = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 34)) {
+          ptr = ctx->ParseMessage(_internal_mutable_info(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* StartHaReplicationResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.StartHaReplicationResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_command().data(), static_cast<int>(this->_internal_command().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationResponse.command");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_command(), target);
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_rid().data(), static_cast<int>(this->_internal_rid().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.StartHaReplicationResponse.rid");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_rid(), target);
+  }
+
+  // .grpc_cli.StartHaReplicationResponse.Result result = 3;
+  if (this->has_result()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        3, _Internal::result(this), target, stream);
+  }
+
+  // .grpc_cli.PosInfo info = 4;
+  if (this->has_info()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        4, _Internal::info(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.StartHaReplicationResponse)
+  return target;
+}
+
+size_t StartHaReplicationResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.StartHaReplicationResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_command());
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_rid());
+  }
+
+  // .grpc_cli.StartHaReplicationResponse.Result result = 3;
+  if (this->has_result()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *result_);
+  }
+
+  // .grpc_cli.PosInfo info = 4;
+  if (this->has_info()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *info_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void StartHaReplicationResponse::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.StartHaReplicationResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const StartHaReplicationResponse* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<StartHaReplicationResponse>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.StartHaReplicationResponse)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.StartHaReplicationResponse)
+    MergeFrom(*source);
+  }
+}
+
+void StartHaReplicationResponse::MergeFrom(const StartHaReplicationResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.StartHaReplicationResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.command().size() > 0) {
+    _internal_set_command(from._internal_command());
+  }
+  if (from.rid().size() > 0) {
+    _internal_set_rid(from._internal_rid());
+  }
+  if (from.has_result()) {
+    _internal_mutable_result()->::grpc_cli::StartHaReplicationResponse_Result::MergeFrom(from._internal_result());
+  }
+  if (from.has_info()) {
+    _internal_mutable_info()->::grpc_cli::PosInfo::MergeFrom(from._internal_info());
+  }
+}
+
+void StartHaReplicationResponse::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.StartHaReplicationResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void StartHaReplicationResponse::CopyFrom(const StartHaReplicationResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.StartHaReplicationResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool StartHaReplicationResponse::IsInitialized() const {
+  return true;
+}
+
+void StartHaReplicationResponse::InternalSwap(StartHaReplicationResponse* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  command_.Swap(&other->command_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  rid_.Swap(&other->rid_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(StartHaReplicationResponse, info_)
+      + sizeof(StartHaReplicationResponse::info_)
+      - PROTOBUF_FIELD_OFFSET(StartHaReplicationResponse, result_)>(
+          reinterpret_cast<char*>(&result_),
+          reinterpret_cast<char*>(&other->result_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata StartHaReplicationResponse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
 class SetLogLevelRequest_Param::_Internal {
  public:
 };
@@ -37897,6 +40699,30 @@ template<> PROTOBUF_NOINLINE ::grpc_cli::ListHaVolumeResponse_Result* Arena::Cre
 }
 template<> PROTOBUF_NOINLINE ::grpc_cli::ListHaVolumeResponse* Arena::CreateMaybeMessage< ::grpc_cli::ListHaVolumeResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::grpc_cli::ListHaVolumeResponse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::ListHaReplicationRequest* Arena::CreateMaybeMessage< ::grpc_cli::ListHaReplicationRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::ListHaReplicationRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::ListHaReplicationResponse_Result_Replication* Arena::CreateMaybeMessage< ::grpc_cli::ListHaReplicationResponse_Result_Replication >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::ListHaReplicationResponse_Result_Replication >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::ListHaReplicationResponse_Result* Arena::CreateMaybeMessage< ::grpc_cli::ListHaReplicationResponse_Result >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::ListHaReplicationResponse_Result >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::ListHaReplicationResponse* Arena::CreateMaybeMessage< ::grpc_cli::ListHaReplicationResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::ListHaReplicationResponse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::StartHaReplicationRequest_Param* Arena::CreateMaybeMessage< ::grpc_cli::StartHaReplicationRequest_Param >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::StartHaReplicationRequest_Param >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::StartHaReplicationRequest* Arena::CreateMaybeMessage< ::grpc_cli::StartHaReplicationRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::StartHaReplicationRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::StartHaReplicationResponse_Result* Arena::CreateMaybeMessage< ::grpc_cli::StartHaReplicationResponse_Result >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::StartHaReplicationResponse_Result >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::StartHaReplicationResponse* Arena::CreateMaybeMessage< ::grpc_cli::StartHaReplicationResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::StartHaReplicationResponse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::grpc_cli::SetLogLevelRequest_Param* Arena::CreateMaybeMessage< ::grpc_cli::SetLogLevelRequest_Param >(Arena* arena) {
   return Arena::CreateMessageInternal< ::grpc_cli::SetLogLevelRequest_Param >(arena);

--- a/proto/generated/cpp/cli.pb.cc
+++ b/proto/generated/cpp/cli.pb.cc
@@ -68,7 +68,11 @@ constexpr SystemInfoResponse_Result_Data::SystemInfoResponse_Result_Data(
   , systemmanufacturer_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
   , systemproductname_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
   , systemserialnumber_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
-  , systemuuid_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string){}
+  , systemuuid_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , baseboardmanufacturer_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , baseboardproductname_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , baseboardserialnumber_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , baseboardversion_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string){}
 struct SystemInfoResponse_Result_DataDefaultTypeInternal {
   constexpr SystemInfoResponse_Result_DataDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
@@ -1898,6 +1902,10 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_cli_2eproto::offsets[] PROTOBU
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, systemproductname_),
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, systemserialnumber_),
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, systemuuid_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, baseboardmanufacturer_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, baseboardproductname_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, baseboardserialnumber_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, baseboardversion_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -2928,131 +2936,131 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 15, -1, sizeof(::grpc_cli::PosInfo)},
   { 21, -1, sizeof(::grpc_cli::SystemInfoRequest)},
   { 29, -1, sizeof(::grpc_cli::SystemInfoResponse_Result_Data)},
-  { 42, -1, sizeof(::grpc_cli::SystemInfoResponse_Result)},
-  { 49, -1, sizeof(::grpc_cli::SystemInfoResponse)},
-  { 58, -1, sizeof(::grpc_cli::SystemStopRequest)},
-  { 66, -1, sizeof(::grpc_cli::SystemStopResponse_Result)},
-  { 72, -1, sizeof(::grpc_cli::SystemStopResponse)},
-  { 81, -1, sizeof(::grpc_cli::GetSystemPropertyRequest)},
-  { 89, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result_Data)},
-  { 95, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result)},
-  { 102, -1, sizeof(::grpc_cli::GetSystemPropertyResponse)},
-  { 111, -1, sizeof(::grpc_cli::SetSystemPropertyRequest_Param)},
-  { 117, -1, sizeof(::grpc_cli::SetSystemPropertyRequest)},
-  { 126, -1, sizeof(::grpc_cli::SetSystemPropertyResponse_Result)},
-  { 132, -1, sizeof(::grpc_cli::SetSystemPropertyResponse)},
-  { 141, -1, sizeof(::grpc_cli::StartTelemetryRequest)},
-  { 149, -1, sizeof(::grpc_cli::StartTelemetryResponse_Result)},
-  { 155, -1, sizeof(::grpc_cli::StartTelemetryResponse)},
-  { 164, -1, sizeof(::grpc_cli::StopTelemetryRequest)},
-  { 172, -1, sizeof(::grpc_cli::StopTelemetryResponse_Result)},
-  { 178, -1, sizeof(::grpc_cli::StopTelemetryResponse)},
-  { 187, -1, sizeof(::grpc_cli::ResetEventWrrRequest)},
-  { 195, -1, sizeof(::grpc_cli::ResetEventWrrResponse_Result)},
-  { 201, -1, sizeof(::grpc_cli::ResetEventWrrResponse)},
-  { 210, -1, sizeof(::grpc_cli::ResetMbrRequest)},
-  { 218, -1, sizeof(::grpc_cli::ResetMbrResponse_Result)},
-  { 224, -1, sizeof(::grpc_cli::ResetMbrResponse)},
-  { 233, -1, sizeof(::grpc_cli::StopRebuildingRequest_Param)},
-  { 239, -1, sizeof(::grpc_cli::StopRebuildingRequest)},
-  { 248, -1, sizeof(::grpc_cli::StopRebuildingResponse_Result)},
-  { 254, -1, sizeof(::grpc_cli::StopRebuildingResponse)},
-  { 263, -1, sizeof(::grpc_cli::UpdateEventWrrRequest_Param)},
-  { 270, -1, sizeof(::grpc_cli::UpdateEventWrrRequest)},
-  { 279, -1, sizeof(::grpc_cli::UpdateEventWrrResponse_Result)},
-  { 285, -1, sizeof(::grpc_cli::UpdateEventWrrResponse)},
-  { 294, -1, sizeof(::grpc_cli::AddSpareRequest_SpareDeviceName)},
-  { 300, -1, sizeof(::grpc_cli::AddSpareRequest_Param)},
-  { 307, -1, sizeof(::grpc_cli::AddSpareRequest)},
-  { 316, -1, sizeof(::grpc_cli::AddSpareResponse_Result)},
-  { 322, -1, sizeof(::grpc_cli::AddSpareResponse)},
-  { 331, -1, sizeof(::grpc_cli::DeviceNameList)},
-  { 337, -1, sizeof(::grpc_cli::RemoveSpareRequest_SpareDeviceName)},
-  { 343, -1, sizeof(::grpc_cli::RemoveSpareRequest_Param)},
-  { 350, -1, sizeof(::grpc_cli::RemoveSpareRequest)},
-  { 359, -1, sizeof(::grpc_cli::RemoveSpareResponse_Result)},
-  { 365, -1, sizeof(::grpc_cli::RemoveSpareResponse)},
-  { 374, -1, sizeof(::grpc_cli::CreateArrayRequest_Param)},
-  { 384, -1, sizeof(::grpc_cli::CreateArrayRequest)},
-  { 393, -1, sizeof(::grpc_cli::CreateArrayResponse_Result)},
-  { 399, -1, sizeof(::grpc_cli::CreateArrayResponse)},
-  { 408, -1, sizeof(::grpc_cli::AutocreateArrayRequest_Param)},
-  { 418, -1, sizeof(::grpc_cli::AutocreateArrayRequest)},
-  { 427, -1, sizeof(::grpc_cli::AutocreateArrayResponse_Result)},
-  { 433, -1, sizeof(::grpc_cli::AutocreateArrayResponse)},
-  { 442, -1, sizeof(::grpc_cli::DeleteArrayRequest_Param)},
-  { 448, -1, sizeof(::grpc_cli::DeleteArrayRequest)},
-  { 457, -1, sizeof(::grpc_cli::DeleteArrayResponse_Result)},
-  { 463, -1, sizeof(::grpc_cli::DeleteArrayResponse)},
-  { 472, 479, sizeof(::grpc_cli::MountArrayRequest_Param)},
-  { 481, -1, sizeof(::grpc_cli::MountArrayRequest)},
-  { 490, -1, sizeof(::grpc_cli::MountArrayResponse_Result)},
-  { 496, -1, sizeof(::grpc_cli::MountArrayResponse)},
-  { 505, -1, sizeof(::grpc_cli::UnmountArrayRequest_Param)},
-  { 511, -1, sizeof(::grpc_cli::UnmountArrayRequest)},
-  { 520, -1, sizeof(::grpc_cli::UnmountArrayResponse_Result)},
-  { 526, -1, sizeof(::grpc_cli::UnmountArrayResponse)},
-  { 535, -1, sizeof(::grpc_cli::Array)},
-  { 556, -1, sizeof(::grpc_cli::ListArrayRequest)},
-  { 564, -1, sizeof(::grpc_cli::ListArrayResponse_Result_ArrayList)},
-  { 570, -1, sizeof(::grpc_cli::ListArrayResponse_Result)},
-  { 577, -1, sizeof(::grpc_cli::ListArrayResponse)},
-  { 586, -1, sizeof(::grpc_cli::ArrayInfoRequest_Param)},
-  { 592, -1, sizeof(::grpc_cli::ArrayInfoRequest)},
-  { 601, -1, sizeof(::grpc_cli::ArrayInfoResponse_Result)},
-  { 608, -1, sizeof(::grpc_cli::ArrayInfoResponse)},
-  { 617, -1, sizeof(::grpc_cli::ListNodeRequest)},
-  { 625, -1, sizeof(::grpc_cli::ListNodeResponse_Result_Node)},
-  { 633, -1, sizeof(::grpc_cli::ListNodeResponse_Result)},
-  { 640, -1, sizeof(::grpc_cli::ListNodeResponse)},
-  { 649, -1, sizeof(::grpc_cli::ListHaVolumeRequest)},
-  { 657, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result_Volume)},
-  { 668, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result)},
-  { 675, -1, sizeof(::grpc_cli::ListHaVolumeResponse)},
-  { 684, -1, sizeof(::grpc_cli::ListHaReplicationRequest)},
-  { 692, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result_Replication)},
-  { 702, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result)},
-  { 709, -1, sizeof(::grpc_cli::ListHaReplicationResponse)},
-  { 718, -1, sizeof(::grpc_cli::StartHaReplicationRequest_Param)},
-  { 733, -1, sizeof(::grpc_cli::StartHaReplicationRequest)},
-  { 742, -1, sizeof(::grpc_cli::StartHaReplicationResponse_Result)},
-  { 748, -1, sizeof(::grpc_cli::StartHaReplicationResponse)},
-  { 757, -1, sizeof(::grpc_cli::SetLogLevelRequest_Param)},
-  { 763, -1, sizeof(::grpc_cli::SetLogLevelRequest)},
-  { 772, -1, sizeof(::grpc_cli::SetLogLevelResponse_Result)},
-  { 778, -1, sizeof(::grpc_cli::SetLogLevelResponse)},
-  { 787, -1, sizeof(::grpc_cli::SetLogPreferenceRequest_Param)},
-  { 793, -1, sizeof(::grpc_cli::SetLogPreferenceRequest)},
-  { 802, -1, sizeof(::grpc_cli::SetLogPreferenceResponse_Result)},
-  { 808, -1, sizeof(::grpc_cli::SetLogPreferenceResponse)},
-  { 817, -1, sizeof(::grpc_cli::LoggerInfoRequest)},
-  { 825, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result_LoggerInfo)},
-  { 839, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result)},
-  { 846, -1, sizeof(::grpc_cli::LoggerInfoResponse)},
-  { 855, -1, sizeof(::grpc_cli::GetLogLevelRequest)},
-  { 863, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result_LogLevel)},
-  { 869, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result)},
-  { 876, -1, sizeof(::grpc_cli::GetLogLevelResponse)},
-  { 885, -1, sizeof(::grpc_cli::ApplyLogFilterRequest)},
-  { 893, -1, sizeof(::grpc_cli::ApplyLogFilterResponse_Result)},
-  { 899, -1, sizeof(::grpc_cli::ApplyLogFilterResponse)},
-  { 908, -1, sizeof(::grpc_cli::CreateDeviceRequest_Param)},
-  { 918, -1, sizeof(::grpc_cli::CreateDeviceRequest)},
-  { 927, -1, sizeof(::grpc_cli::CreateDeviceResponse_Result)},
-  { 933, -1, sizeof(::grpc_cli::CreateDeviceResponse)},
-  { 942, -1, sizeof(::grpc_cli::ScanDeviceRequest)},
-  { 950, -1, sizeof(::grpc_cli::ScanDeviceResponse_Result)},
-  { 956, -1, sizeof(::grpc_cli::ScanDeviceResponse)},
-  { 965, -1, sizeof(::grpc_cli::Device)},
-  { 978, -1, sizeof(::grpc_cli::ListDeviceRequest)},
-  { 986, -1, sizeof(::grpc_cli::ListDeviceResponse_Result_DeviceList)},
-  { 992, -1, sizeof(::grpc_cli::ListDeviceResponse_Result)},
-  { 999, -1, sizeof(::grpc_cli::ListDeviceResponse)},
-  { 1008, -1, sizeof(::grpc_cli::SmartLog)},
-  { 1035, -1, sizeof(::grpc_cli::GetSmartLogRequest_Param)},
-  { 1041, -1, sizeof(::grpc_cli::GetSmartLogRequest)},
-  { 1050, -1, sizeof(::grpc_cli::GetSmartLogResponse_Result)},
-  { 1057, -1, sizeof(::grpc_cli::GetSmartLogResponse)},
+  { 46, -1, sizeof(::grpc_cli::SystemInfoResponse_Result)},
+  { 53, -1, sizeof(::grpc_cli::SystemInfoResponse)},
+  { 62, -1, sizeof(::grpc_cli::SystemStopRequest)},
+  { 70, -1, sizeof(::grpc_cli::SystemStopResponse_Result)},
+  { 76, -1, sizeof(::grpc_cli::SystemStopResponse)},
+  { 85, -1, sizeof(::grpc_cli::GetSystemPropertyRequest)},
+  { 93, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result_Data)},
+  { 99, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result)},
+  { 106, -1, sizeof(::grpc_cli::GetSystemPropertyResponse)},
+  { 115, -1, sizeof(::grpc_cli::SetSystemPropertyRequest_Param)},
+  { 121, -1, sizeof(::grpc_cli::SetSystemPropertyRequest)},
+  { 130, -1, sizeof(::grpc_cli::SetSystemPropertyResponse_Result)},
+  { 136, -1, sizeof(::grpc_cli::SetSystemPropertyResponse)},
+  { 145, -1, sizeof(::grpc_cli::StartTelemetryRequest)},
+  { 153, -1, sizeof(::grpc_cli::StartTelemetryResponse_Result)},
+  { 159, -1, sizeof(::grpc_cli::StartTelemetryResponse)},
+  { 168, -1, sizeof(::grpc_cli::StopTelemetryRequest)},
+  { 176, -1, sizeof(::grpc_cli::StopTelemetryResponse_Result)},
+  { 182, -1, sizeof(::grpc_cli::StopTelemetryResponse)},
+  { 191, -1, sizeof(::grpc_cli::ResetEventWrrRequest)},
+  { 199, -1, sizeof(::grpc_cli::ResetEventWrrResponse_Result)},
+  { 205, -1, sizeof(::grpc_cli::ResetEventWrrResponse)},
+  { 214, -1, sizeof(::grpc_cli::ResetMbrRequest)},
+  { 222, -1, sizeof(::grpc_cli::ResetMbrResponse_Result)},
+  { 228, -1, sizeof(::grpc_cli::ResetMbrResponse)},
+  { 237, -1, sizeof(::grpc_cli::StopRebuildingRequest_Param)},
+  { 243, -1, sizeof(::grpc_cli::StopRebuildingRequest)},
+  { 252, -1, sizeof(::grpc_cli::StopRebuildingResponse_Result)},
+  { 258, -1, sizeof(::grpc_cli::StopRebuildingResponse)},
+  { 267, -1, sizeof(::grpc_cli::UpdateEventWrrRequest_Param)},
+  { 274, -1, sizeof(::grpc_cli::UpdateEventWrrRequest)},
+  { 283, -1, sizeof(::grpc_cli::UpdateEventWrrResponse_Result)},
+  { 289, -1, sizeof(::grpc_cli::UpdateEventWrrResponse)},
+  { 298, -1, sizeof(::grpc_cli::AddSpareRequest_SpareDeviceName)},
+  { 304, -1, sizeof(::grpc_cli::AddSpareRequest_Param)},
+  { 311, -1, sizeof(::grpc_cli::AddSpareRequest)},
+  { 320, -1, sizeof(::grpc_cli::AddSpareResponse_Result)},
+  { 326, -1, sizeof(::grpc_cli::AddSpareResponse)},
+  { 335, -1, sizeof(::grpc_cli::DeviceNameList)},
+  { 341, -1, sizeof(::grpc_cli::RemoveSpareRequest_SpareDeviceName)},
+  { 347, -1, sizeof(::grpc_cli::RemoveSpareRequest_Param)},
+  { 354, -1, sizeof(::grpc_cli::RemoveSpareRequest)},
+  { 363, -1, sizeof(::grpc_cli::RemoveSpareResponse_Result)},
+  { 369, -1, sizeof(::grpc_cli::RemoveSpareResponse)},
+  { 378, -1, sizeof(::grpc_cli::CreateArrayRequest_Param)},
+  { 388, -1, sizeof(::grpc_cli::CreateArrayRequest)},
+  { 397, -1, sizeof(::grpc_cli::CreateArrayResponse_Result)},
+  { 403, -1, sizeof(::grpc_cli::CreateArrayResponse)},
+  { 412, -1, sizeof(::grpc_cli::AutocreateArrayRequest_Param)},
+  { 422, -1, sizeof(::grpc_cli::AutocreateArrayRequest)},
+  { 431, -1, sizeof(::grpc_cli::AutocreateArrayResponse_Result)},
+  { 437, -1, sizeof(::grpc_cli::AutocreateArrayResponse)},
+  { 446, -1, sizeof(::grpc_cli::DeleteArrayRequest_Param)},
+  { 452, -1, sizeof(::grpc_cli::DeleteArrayRequest)},
+  { 461, -1, sizeof(::grpc_cli::DeleteArrayResponse_Result)},
+  { 467, -1, sizeof(::grpc_cli::DeleteArrayResponse)},
+  { 476, 483, sizeof(::grpc_cli::MountArrayRequest_Param)},
+  { 485, -1, sizeof(::grpc_cli::MountArrayRequest)},
+  { 494, -1, sizeof(::grpc_cli::MountArrayResponse_Result)},
+  { 500, -1, sizeof(::grpc_cli::MountArrayResponse)},
+  { 509, -1, sizeof(::grpc_cli::UnmountArrayRequest_Param)},
+  { 515, -1, sizeof(::grpc_cli::UnmountArrayRequest)},
+  { 524, -1, sizeof(::grpc_cli::UnmountArrayResponse_Result)},
+  { 530, -1, sizeof(::grpc_cli::UnmountArrayResponse)},
+  { 539, -1, sizeof(::grpc_cli::Array)},
+  { 560, -1, sizeof(::grpc_cli::ListArrayRequest)},
+  { 568, -1, sizeof(::grpc_cli::ListArrayResponse_Result_ArrayList)},
+  { 574, -1, sizeof(::grpc_cli::ListArrayResponse_Result)},
+  { 581, -1, sizeof(::grpc_cli::ListArrayResponse)},
+  { 590, -1, sizeof(::grpc_cli::ArrayInfoRequest_Param)},
+  { 596, -1, sizeof(::grpc_cli::ArrayInfoRequest)},
+  { 605, -1, sizeof(::grpc_cli::ArrayInfoResponse_Result)},
+  { 612, -1, sizeof(::grpc_cli::ArrayInfoResponse)},
+  { 621, -1, sizeof(::grpc_cli::ListNodeRequest)},
+  { 629, -1, sizeof(::grpc_cli::ListNodeResponse_Result_Node)},
+  { 637, -1, sizeof(::grpc_cli::ListNodeResponse_Result)},
+  { 644, -1, sizeof(::grpc_cli::ListNodeResponse)},
+  { 653, -1, sizeof(::grpc_cli::ListHaVolumeRequest)},
+  { 661, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result_Volume)},
+  { 672, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result)},
+  { 679, -1, sizeof(::grpc_cli::ListHaVolumeResponse)},
+  { 688, -1, sizeof(::grpc_cli::ListHaReplicationRequest)},
+  { 696, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result_Replication)},
+  { 706, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result)},
+  { 713, -1, sizeof(::grpc_cli::ListHaReplicationResponse)},
+  { 722, -1, sizeof(::grpc_cli::StartHaReplicationRequest_Param)},
+  { 737, -1, sizeof(::grpc_cli::StartHaReplicationRequest)},
+  { 746, -1, sizeof(::grpc_cli::StartHaReplicationResponse_Result)},
+  { 752, -1, sizeof(::grpc_cli::StartHaReplicationResponse)},
+  { 761, -1, sizeof(::grpc_cli::SetLogLevelRequest_Param)},
+  { 767, -1, sizeof(::grpc_cli::SetLogLevelRequest)},
+  { 776, -1, sizeof(::grpc_cli::SetLogLevelResponse_Result)},
+  { 782, -1, sizeof(::grpc_cli::SetLogLevelResponse)},
+  { 791, -1, sizeof(::grpc_cli::SetLogPreferenceRequest_Param)},
+  { 797, -1, sizeof(::grpc_cli::SetLogPreferenceRequest)},
+  { 806, -1, sizeof(::grpc_cli::SetLogPreferenceResponse_Result)},
+  { 812, -1, sizeof(::grpc_cli::SetLogPreferenceResponse)},
+  { 821, -1, sizeof(::grpc_cli::LoggerInfoRequest)},
+  { 829, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result_LoggerInfo)},
+  { 843, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result)},
+  { 850, -1, sizeof(::grpc_cli::LoggerInfoResponse)},
+  { 859, -1, sizeof(::grpc_cli::GetLogLevelRequest)},
+  { 867, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result_LogLevel)},
+  { 873, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result)},
+  { 880, -1, sizeof(::grpc_cli::GetLogLevelResponse)},
+  { 889, -1, sizeof(::grpc_cli::ApplyLogFilterRequest)},
+  { 897, -1, sizeof(::grpc_cli::ApplyLogFilterResponse_Result)},
+  { 903, -1, sizeof(::grpc_cli::ApplyLogFilterResponse)},
+  { 912, -1, sizeof(::grpc_cli::CreateDeviceRequest_Param)},
+  { 922, -1, sizeof(::grpc_cli::CreateDeviceRequest)},
+  { 931, -1, sizeof(::grpc_cli::CreateDeviceResponse_Result)},
+  { 937, -1, sizeof(::grpc_cli::CreateDeviceResponse)},
+  { 946, -1, sizeof(::grpc_cli::ScanDeviceRequest)},
+  { 954, -1, sizeof(::grpc_cli::ScanDeviceResponse_Result)},
+  { 960, -1, sizeof(::grpc_cli::ScanDeviceResponse)},
+  { 969, -1, sizeof(::grpc_cli::Device)},
+  { 982, -1, sizeof(::grpc_cli::ListDeviceRequest)},
+  { 990, -1, sizeof(::grpc_cli::ListDeviceResponse_Result_DeviceList)},
+  { 996, -1, sizeof(::grpc_cli::ListDeviceResponse_Result)},
+  { 1003, -1, sizeof(::grpc_cli::ListDeviceResponse)},
+  { 1012, -1, sizeof(::grpc_cli::SmartLog)},
+  { 1039, -1, sizeof(::grpc_cli::GetSmartLogRequest_Param)},
+  { 1045, -1, sizeof(::grpc_cli::GetSmartLogRequest)},
+  { 1054, -1, sizeof(::grpc_cli::GetSmartLogResponse_Result)},
+  { 1061, -1, sizeof(::grpc_cli::GetSmartLogResponse)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -3196,408 +3204,411 @@ const char descriptor_table_protodef_cli_2eproto[] PROTOBUF_SECTION_VARIABLE(pro
   "tionB\010\n\006_causeB\013\n\t_solution\"\032\n\007PosInfo\022\017"
   "\n\007version\030\001 \001(\t\"D\n\021SystemInfoRequest\022\017\n\007"
   "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030"
-  "\003 \001(\t\"\260\003\n\022SystemInfoResponse\022\017\n\007command\030"
+  "\003 \001(\t\"\246\004\n\022SystemInfoResponse\022\017\n\007command\030"
   "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grp"
   "c_cli.SystemInfoResponse.Result\022\037\n\004info\030"
-  "\004 \001(\0132\021.grpc_cli.PosInfo\032\245\002\n\006Result\022 \n\006s"
+  "\004 \001(\0132\021.grpc_cli.PosInfo\032\233\003\n\006Result\022 \n\006s"
   "tatus\030\001 \001(\0132\020.grpc_cli.Status\0226\n\004data\030\002 "
   "\001(\0132(.grpc_cli.SystemInfoResponse.Result"
-  ".Data\032\300\001\n\004Data\022\017\n\007version\030\001 \001(\t\022\023\n\013biosV"
+  ".Data\032\266\002\n\004Data\022\017\n\007version\030\001 \001(\t\022\023\n\013biosV"
   "ersion\030\002 \001(\t\022\022\n\nbiosVendor\030\003 \001(\t\022\027\n\017bios"
   "ReleaseDate\030\004 \001(\t\022\032\n\022systemManufacturer\030"
   "\005 \001(\t\022\031\n\021systemProductName\030\006 \001(\t\022\032\n\022syst"
   "emSerialNumber\030\007 \001(\t\022\022\n\nsystemUuid\030\010 \001(\t"
-  "\"D\n\021SystemStopRequest\022\017\n\007command\030\001 \001(\t\022\013"
-  "\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\264\001\n\022Syste"
-  "mStopResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 "
-  "\001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.SystemSto"
-  "pResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cl"
+  "\022\035\n\025baseboardManufacturer\030\t \001(\t\022\034\n\024baseb"
+  "oardProductName\030\n \001(\t\022\035\n\025baseboardSerial"
+  "Number\030\013 \001(\t\022\030\n\020baseboardVersion\030\014 \001(\t\"D"
+  "\n\021SystemStopRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003"
+  "rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\264\001\n\022SystemS"
+  "topResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001("
+  "\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.SystemStopR"
+  "esponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli."
+  "PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc"
+  "_cli.Status\"K\n\030GetSystemPropertyRequest\022"
+  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequest"
+  "or\030\003 \001(\t\"\242\002\n\031GetSystemPropertyResponse\022\017"
+  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022:\n\006result\030\003"
+  " \001(\0132*.grpc_cli.GetSystemPropertyRespons"
+  "e.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInf"
+  "o\032\211\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli."
+  "Status\022=\n\004data\030\002 \001(\0132/.grpc_cli.GetSyste"
+  "mPropertyResponse.Result.Data\032\036\n\004Data\022\026\n"
+  "\016rebuild_policy\030\001 \001(\t\"\234\001\n\030SetSystemPrope"
+  "rtyRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t"
+  "\022\021\n\trequestor\030\003 \001(\t\0227\n\005param\030\004 \001(\0132(.grp"
+  "c_cli.SetSystemPropertyRequest.Param\032\026\n\005"
+  "Param\022\r\n\005level\030\001 \001(\t\"\302\001\n\031SetSystemProper"
+  "tyResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t"
+  "\022:\n\006result\030\003 \001(\0132*.grpc_cli.SetSystemPro"
+  "pertyResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grp"
+  "c_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132"
+  "\020.grpc_cli.Status\"H\n\025StartTelemetryReque"
+  "st\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequ"
+  "estor\030\003 \001(\t\"\274\001\n\026StartTelemetryResponse\022\017"
+  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003"
+  " \001(\0132\'.grpc_cli.StartTelemetryResponse.R"
+  "esult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*"
+  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
+  "us\"G\n\024StopTelemetryRequest\022\017\n\007command\030\001 "
+  "\001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\272\001\n\025"
+  "StopTelemetryResponse\022\017\n\007command\030\001 \001(\t\022\013"
+  "\n\003rid\030\002 \001(\t\0226\n\006result\030\003 \001(\0132&.grpc_cli.S"
+  "topTelemetryResponse.Result\022\037\n\004info\030\004 \001("
+  "\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006status"
+  "\030\001 \001(\0132\020.grpc_cli.Status\"G\n\024ResetEventWr"
+  "rRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021"
+  "\n\trequestor\030\003 \001(\t\"\272\001\n\025ResetEventWrrRespo"
+  "nse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0226\n\006res"
+  "ult\030\003 \001(\0132&.grpc_cli.ResetEventWrrRespon"
+  "se.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosIn"
+  "fo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli."
+  "Status\"B\n\017ResetMbrRequest\022\017\n\007command\030\001 \001"
+  "(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\260\001\n\020R"
+  "esetMbrResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
+  "\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cli.ResetMb"
+  "rResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cl"
   "i.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.gr"
-  "pc_cli.Status\"K\n\030GetSystemPropertyReques"
-  "t\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treque"
-  "stor\030\003 \001(\t\"\242\002\n\031GetSystemPropertyResponse"
-  "\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022:\n\006result"
-  "\030\003 \001(\0132*.grpc_cli.GetSystemPropertyRespo"
-  "nse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosI"
-  "nfo\032\211\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
-  "i.Status\022=\n\004data\030\002 \001(\0132/.grpc_cli.GetSys"
-  "temPropertyResponse.Result.Data\032\036\n\004Data\022"
-  "\026\n\016rebuild_policy\030\001 \001(\t\"\234\001\n\030SetSystemPro"
-  "pertyRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001"
-  "(\t\022\021\n\trequestor\030\003 \001(\t\0227\n\005param\030\004 \001(\0132(.g"
-  "rpc_cli.SetSystemPropertyRequest.Param\032\026"
-  "\n\005Param\022\r\n\005level\030\001 \001(\t\"\302\001\n\031SetSystemProp"
-  "ertyResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001"
-  "(\t\022:\n\006result\030\003 \001(\0132*.grpc_cli.SetSystemP"
-  "ropertyResponse.Result\022\037\n\004info\030\004 \001(\0132\021.g"
-  "rpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001("
-  "\0132\020.grpc_cli.Status\"H\n\025StartTelemetryReq"
-  "uest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tre"
-  "questor\030\003 \001(\t\"\274\001\n\026StartTelemetryResponse"
-  "\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result"
-  "\030\003 \001(\0132\'.grpc_cli.StartTelemetryResponse"
-  ".Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo"
-  "\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.St"
-  "atus\"G\n\024StopTelemetryRequest\022\017\n\007command\030"
-  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\272\001"
-  "\n\025StopTelemetryResponse\022\017\n\007command\030\001 \001(\t"
-  "\022\013\n\003rid\030\002 \001(\t\0226\n\006result\030\003 \001(\0132&.grpc_cli"
-  ".StopTelemetryResponse.Result\022\037\n\004info\030\004 "
-  "\001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006stat"
-  "us\030\001 \001(\0132\020.grpc_cli.Status\"G\n\024ResetEvent"
-  "WrrRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t"
-  "\022\021\n\trequestor\030\003 \001(\t\"\272\001\n\025ResetEventWrrRes"
-  "ponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0226\n\006r"
-  "esult\030\003 \001(\0132&.grpc_cli.ResetEventWrrResp"
-  "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
-  "Info\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
-  "i.Status\"B\n\017ResetMbrRequest\022\017\n\007command\030\001"
-  " \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\260\001\n"
-  "\020ResetMbrResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
-  "d\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cli.Reset"
-  "MbrResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_"
-  "cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020."
-  "grpc_cli.Status\"\225\001\n\025StopRebuildingReques"
-  "t\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treque"
-  "stor\030\003 \001(\t\0224\n\005param\030\004 \001(\0132%.grpc_cli.Sto"
-  "pRebuildingRequest.Param\032\025\n\005Param\022\014\n\004nam"
-  "e\030\001 \001(\t\"\274\001\n\026StopRebuildingResponse\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\013"
-  "2\'.grpc_cli.StopRebuildingResponse.Resul"
-  "t\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Re"
-  "sult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\245"
-  "\001\n\025UpdateEventWrrRequest\022\017\n\007command\030\001 \001("
-  "\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0224\n\005par"
-  "am\030\004 \001(\0132%.grpc_cli.UpdateEventWrrReques"
-  "t.Param\032%\n\005Param\022\014\n\004name\030\001 \001(\t\022\016\n\006weight"
-  "\030\002 \001(\003\"\274\001\n\026UpdateEventWrrResponse\022\017\n\007com"
-  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132"
-  "\'.grpc_cli.UpdateEventWrrResponse.Result"
-  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Res"
-  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\353\001"
-  "\n\017AddSpareRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
-  "d\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022.\n\005param\030\004 \001("
-  "\0132\037.grpc_cli.AddSpareRequest.Param\032%\n\017Sp"
-  "areDeviceName\022\022\n\ndeviceName\030\001 \001(\t\032P\n\005Par"
-  "am\022\r\n\005array\030\001 \001(\t\0228\n\005spare\030\003 \003(\0132).grpc_"
-  "cli.AddSpareRequest.SpareDeviceName\"\260\001\n\020"
-  "AddSpareResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
-  "\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cli.AddSpa"
-  "reResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_c"
-  "li.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.g"
-  "rpc_cli.Status\"$\n\016DeviceNameList\022\022\n\ndevi"
-  "ceName\030\001 \001(\t\"\364\001\n\022RemoveSpareRequest\022\017\n\007c"
-  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003"
-  " \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.RemoveSpa"
-  "reRequest.Param\032%\n\017SpareDeviceName\022\022\n\nde"
-  "viceName\030\001 \001(\t\032S\n\005Param\022\r\n\005array\030\001 \001(\t\022;"
-  "\n\005spare\030\002 \003(\0132,.grpc_cli.RemoveSpareRequ"
-  "est.SpareDeviceName\"\266\001\n\023RemoveSpareRespo"
-  "nse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006res"
-  "ult\030\003 \001(\0132$.grpc_cli.RemoveSpareResponse"
-  ".Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo"
-  "\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.St"
-  "atus\"\235\002\n\022CreateArrayRequest\022\017\n\007command\030\001"
-  " \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005"
-  "param\030\004 \001(\0132\".grpc_cli.CreateArrayReques"
-  "t.Param\032\242\001\n\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006buffe"
-  "r\030\002 \003(\0132\030.grpc_cli.DeviceNameList\022&\n\004dat"
-  "a\030\003 \003(\0132\030.grpc_cli.DeviceNameList\022\'\n\005spa"
-  "re\030\004 \003(\0132\030.grpc_cli.DeviceNameList\022\020\n\010ra"
-  "idtype\030\005 \001(\t\"\266\001\n\023CreateArrayResponse\022\017\n\007"
-  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001"
-  "(\0132$.grpc_cli.CreateArrayResponse.Result"
-  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Res"
-  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\366\001"
-  "\n\026AutocreateArrayRequest\022\017\n\007command\030\001 \001("
-  "\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0225\n\005par"
-  "am\030\004 \001(\0132&.grpc_cli.AutocreateArrayReque"
-  "st.Param\032t\n\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006buffe"
-  "r\030\002 \003(\0132\030.grpc_cli.DeviceNameList\022\017\n\007num"
-  "Data\030\003 \001(\005\022\020\n\010numSpare\030\004 \001(\005\022\020\n\010raidtype"
-  "\030\005 \001(\t\"\276\001\n\027AutocreateArrayResponse\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0228\n\006result\030\003 \001(\013"
-  "2(.grpc_cli.AutocreateArrayResponse.Resu"
-  "lt\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006R"
-  "esult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\""
-  "\217\001\n\022DeleteArrayRequest\022\017\n\007command\030\001 \001(\t\022"
-  "\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005param"
-  "\030\004 \001(\0132\".grpc_cli.DeleteArrayRequest.Par"
-  "am\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\266\001\n\023DeleteArra"
-  "yResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022"
-  "4\n\006result\030\003 \001(\0132$.grpc_cli.DeleteArrayRe"
-  "sponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.P"
-  "osInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_"
-  "cli.Status\"\305\001\n\021MountArrayRequest\022\017\n\007comm"
-  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001("
-  "\t\0220\n\005param\030\004 \001(\0132!.grpc_cli.MountArrayRe"
-  "quest.Param\032M\n\005Param\022\014\n\004name\030\001 \001(\t\022\037\n\022en"
-  "ableWriteThrough\030\002 \001(\010H\000\210\001\001B\025\n\023_enableWr"
-  "iteThrough\"\264\001\n\022MountArrayResponse\022\017\n\007com"
-  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132"
-  "#.grpc_cli.MountArrayResponse.Result\022\037\n\004"
-  "info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022"
-  " \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\221\001\n\023Un"
-  "mountArrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
-  "d\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005param\030\004 \001("
-  "\0132#.grpc_cli.UnmountArrayRequest.Param\032\025"
-  "\n\005Param\022\014\n\004name\030\001 \001(\t\"\270\001\n\024UnmountArrayRe"
-  "sponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006"
-  "result\030\003 \001(\0132%.grpc_cli.UnmountArrayResp"
-  "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
-  "Info\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
-  "i.Status\"\314\002\n\005Array\022\r\n\005index\030\001 \001(\005\022\021\n\tuni"
-  "que_id\030\002 \001(\005\022\014\n\004name\030\003 \001(\t\022\016\n\006status\030\004 \001"
-  "(\t\022\r\n\005state\030\005 \001(\t\022\021\n\tsituation\030\006 \001(\t\022\026\n\016"
-  "createDatetime\030\007 \001(\t\022\026\n\016updateDatetime\030\010"
-  " \001(\t\022\032\n\022rebuildingProgress\030\t \001(\t\022\020\n\010capa"
-  "city\030\n \001(\004\022\014\n\004used\030\013 \001(\004\022\016\n\006gcMode\030\014 \001(\t"
-  "\022\020\n\010metaRaid\030\r \001(\t\022\020\n\010dataRaid\030\016 \001(\t\022\033\n\023"
-  "writeThroughEnabled\030\017 \001(\010\022$\n\ndevicelist\030"
-  "\020 \003(\0132\020.grpc_cli.Device\"C\n\020ListArrayRequ"
-  "est\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treq"
-  "uestor\030\003 \001(\t\"\240\002\n\021ListArrayResponse\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003 \001(\013"
-  "2\".grpc_cli.ListArrayResponse.Result\022\037\n\004"
-  "info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\227\001\n\006Result"
-  "\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022:\n\004da"
-  "ta\030\002 \001(\0132,.grpc_cli.ListArrayResponse.Re"
-  "sult.ArrayList\032/\n\tArrayList\022\"\n\tarrayList"
-  "\030\001 \003(\0132\017.grpc_cli.Array\"\213\001\n\020ArrayInfoReq"
-  "uest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tre"
-  "questor\030\003 \001(\t\022/\n\005param\030\004 \001(\0132 .grpc_cli."
-  "ArrayInfoRequest.Param\032\025\n\005Param\022\014\n\004name\030"
-  "\001 \001(\t\"\321\001\n\021ArrayInfoResponse\022\017\n\007command\030\001"
-  " \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003 \001(\0132\".grpc"
-  "_cli.ArrayInfoResponse.Result\022\037\n\004info\030\004 "
-  "\001(\0132\021.grpc_cli.PosInfo\032I\n\006Result\022 \n\006stat"
-  "us\030\001 \001(\0132\020.grpc_cli.Status\022\035\n\004data\030\002 \001(\013"
-  "2\017.grpc_cli.Array\"B\n\017ListNodeRequest\022\017\n\007"
-  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030"
-  "\003 \001(\t\"\233\002\n\020ListNodeResponse\022\017\n\007command\030\001 "
-  "\001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_"
-  "cli.ListNodeResponse.Result\022\037\n\004info\030\004 \001("
-  "\0132\021.grpc_cli.PosInfo\032\224\001\n\006Result\022 \n\006statu"
-  "s\030\001 \001(\0132\020.grpc_cli.Status\0224\n\004data\030\002 \003(\0132"
-  "&.grpc_cli.ListNodeResponse.Result.Node\032"
-  "2\n\004Node\022\014\n\004name\030\001 \001(\t\022\n\n\002ip\030\002 \001(\t\022\020\n\010las"
-  "tseen\030\003 \001(\t\"F\n\023ListHaVolumeRequest\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 "
-  "\001(\t\"\336\002\n\024ListHaVolumeResponse\022\017\n\007command\030"
-  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001(\0132%.grp"
-  "c_cli.ListHaVolumeResponse.Result\022\037\n\004inf"
-  "o\030\004 \001(\0132\021.grpc_cli.PosInfo\032\317\001\n\006Result\022 \n"
-  "\006status\030\001 \001(\0132\020.grpc_cli.Status\022:\n\004data\030"
-  "\002 \003(\0132,.grpc_cli.ListHaVolumeResponse.Re"
-  "sult.Volume\032g\n\006Volume\022\n\n\002id\030\001 \001(\005\022\014\n\004nam"
-  "e\030\002 \001(\t\022\020\n\010nodeName\030\003 \001(\t\022\021\n\tarrayName\030\004"
-  " \001(\t\022\014\n\004size\030\005 \001(\003\022\020\n\010lastseen\030\006 \001(\t\"K\n\030"
-  "ListHaReplicationRequest\022\017\n\007command\030\001 \001("
-  "\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\226\003\n\031Li"
-  "stHaReplicationResponse\022\017\n\007command\030\001 \001(\t"
-  "\022\013\n\003rid\030\002 \001(\t\022:\n\006result\030\003 \001(\0132*.grpc_cli"
-  ".ListHaReplicationResponse.Result\022\037\n\004inf"
-  "o\030\004 \001(\0132\021.grpc_cli.PosInfo\032\375\001\n\006Result\022 \n"
-  "\006status\030\001 \001(\0132\020.grpc_cli.Status\022D\n\004data\030"
-  "\002 \003(\01326.grpc_cli.ListHaReplicationRespon"
-  "se.Result.Replication\032\212\001\n\013Replication\022\n\n"
-  "\002id\030\001 \001(\005\022\026\n\016sourceVolumeId\030\002 \001(\005\022\032\n\022sou"
-  "rceWalVolume_id\030\003 \001(\005\022\033\n\023destinationVolu"
-  "meId\030\004 \001(\005\022\036\n\026destinationWalVolumeId\030\005 \001"
-  "(\005\"\223\003\n\031StartHaReplicationRequest\022\017\n\007comm"
-  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001("
-  "\t\0228\n\005param\030\004 \001(\0132).grpc_cli.StartHaRepli"
-  "cationRequest.Param\032\212\002\n\005Param\022\027\n\017primary"
-  "NodeName\030\001 \001(\t\022\030\n\020primaryArrayName\030\002 \001(\t"
-  "\022\031\n\021primaryVolumeName\030\003 \001(\t\022\034\n\024primaryWa"
-  "lVolumeName\030\004 \001(\t\022\031\n\021secondaryNodeName\030\005"
-  " \001(\t\022\032\n\022secondaryArrayName\030\006 \001(\t\022\033\n\023seco"
-  "ndaryVolumeName\030\007 \001(\t\022\036\n\026secondaryWalVol"
-  "umeName\030\010 \001(\t\022\016\n\006stuats\030\t \001(\t\022\021\n\ttimesta"
-  "mp\030\n \001(\t\"\304\001\n\032StartHaReplicationResponse\022"
-  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022;\n\006result\030"
-  "\003 \001(\0132+.grpc_cli.StartHaReplicationRespo"
-  "nse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosI"
-  "nfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli"
-  ".Status\"\220\001\n\022SetLogLevelRequest\022\017\n\007comman"
-  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022"
-  "1\n\005param\030\004 \001(\0132\".grpc_cli.SetLogLevelReq"
-  "uest.Param\032\026\n\005Param\022\r\n\005level\030\001 \001(\t\"\266\001\n\023S"
-  "etLogLevelResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003r"
-  "id\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.SetL"
-  "ogLevelResponse.Result\022\037\n\004info\030\004 \001(\0132\021.g"
-  "rpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001("
-  "\0132\020.grpc_cli.Status\"\246\001\n\027SetLogPreference"
-  "Request\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n"
-  "\trequestor\030\003 \001(\t\0226\n\005param\030\004 \001(\0132\'.grpc_c"
-  "li.SetLogPreferenceRequest.Param\032\"\n\005Para"
-  "m\022\031\n\021structuredLogging\030\001 \001(\t\"\300\001\n\030SetLogP"
-  "referenceResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
-  "d\030\002 \001(\t\0229\n\006result\030\003 \001(\0132).grpc_cli.SetLo"
-  "gPreferenceResponse.Result\022\037\n\004info\030\004 \001(\013"
-  "2\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030"
-  "\001 \001(\0132\020.grpc_cli.Status\"D\n\021LoggerInfoReq"
-  "uest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tre"
-  "questor\030\003 \001(\t\"\345\003\n\022LoggerInfoResponse\022\017\n\007"
-  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001"
-  "(\0132#.grpc_cli.LoggerInfoResponse.Result\022"
-  "\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\332\002\n\006Res"
-  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022<\n"
-  "\004data\030\002 \001(\0132..grpc_cli.LoggerInfoRespons"
-  "e.Result.LoggerInfo\032\357\001\n\nLoggerInfo\022\024\n\014mi"
-  "norLogPath\030\001 \001(\t\022\024\n\014majorLogPath\030\002 \001(\t\022\027"
-  "\n\017logfileSizeInMb\030\003 \001(\t\022\034\n\024logfileRotati"
-  "onCount\030\004 \001(\005\022\034\n\024minAllowableLogLevel\030\005 "
-  "\001(\t\022\025\n\rfilterEnabled\030\006 \001(\005\022\026\n\016filterIncl"
-  "uded\030\007 \001(\t\022\026\n\016filterExcluded\030\010 \001(\t\022\031\n\021st"
-  "ructuredLogging\030\t \001(\010\"E\n\022GetLogLevelRequ"
-  "est\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treq"
-  "uestor\030\003 \001(\t\"\217\002\n\023GetLogLevelResponse\022\017\n\007"
-  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001"
-  "(\0132$.grpc_cli.GetLogLevelResponse.Result"
-  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\202\001\n\006Re"
-  "sult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022;"
-  "\n\004data\030\002 \001(\0132-.grpc_cli.GetLogLevelRespo"
-  "nse.Result.LogLevel\032\031\n\010LogLevel\022\r\n\005level"
-  "\030\001 \001(\t\"H\n\025ApplyLogFilterRequest\022\017\n\007comma"
-  "nd\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t"
-  "\"\274\001\n\026ApplyLogFilterResponse\022\017\n\007command\030\001"
-  " \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'.grpc"
-  "_cli.ApplyLogFilterResponse.Result\022\037\n\004in"
-  "fo\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n"
-  "\006status\030\001 \001(\0132\020.grpc_cli.Status\"\326\001\n\023Crea"
-  "teDeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005param\030\004 \001(\0132"
-  "#.grpc_cli.CreateDeviceRequest.Param\032Z\n\005"
-  "Param\022\014\n\004name\030\001 \001(\t\022\021\n\tnumBlocks\030\002 \001(\r\022\021"
-  "\n\tblockSize\030\003 \001(\r\022\017\n\007devType\030\004 \001(\t\022\014\n\004nu"
-  "ma\030\005 \001(\r\"\270\001\n\024CreateDeviceResponse\022\017\n\007com"
-  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001(\0132"
-  "%.grpc_cli.CreateDeviceResponse.Result\022\037"
+  "pc_cli.Status\"\225\001\n\025StopRebuildingRequest\022"
+  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequest"
+  "or\030\003 \001(\t\0224\n\005param\030\004 \001(\0132%.grpc_cli.StopR"
+  "ebuildingRequest.Param\032\025\n\005Param\022\014\n\004name\030"
+  "\001 \001(\t\"\274\001\n\026StopRebuildingResponse\022\017\n\007comm"
+  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'"
+  ".grpc_cli.StopRebuildingResponse.Result\022"
+  "\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Resu"
+  "lt\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\245\001\n"
+  "\025UpdateEventWrrRequest\022\017\n\007command\030\001 \001(\t\022"
+  "\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0224\n\005param"
+  "\030\004 \001(\0132%.grpc_cli.UpdateEventWrrRequest."
+  "Param\032%\n\005Param\022\014\n\004name\030\001 \001(\t\022\016\n\006weight\030\002"
+  " \001(\003\"\274\001\n\026UpdateEventWrrResponse\022\017\n\007comma"
+  "nd\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'."
+  "grpc_cli.UpdateEventWrrResponse.Result\022\037"
   "\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Resul"
-  "t\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"D\n\021S"
-  "canDeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
-  "\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\264\001\n\022ScanDevice"
-  "Response\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223"
-  "\n\006result\030\003 \001(\0132#.grpc_cli.ScanDeviceResp"
+  "t\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\353\001\n\017"
+  "AddSpareRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
+  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022.\n\005param\030\004 \001(\0132"
+  "\037.grpc_cli.AddSpareRequest.Param\032%\n\017Spar"
+  "eDeviceName\022\022\n\ndeviceName\030\001 \001(\t\032P\n\005Param"
+  "\022\r\n\005array\030\001 \001(\t\0228\n\005spare\030\003 \003(\0132).grpc_cl"
+  "i.AddSpareRequest.SpareDeviceName\"\260\001\n\020Ad"
+  "dSpareResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
+  " \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cli.AddSpare"
+  "Response.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli"
+  ".PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grp"
+  "c_cli.Status\"$\n\016DeviceNameList\022\022\n\ndevice"
+  "Name\030\001 \001(\t\"\364\001\n\022RemoveSpareRequest\022\017\n\007com"
+  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001"
+  "(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.RemoveSpare"
+  "Request.Param\032%\n\017SpareDeviceName\022\022\n\ndevi"
+  "ceName\030\001 \001(\t\032S\n\005Param\022\r\n\005array\030\001 \001(\t\022;\n\005"
+  "spare\030\002 \003(\0132,.grpc_cli.RemoveSpareReques"
+  "t.SpareDeviceName\"\266\001\n\023RemoveSpareRespons"
+  "e\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006resul"
+  "t\030\003 \001(\0132$.grpc_cli.RemoveSpareResponse.R"
+  "esult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*"
+  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
+  "us\"\235\002\n\022CreateArrayRequest\022\017\n\007command\030\001 \001"
+  "(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005pa"
+  "ram\030\004 \001(\0132\".grpc_cli.CreateArrayRequest."
+  "Param\032\242\001\n\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006buffer\030"
+  "\002 \003(\0132\030.grpc_cli.DeviceNameList\022&\n\004data\030"
+  "\003 \003(\0132\030.grpc_cli.DeviceNameList\022\'\n\005spare"
+  "\030\004 \003(\0132\030.grpc_cli.DeviceNameList\022\020\n\010raid"
+  "type\030\005 \001(\t\"\266\001\n\023CreateArrayResponse\022\017\n\007co"
+  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\013"
+  "2$.grpc_cli.CreateArrayResponse.Result\022\037"
+  "\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Resul"
+  "t\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\366\001\n\026"
+  "AutocreateArrayRequest\022\017\n\007command\030\001 \001(\t\022"
+  "\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0225\n\005param"
+  "\030\004 \001(\0132&.grpc_cli.AutocreateArrayRequest"
+  ".Param\032t\n\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006buffer\030"
+  "\002 \003(\0132\030.grpc_cli.DeviceNameList\022\017\n\007numDa"
+  "ta\030\003 \001(\005\022\020\n\010numSpare\030\004 \001(\005\022\020\n\010raidtype\030\005"
+  " \001(\t\"\276\001\n\027AutocreateArrayResponse\022\017\n\007comm"
+  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0228\n\006result\030\003 \001(\0132("
+  ".grpc_cli.AutocreateArrayResponse.Result"
+  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Res"
+  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\217\001"
+  "\n\022DeleteArrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n"
+  "\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005param\030\004"
+  " \001(\0132\".grpc_cli.DeleteArrayRequest.Param"
+  "\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\266\001\n\023DeleteArrayR"
+  "esponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n"
+  "\006result\030\003 \001(\0132$.grpc_cli.DeleteArrayResp"
   "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
   "Info\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
-  "i.Status\"\213\001\n\006Device\022\014\n\004name\030\001 \001(\t\022\014\n\004typ"
-  "e\030\002 \001(\t\022\017\n\007address\030\003 \001(\t\022\r\n\005class\030\004 \001(\t\022"
-  "\023\n\013modelNumber\030\005 \001(\t\022\014\n\004numa\030\006 \001(\t\022\014\n\004si"
-  "ze\030\007 \001(\004\022\024\n\014serialNumber\030\010 \001(\t\"D\n\021ListDe"
-  "viceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001("
-  "\t\022\021\n\trequestor\030\003 \001(\t\"\247\002\n\022ListDeviceRespo"
-  "nse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006res"
-  "ult\030\003 \001(\0132#.grpc_cli.ListDeviceResponse."
-  "Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032"
-  "\234\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.St"
-  "atus\022<\n\004data\030\002 \001(\0132..grpc_cli.ListDevice"
-  "Response.Result.DeviceList\0322\n\nDeviceList"
-  "\022$\n\ndevicelist\030\001 \003(\0132\020.grpc_cli.Device\"\335"
-  "\004\n\010SmartLog\022\033\n\023availableSpareSpace\030\001 \001(\t"
-  "\022\023\n\013temperature\030\002 \001(\t\022\031\n\021deviceReliabili"
-  "ty\030\003 \001(\t\022\020\n\010readOnly\030\004 \001(\t\022\034\n\024volatileMe"
-  "moryBackup\030\005 \001(\t\022\032\n\022currentTemperature\030\006"
-  " \001(\t\022\026\n\016availableSpare\030\007 \001(\t\022\037\n\027availabl"
-  "eSpareThreshold\030\010 \001(\t\022\032\n\022lifePercentageU"
-  "sed\030\t \001(\t\022\025\n\rdataUnitsRead\030\n \001(\t\022\030\n\020data"
-  "UnitsWritten\030\013 \001(\t\022\030\n\020hostReadCommands\030\014"
-  " \001(\t\022\031\n\021hostWriteCommands\030\r \001(\t\022\032\n\022contr"
-  "ollerBusyTime\030\016 \001(\t\022\023\n\013powerCycles\030\017 \001(\t"
-  "\022\024\n\014powerOnHours\030\020 \001(\t\022\027\n\017unsafeShutdown"
-  "s\030\021 \001(\t\022 \n\030unrecoverableMediaErrors\030\022 \001("
-  "\t\022\037\n\027lifetimeErrorLogEntries\030\023 \001(\t\022\036\n\026wa"
-  "rningTemperatureTime\030\024 \001(\t\022\037\n\027criticalTe"
-  "mperatureTime\030\025 \001(\t\022\031\n\021temperatureSensor"
-  "\030\026 \003(\t\"\217\001\n\022GetSmartLogRequest\022\017\n\007command"
-  "\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221"
-  "\n\005param\030\004 \001(\0132\".grpc_cli.GetSmartLogRequ"
-  "est.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\330\001\n\023Get"
-  "SmartLogResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
-  "\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.GetSma"
-  "rtLogResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grp"
-  "c_cli.PosInfo\032L\n\006Result\022 \n\006status\030\001 \001(\0132"
-  "\020.grpc_cli.Status\022 \n\004data\030\002 \001(\0132\022.grpc_c"
-  "li.SmartLog2\221\026\n\006PosCli\022_\n\nSystemInfo\022\033.g"
-  "rpc_cli.SystemInfoRequest\032\034.grpc_cli.Sys"
-  "temInfoResponse\"\026\202\323\344\223\002\020\022\016/v1/systeminfo\022"
-  "_\n\nSystemStop\022\033.grpc_cli.SystemStopReque"
-  "st\032\034.grpc_cli.SystemStopResponse\"\026\202\323\344\223\002\020"
-  "\022\016/v1/systemstop\022}\n\021GetSystemProperty\022\"."
-  "grpc_cli.GetSystemPropertyRequest\032#.grpc"
-  "_cli.GetSystemPropertyResponse\"\037\202\323\344\223\002\031\022\027"
-  "/v1/get_system_property\022\205\001\n\021SetSystemPro"
-  "perty\022\".grpc_cli.SetSystemPropertyReques"
-  "t\032#.grpc_cli.SetSystemPropertyResponse\"\'"
-  "\202\323\344\223\002!\022\037/v1/set_system_property/{level}\022"
-  "p\n\016StartTelemetry\022\037.grpc_cli.StartTeleme"
-  "tryRequest\032 .grpc_cli.StartTelemetryResp"
-  "onse\"\033\202\323\344\223\002\025\022\023/v1/start_telemetry\022l\n\rSto"
-  "pTelemetry\022\036.grpc_cli.StopTelemetryReque"
-  "st\032\037.grpc_cli.StopTelemetryResponse\"\032\202\323\344"
-  "\223\002\024\022\022/v1/stop_telemetry\022P\n\rResetEventWrr"
-  "\022\036.grpc_cli.ResetEventWrrRequest\032\037.grpc_"
-  "cli.ResetEventWrrResponse\022A\n\010ResetMbr\022\031."
-  "grpc_cli.ResetMbrRequest\032\032.grpc_cli.Rese"
-  "tMbrResponse\022S\n\016StopRebuilding\022\037.grpc_cl"
-  "i.StopRebuildingRequest\032 .grpc_cli.StopR"
-  "ebuildingResponse\022S\n\016UpdateEventWrr\022\037.gr"
-  "pc_cli.UpdateEventWrrRequest\032 .grpc_cli."
-  "UpdateEventWrrResponse\022W\n\010AddSpare\022\031.grp"
-  "c_cli.AddSpareRequest\032\032.grpc_cli.AddSpar"
-  "eResponse\"\024\202\323\344\223\002\016\"\014/v1/addspare\022c\n\013Remov"
-  "eSpare\022\034.grpc_cli.RemoveSpareRequest\032\035.g"
-  "rpc_cli.RemoveSpareResponse\"\027\202\323\344\223\002\021\"\017/v1"
-  "/removespare\022c\n\013CreateArray\022\034.grpc_cli.C"
-  "reateArrayRequest\032\035.grpc_cli.CreateArray"
-  "Response\"\027\202\323\344\223\002\021\"\017/v1/createarray\022s\n\017Aut"
-  "ocreateArray\022 .grpc_cli.AutocreateArrayR"
-  "equest\032!.grpc_cli.AutocreateArrayRespons"
-  "e\"\033\202\323\344\223\002\025\"\023/v1/autocreatearray\022d\n\013Delete"
-  "Array\022\034.grpc_cli.DeleteArrayRequest\032\035.gr"
-  "pc_cli.DeleteArrayResponse\"\030\202\323\344\223\002\022\"\020/v1/"
-  "deletearray/\022_\n\nMountArray\022\033.grpc_cli.Mo"
-  "untArrayRequest\032\034.grpc_cli.MountArrayRes"
-  "ponse\"\026\202\323\344\223\002\020\"\016/v1/mountarray\022g\n\014Unmount"
-  "Array\022\035.grpc_cli.UnmountArrayRequest\032\036.g"
-  "rpc_cli.UnmountArrayResponse\"\030\202\323\344\223\002\022\"\020/v"
-  "1/unmountarray\022[\n\tListArray\022\032.grpc_cli.L"
-  "istArrayRequest\032\033.grpc_cli.ListArrayResp"
-  "onse\"\025\202\323\344\223\002\017\"\r/v1/listarray\022[\n\tArrayInfo"
-  "\022\032.grpc_cli.ArrayInfoRequest\032\033.grpc_cli."
-  "ArrayInfoResponse\"\025\202\323\344\223\002\017\"\r/v1/arrayinfo"
-  "\022w\n\020SetLogPreference\022!.grpc_cli.SetLogPr"
-  "eferenceRequest\032\".grpc_cli.SetLogPrefere"
-  "nceResponse\"\034\202\323\344\223\002\026\"\024/v1/setlogpreferenc"
-  "e\022c\n\013SetLogLevel\022\034.grpc_cli.SetLogLevelR"
-  "equest\032\035.grpc_cli.SetLogLevelResponse\"\027\202"
-  "\323\344\223\002\021\"\017/v1/setloglevel\022_\n\nLoggerInfo\022\033.g"
-  "rpc_cli.LoggerInfoRequest\032\034.grpc_cli.Log"
-  "gerInfoResponse\"\026\202\323\344\223\002\020\"\016/v1/loggerinfo\022"
-  "c\n\013GetLogLevel\022\034.grpc_cli.GetLogLevelReq"
-  "uest\032\035.grpc_cli.GetLogLevelResponse\"\027\202\323\344"
-  "\223\002\021\"\017/v1/getloglevel\022l\n\016ApplyLogFilter\022\037"
-  ".grpc_cli.ApplyLogFilterRequest\032 .grpc_c"
-  "li.ApplyLogFilterResponse\"\027\202\323\344\223\002\021\"\017/v1/a"
-  "pplyfilter\022g\n\014CreateDevice\022\035.grpc_cli.Cr"
-  "eateDeviceRequest\032\036.grpc_cli.CreateDevic"
-  "eResponse\"\030\202\323\344\223\002\022\"\020/v1/createdevice\022_\n\nS"
-  "canDevice\022\033.grpc_cli.ScanDeviceRequest\032\034"
-  ".grpc_cli.ScanDeviceResponse\"\026\202\323\344\223\002\020\"\016/v"
-  "1/scandevice\022_\n\nListDevice\022\033.grpc_cli.Li"
-  "stDeviceRequest\032\034.grpc_cli.ListDeviceRes"
-  "ponse\"\026\202\323\344\223\002\020\"\016/v1/listdevice\022`\n\013GetSmar"
-  "tLog\022\034.grpc_cli.GetSmartLogRequest\032\035.grp"
-  "c_cli.GetSmartLogResponse\"\024\202\323\344\223\002\016\"\014/v1/s"
-  "martlogB\tZ\007cli/apib\006proto3"
+  "i.Status\"\305\001\n\021MountArrayRequest\022\017\n\007comman"
+  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022"
+  "0\n\005param\030\004 \001(\0132!.grpc_cli.MountArrayRequ"
+  "est.Param\032M\n\005Param\022\014\n\004name\030\001 \001(\t\022\037\n\022enab"
+  "leWriteThrough\030\002 \001(\010H\000\210\001\001B\025\n\023_enableWrit"
+  "eThrough\"\264\001\n\022MountArrayResponse\022\017\n\007comma"
+  "nd\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#."
+  "grpc_cli.MountArrayResponse.Result\022\037\n\004in"
+  "fo\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n"
+  "\006status\030\001 \001(\0132\020.grpc_cli.Status\"\221\001\n\023Unmo"
+  "untArrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
+  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005param\030\004 \001(\0132"
+  "#.grpc_cli.UnmountArrayRequest.Param\032\025\n\005"
+  "Param\022\014\n\004name\030\001 \001(\t\"\270\001\n\024UnmountArrayResp"
+  "onse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006re"
+  "sult\030\003 \001(\0132%.grpc_cli.UnmountArrayRespon"
+  "se.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosIn"
+  "fo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli."
+  "Status\"\314\002\n\005Array\022\r\n\005index\030\001 \001(\005\022\021\n\tuniqu"
+  "e_id\030\002 \001(\005\022\014\n\004name\030\003 \001(\t\022\016\n\006status\030\004 \001(\t"
+  "\022\r\n\005state\030\005 \001(\t\022\021\n\tsituation\030\006 \001(\t\022\026\n\016cr"
+  "eateDatetime\030\007 \001(\t\022\026\n\016updateDatetime\030\010 \001"
+  "(\t\022\032\n\022rebuildingProgress\030\t \001(\t\022\020\n\010capaci"
+  "ty\030\n \001(\004\022\014\n\004used\030\013 \001(\004\022\016\n\006gcMode\030\014 \001(\t\022\020"
+  "\n\010metaRaid\030\r \001(\t\022\020\n\010dataRaid\030\016 \001(\t\022\033\n\023wr"
+  "iteThroughEnabled\030\017 \001(\010\022$\n\ndevicelist\030\020 "
+  "\003(\0132\020.grpc_cli.Device\"C\n\020ListArrayReques"
+  "t\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treque"
+  "stor\030\003 \001(\t\"\240\002\n\021ListArrayResponse\022\017\n\007comm"
+  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003 \001(\0132\""
+  ".grpc_cli.ListArrayResponse.Result\022\037\n\004in"
+  "fo\030\004 \001(\0132\021.grpc_cli.PosInfo\032\227\001\n\006Result\022 "
+  "\n\006status\030\001 \001(\0132\020.grpc_cli.Status\022:\n\004data"
+  "\030\002 \001(\0132,.grpc_cli.ListArrayResponse.Resu"
+  "lt.ArrayList\032/\n\tArrayList\022\"\n\tarrayList\030\001"
+  " \003(\0132\017.grpc_cli.Array\"\213\001\n\020ArrayInfoReque"
+  "st\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequ"
+  "estor\030\003 \001(\t\022/\n\005param\030\004 \001(\0132 .grpc_cli.Ar"
+  "rayInfoRequest.Param\032\025\n\005Param\022\014\n\004name\030\001 "
+  "\001(\t\"\321\001\n\021ArrayInfoResponse\022\017\n\007command\030\001 \001"
+  "(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003 \001(\0132\".grpc_c"
+  "li.ArrayInfoResponse.Result\022\037\n\004info\030\004 \001("
+  "\0132\021.grpc_cli.PosInfo\032I\n\006Result\022 \n\006status"
+  "\030\001 \001(\0132\020.grpc_cli.Status\022\035\n\004data\030\002 \001(\0132\017"
+  ".grpc_cli.Array\"B\n\017ListNodeRequest\022\017\n\007co"
+  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 "
+  "\001(\t\"\233\002\n\020ListNodeResponse\022\017\n\007command\030\001 \001("
+  "\t\022\013\n\003rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cl"
+  "i.ListNodeResponse.Result\022\037\n\004info\030\004 \001(\0132"
+  "\021.grpc_cli.PosInfo\032\224\001\n\006Result\022 \n\006status\030"
+  "\001 \001(\0132\020.grpc_cli.Status\0224\n\004data\030\002 \003(\0132&."
+  "grpc_cli.ListNodeResponse.Result.Node\0322\n"
+  "\004Node\022\014\n\004name\030\001 \001(\t\022\n\n\002ip\030\002 \001(\t\022\020\n\010lasts"
+  "een\030\003 \001(\t\"F\n\023ListHaVolumeRequest\022\017\n\007comm"
+  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001("
+  "\t\"\336\002\n\024ListHaVolumeResponse\022\017\n\007command\030\001 "
+  "\001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001(\0132%.grpc_"
+  "cli.ListHaVolumeResponse.Result\022\037\n\004info\030"
+  "\004 \001(\0132\021.grpc_cli.PosInfo\032\317\001\n\006Result\022 \n\006s"
+  "tatus\030\001 \001(\0132\020.grpc_cli.Status\022:\n\004data\030\002 "
+  "\003(\0132,.grpc_cli.ListHaVolumeResponse.Resu"
+  "lt.Volume\032g\n\006Volume\022\n\n\002id\030\001 \001(\005\022\014\n\004name\030"
+  "\002 \001(\t\022\020\n\010nodeName\030\003 \001(\t\022\021\n\tarrayName\030\004 \001"
+  "(\t\022\014\n\004size\030\005 \001(\003\022\020\n\010lastseen\030\006 \001(\t\"K\n\030Li"
+  "stHaReplicationRequest\022\017\n\007command\030\001 \001(\t\022"
+  "\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\226\003\n\031List"
+  "HaReplicationResponse\022\017\n\007command\030\001 \001(\t\022\013"
+  "\n\003rid\030\002 \001(\t\022:\n\006result\030\003 \001(\0132*.grpc_cli.L"
+  "istHaReplicationResponse.Result\022\037\n\004info\030"
+  "\004 \001(\0132\021.grpc_cli.PosInfo\032\375\001\n\006Result\022 \n\006s"
+  "tatus\030\001 \001(\0132\020.grpc_cli.Status\022D\n\004data\030\002 "
+  "\003(\01326.grpc_cli.ListHaReplicationResponse"
+  ".Result.Replication\032\212\001\n\013Replication\022\n\n\002i"
+  "d\030\001 \001(\005\022\026\n\016sourceVolumeId\030\002 \001(\005\022\032\n\022sourc"
+  "eWalVolume_id\030\003 \001(\005\022\033\n\023destinationVolume"
+  "Id\030\004 \001(\005\022\036\n\026destinationWalVolumeId\030\005 \001(\005"
+  "\"\223\003\n\031StartHaReplicationRequest\022\017\n\007comman"
+  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022"
+  "8\n\005param\030\004 \001(\0132).grpc_cli.StartHaReplica"
+  "tionRequest.Param\032\212\002\n\005Param\022\027\n\017primaryNo"
+  "deName\030\001 \001(\t\022\030\n\020primaryArrayName\030\002 \001(\t\022\031"
+  "\n\021primaryVolumeName\030\003 \001(\t\022\034\n\024primaryWalV"
+  "olumeName\030\004 \001(\t\022\031\n\021secondaryNodeName\030\005 \001"
+  "(\t\022\032\n\022secondaryArrayName\030\006 \001(\t\022\033\n\023second"
+  "aryVolumeName\030\007 \001(\t\022\036\n\026secondaryWalVolum"
+  "eName\030\010 \001(\t\022\016\n\006stuats\030\t \001(\t\022\021\n\ttimestamp"
+  "\030\n \001(\t\"\304\001\n\032StartHaReplicationResponse\022\017\n"
+  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022;\n\006result\030\003 "
+  "\001(\0132+.grpc_cli.StartHaReplicationRespons"
+  "e.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInf"
+  "o\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.S"
+  "tatus\"\220\001\n\022SetLogLevelRequest\022\017\n\007command\030"
+  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n"
+  "\005param\030\004 \001(\0132\".grpc_cli.SetLogLevelReque"
+  "st.Param\032\026\n\005Param\022\r\n\005level\030\001 \001(\t\"\266\001\n\023Set"
+  "LogLevelResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
+  "\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.SetLog"
+  "LevelResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grp"
+  "c_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132"
+  "\020.grpc_cli.Status\"\246\001\n\027SetLogPreferenceRe"
+  "quest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tr"
+  "equestor\030\003 \001(\t\0226\n\005param\030\004 \001(\0132\'.grpc_cli"
+  ".SetLogPreferenceRequest.Param\032\"\n\005Param\022"
+  "\031\n\021structuredLogging\030\001 \001(\t\"\300\001\n\030SetLogPre"
+  "ferenceResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
+  "\002 \001(\t\0229\n\006result\030\003 \001(\0132).grpc_cli.SetLogP"
+  "referenceResponse.Result\022\037\n\004info\030\004 \001(\0132\021"
+  ".grpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 "
+  "\001(\0132\020.grpc_cli.Status\"D\n\021LoggerInfoReque"
+  "st\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequ"
+  "estor\030\003 \001(\t\"\345\003\n\022LoggerInfoResponse\022\017\n\007co"
+  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\013"
+  "2#.grpc_cli.LoggerInfoResponse.Result\022\037\n"
+  "\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\332\002\n\006Resul"
+  "t\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022<\n\004d"
+  "ata\030\002 \001(\0132..grpc_cli.LoggerInfoResponse."
+  "Result.LoggerInfo\032\357\001\n\nLoggerInfo\022\024\n\014mino"
+  "rLogPath\030\001 \001(\t\022\024\n\014majorLogPath\030\002 \001(\t\022\027\n\017"
+  "logfileSizeInMb\030\003 \001(\t\022\034\n\024logfileRotation"
+  "Count\030\004 \001(\005\022\034\n\024minAllowableLogLevel\030\005 \001("
+  "\t\022\025\n\rfilterEnabled\030\006 \001(\005\022\026\n\016filterInclud"
+  "ed\030\007 \001(\t\022\026\n\016filterExcluded\030\010 \001(\t\022\031\n\021stru"
+  "cturedLogging\030\t \001(\010\"E\n\022GetLogLevelReques"
+  "t\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treque"
+  "stor\030\003 \001(\t\"\217\002\n\023GetLogLevelResponse\022\017\n\007co"
+  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\013"
+  "2$.grpc_cli.GetLogLevelResponse.Result\022\037"
+  "\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\202\001\n\006Resu"
+  "lt\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022;\n\004"
+  "data\030\002 \001(\0132-.grpc_cli.GetLogLevelRespons"
+  "e.Result.LogLevel\032\031\n\010LogLevel\022\r\n\005level\030\001"
+  " \001(\t\"H\n\025ApplyLogFilterRequest\022\017\n\007command"
+  "\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\274"
+  "\001\n\026ApplyLogFilterResponse\022\017\n\007command\030\001 \001"
+  "(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'.grpc_c"
+  "li.ApplyLogFilterResponse.Result\022\037\n\004info"
+  "\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006s"
+  "tatus\030\001 \001(\0132\020.grpc_cli.Status\"\326\001\n\023Create"
+  "DeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 "
+  "\001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005param\030\004 \001(\0132#."
+  "grpc_cli.CreateDeviceRequest.Param\032Z\n\005Pa"
+  "ram\022\014\n\004name\030\001 \001(\t\022\021\n\tnumBlocks\030\002 \001(\r\022\021\n\t"
+  "blockSize\030\003 \001(\r\022\017\n\007devType\030\004 \001(\t\022\014\n\004numa"
+  "\030\005 \001(\r\"\270\001\n\024CreateDeviceResponse\022\017\n\007comma"
+  "nd\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001(\0132%."
+  "grpc_cli.CreateDeviceResponse.Result\022\037\n\004"
+  "info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022"
+  " \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"D\n\021Sca"
+  "nDeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
+  " \001(\t\022\021\n\trequestor\030\003 \001(\t\"\264\001\n\022ScanDeviceRe"
+  "sponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006"
+  "result\030\003 \001(\0132#.grpc_cli.ScanDeviceRespon"
+  "se.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosIn"
+  "fo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli."
+  "Status\"\213\001\n\006Device\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030"
+  "\002 \001(\t\022\017\n\007address\030\003 \001(\t\022\r\n\005class\030\004 \001(\t\022\023\n"
+  "\013modelNumber\030\005 \001(\t\022\014\n\004numa\030\006 \001(\t\022\014\n\004size"
+  "\030\007 \001(\004\022\024\n\014serialNumber\030\010 \001(\t\"D\n\021ListDevi"
+  "ceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022"
+  "\021\n\trequestor\030\003 \001(\t\"\247\002\n\022ListDeviceRespons"
+  "e\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006resul"
+  "t\030\003 \001(\0132#.grpc_cli.ListDeviceResponse.Re"
+  "sult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\234\001"
+  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
+  "us\022<\n\004data\030\002 \001(\0132..grpc_cli.ListDeviceRe"
+  "sponse.Result.DeviceList\0322\n\nDeviceList\022$"
+  "\n\ndevicelist\030\001 \003(\0132\020.grpc_cli.Device\"\335\004\n"
+  "\010SmartLog\022\033\n\023availableSpareSpace\030\001 \001(\t\022\023"
+  "\n\013temperature\030\002 \001(\t\022\031\n\021deviceReliability"
+  "\030\003 \001(\t\022\020\n\010readOnly\030\004 \001(\t\022\034\n\024volatileMemo"
+  "ryBackup\030\005 \001(\t\022\032\n\022currentTemperature\030\006 \001"
+  "(\t\022\026\n\016availableSpare\030\007 \001(\t\022\037\n\027availableS"
+  "pareThreshold\030\010 \001(\t\022\032\n\022lifePercentageUse"
+  "d\030\t \001(\t\022\025\n\rdataUnitsRead\030\n \001(\t\022\030\n\020dataUn"
+  "itsWritten\030\013 \001(\t\022\030\n\020hostReadCommands\030\014 \001"
+  "(\t\022\031\n\021hostWriteCommands\030\r \001(\t\022\032\n\022control"
+  "lerBusyTime\030\016 \001(\t\022\023\n\013powerCycles\030\017 \001(\t\022\024"
+  "\n\014powerOnHours\030\020 \001(\t\022\027\n\017unsafeShutdowns\030"
+  "\021 \001(\t\022 \n\030unrecoverableMediaErrors\030\022 \001(\t\022"
+  "\037\n\027lifetimeErrorLogEntries\030\023 \001(\t\022\036\n\026warn"
+  "ingTemperatureTime\030\024 \001(\t\022\037\n\027criticalTemp"
+  "eratureTime\030\025 \001(\t\022\031\n\021temperatureSensor\030\026"
+  " \003(\t\"\217\001\n\022GetSmartLogRequest\022\017\n\007command\030\001"
+  " \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005"
+  "param\030\004 \001(\0132\".grpc_cli.GetSmartLogReques"
+  "t.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\330\001\n\023GetSm"
+  "artLogResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
+  " \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.GetSmart"
+  "LogResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_"
+  "cli.PosInfo\032L\n\006Result\022 \n\006status\030\001 \001(\0132\020."
+  "grpc_cli.Status\022 \n\004data\030\002 \001(\0132\022.grpc_cli"
+  ".SmartLog2\221\026\n\006PosCli\022_\n\nSystemInfo\022\033.grp"
+  "c_cli.SystemInfoRequest\032\034.grpc_cli.Syste"
+  "mInfoResponse\"\026\202\323\344\223\002\020\022\016/v1/systeminfo\022_\n"
+  "\nSystemStop\022\033.grpc_cli.SystemStopRequest"
+  "\032\034.grpc_cli.SystemStopResponse\"\026\202\323\344\223\002\020\022\016"
+  "/v1/systemstop\022}\n\021GetSystemProperty\022\".gr"
+  "pc_cli.GetSystemPropertyRequest\032#.grpc_c"
+  "li.GetSystemPropertyResponse\"\037\202\323\344\223\002\031\022\027/v"
+  "1/get_system_property\022\205\001\n\021SetSystemPrope"
+  "rty\022\".grpc_cli.SetSystemPropertyRequest\032"
+  "#.grpc_cli.SetSystemPropertyResponse\"\'\202\323"
+  "\344\223\002!\022\037/v1/set_system_property/{level}\022p\n"
+  "\016StartTelemetry\022\037.grpc_cli.StartTelemetr"
+  "yRequest\032 .grpc_cli.StartTelemetryRespon"
+  "se\"\033\202\323\344\223\002\025\022\023/v1/start_telemetry\022l\n\rStopT"
+  "elemetry\022\036.grpc_cli.StopTelemetryRequest"
+  "\032\037.grpc_cli.StopTelemetryResponse\"\032\202\323\344\223\002"
+  "\024\022\022/v1/stop_telemetry\022P\n\rResetEventWrr\022\036"
+  ".grpc_cli.ResetEventWrrRequest\032\037.grpc_cl"
+  "i.ResetEventWrrResponse\022A\n\010ResetMbr\022\031.gr"
+  "pc_cli.ResetMbrRequest\032\032.grpc_cli.ResetM"
+  "brResponse\022S\n\016StopRebuilding\022\037.grpc_cli."
+  "StopRebuildingRequest\032 .grpc_cli.StopReb"
+  "uildingResponse\022S\n\016UpdateEventWrr\022\037.grpc"
+  "_cli.UpdateEventWrrRequest\032 .grpc_cli.Up"
+  "dateEventWrrResponse\022W\n\010AddSpare\022\031.grpc_"
+  "cli.AddSpareRequest\032\032.grpc_cli.AddSpareR"
+  "esponse\"\024\202\323\344\223\002\016\"\014/v1/addspare\022c\n\013RemoveS"
+  "pare\022\034.grpc_cli.RemoveSpareRequest\032\035.grp"
+  "c_cli.RemoveSpareResponse\"\027\202\323\344\223\002\021\"\017/v1/r"
+  "emovespare\022c\n\013CreateArray\022\034.grpc_cli.Cre"
+  "ateArrayRequest\032\035.grpc_cli.CreateArrayRe"
+  "sponse\"\027\202\323\344\223\002\021\"\017/v1/createarray\022s\n\017Autoc"
+  "reateArray\022 .grpc_cli.AutocreateArrayReq"
+  "uest\032!.grpc_cli.AutocreateArrayResponse\""
+  "\033\202\323\344\223\002\025\"\023/v1/autocreatearray\022d\n\013DeleteAr"
+  "ray\022\034.grpc_cli.DeleteArrayRequest\032\035.grpc"
+  "_cli.DeleteArrayResponse\"\030\202\323\344\223\002\022\"\020/v1/de"
+  "letearray/\022_\n\nMountArray\022\033.grpc_cli.Moun"
+  "tArrayRequest\032\034.grpc_cli.MountArrayRespo"
+  "nse\"\026\202\323\344\223\002\020\"\016/v1/mountarray\022g\n\014UnmountAr"
+  "ray\022\035.grpc_cli.UnmountArrayRequest\032\036.grp"
+  "c_cli.UnmountArrayResponse\"\030\202\323\344\223\002\022\"\020/v1/"
+  "unmountarray\022[\n\tListArray\022\032.grpc_cli.Lis"
+  "tArrayRequest\032\033.grpc_cli.ListArrayRespon"
+  "se\"\025\202\323\344\223\002\017\"\r/v1/listarray\022[\n\tArrayInfo\022\032"
+  ".grpc_cli.ArrayInfoRequest\032\033.grpc_cli.Ar"
+  "rayInfoResponse\"\025\202\323\344\223\002\017\"\r/v1/arrayinfo\022w"
+  "\n\020SetLogPreference\022!.grpc_cli.SetLogPref"
+  "erenceRequest\032\".grpc_cli.SetLogPreferenc"
+  "eResponse\"\034\202\323\344\223\002\026\"\024/v1/setlogpreference\022"
+  "c\n\013SetLogLevel\022\034.grpc_cli.SetLogLevelReq"
+  "uest\032\035.grpc_cli.SetLogLevelResponse\"\027\202\323\344"
+  "\223\002\021\"\017/v1/setloglevel\022_\n\nLoggerInfo\022\033.grp"
+  "c_cli.LoggerInfoRequest\032\034.grpc_cli.Logge"
+  "rInfoResponse\"\026\202\323\344\223\002\020\"\016/v1/loggerinfo\022c\n"
+  "\013GetLogLevel\022\034.grpc_cli.GetLogLevelReque"
+  "st\032\035.grpc_cli.GetLogLevelResponse\"\027\202\323\344\223\002"
+  "\021\"\017/v1/getloglevel\022l\n\016ApplyLogFilter\022\037.g"
+  "rpc_cli.ApplyLogFilterRequest\032 .grpc_cli"
+  ".ApplyLogFilterResponse\"\027\202\323\344\223\002\021\"\017/v1/app"
+  "lyfilter\022g\n\014CreateDevice\022\035.grpc_cli.Crea"
+  "teDeviceRequest\032\036.grpc_cli.CreateDeviceR"
+  "esponse\"\030\202\323\344\223\002\022\"\020/v1/createdevice\022_\n\nSca"
+  "nDevice\022\033.grpc_cli.ScanDeviceRequest\032\034.g"
+  "rpc_cli.ScanDeviceResponse\"\026\202\323\344\223\002\020\"\016/v1/"
+  "scandevice\022_\n\nListDevice\022\033.grpc_cli.List"
+  "DeviceRequest\032\034.grpc_cli.ListDeviceRespo"
+  "nse\"\026\202\323\344\223\002\020\"\016/v1/listdevice\022`\n\013GetSmartL"
+  "og\022\034.grpc_cli.GetSmartLogRequest\032\035.grpc_"
+  "cli.GetSmartLogResponse\"\024\202\323\344\223\002\016\"\014/v1/sma"
+  "rtlogB\tZ\007cli/apib\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_cli_2eproto_deps[1] = {
   &::descriptor_table_annotations_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_cli_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_cli_2eproto = {
-  false, false, 16106, descriptor_table_protodef_cli_2eproto, "cli.proto", 
+  false, false, 16224, descriptor_table_protodef_cli_2eproto, "cli.proto", 
   &descriptor_table_cli_2eproto_once, descriptor_table_cli_2eproto_deps, 1, 129,
   schemas, file_default_instances, TableStruct_cli_2eproto::offsets,
   file_level_metadata_cli_2eproto, file_level_enum_descriptors_cli_2eproto, file_level_service_descriptors_cli_2eproto,
@@ -4524,6 +4535,26 @@ SystemInfoResponse_Result_Data::SystemInfoResponse_Result_Data(const SystemInfoR
     systemuuid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_systemuuid(), 
       GetArena());
   }
+  baseboardmanufacturer_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_baseboardmanufacturer().empty()) {
+    baseboardmanufacturer_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_baseboardmanufacturer(), 
+      GetArena());
+  }
+  baseboardproductname_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_baseboardproductname().empty()) {
+    baseboardproductname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_baseboardproductname(), 
+      GetArena());
+  }
+  baseboardserialnumber_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_baseboardserialnumber().empty()) {
+    baseboardserialnumber_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_baseboardserialnumber(), 
+      GetArena());
+  }
+  baseboardversion_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_baseboardversion().empty()) {
+    baseboardversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_baseboardversion(), 
+      GetArena());
+  }
   // @@protoc_insertion_point(copy_constructor:grpc_cli.SystemInfoResponse.Result.Data)
 }
 
@@ -4536,6 +4567,10 @@ systemmanufacturer_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmpt
 systemproductname_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 systemserialnumber_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 systemuuid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+baseboardmanufacturer_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+baseboardproductname_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+baseboardserialnumber_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+baseboardversion_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 }
 
 SystemInfoResponse_Result_Data::~SystemInfoResponse_Result_Data() {
@@ -4554,6 +4589,10 @@ void SystemInfoResponse_Result_Data::SharedDtor() {
   systemproductname_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   systemserialnumber_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   systemuuid_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  baseboardmanufacturer_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  baseboardproductname_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  baseboardserialnumber_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  baseboardversion_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 }
 
 void SystemInfoResponse_Result_Data::ArenaDtor(void* object) {
@@ -4580,6 +4619,10 @@ void SystemInfoResponse_Result_Data::Clear() {
   systemproductname_.ClearToEmpty();
   systemserialnumber_.ClearToEmpty();
   systemuuid_.ClearToEmpty();
+  baseboardmanufacturer_.ClearToEmpty();
+  baseboardproductname_.ClearToEmpty();
+  baseboardserialnumber_.ClearToEmpty();
+  baseboardversion_.ClearToEmpty();
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -4659,6 +4702,42 @@ const char* SystemInfoResponse_Result_Data::_InternalParse(const char* ptr, ::PR
           auto str = _internal_mutable_systemuuid();
           ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.systemUuid"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string baseboardManufacturer = 9;
+      case 9:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 74)) {
+          auto str = _internal_mutable_baseboardmanufacturer();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.baseboardManufacturer"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string baseboardProductName = 10;
+      case 10:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 82)) {
+          auto str = _internal_mutable_baseboardproductname();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.baseboardProductName"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string baseboardSerialNumber = 11;
+      case 11:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 90)) {
+          auto str = _internal_mutable_baseboardserialnumber();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.baseboardSerialNumber"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string baseboardVersion = 12;
+      case 12:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 98)) {
+          auto str = _internal_mutable_baseboardversion();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.baseboardVersion"));
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -4770,6 +4849,46 @@ failure:
         8, this->_internal_systemuuid(), target);
   }
 
+  // string baseboardManufacturer = 9;
+  if (this->baseboardmanufacturer().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_baseboardmanufacturer().data(), static_cast<int>(this->_internal_baseboardmanufacturer().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.baseboardManufacturer");
+    target = stream->WriteStringMaybeAliased(
+        9, this->_internal_baseboardmanufacturer(), target);
+  }
+
+  // string baseboardProductName = 10;
+  if (this->baseboardproductname().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_baseboardproductname().data(), static_cast<int>(this->_internal_baseboardproductname().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.baseboardProductName");
+    target = stream->WriteStringMaybeAliased(
+        10, this->_internal_baseboardproductname(), target);
+  }
+
+  // string baseboardSerialNumber = 11;
+  if (this->baseboardserialnumber().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_baseboardserialnumber().data(), static_cast<int>(this->_internal_baseboardserialnumber().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.baseboardSerialNumber");
+    target = stream->WriteStringMaybeAliased(
+        11, this->_internal_baseboardserialnumber(), target);
+  }
+
+  // string baseboardVersion = 12;
+  if (this->baseboardversion().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_baseboardversion().data(), static_cast<int>(this->_internal_baseboardversion().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.baseboardVersion");
+    target = stream->WriteStringMaybeAliased(
+        12, this->_internal_baseboardversion(), target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -4842,6 +4961,34 @@ size_t SystemInfoResponse_Result_Data::ByteSizeLong() const {
         this->_internal_systemuuid());
   }
 
+  // string baseboardManufacturer = 9;
+  if (this->baseboardmanufacturer().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_baseboardmanufacturer());
+  }
+
+  // string baseboardProductName = 10;
+  if (this->baseboardproductname().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_baseboardproductname());
+  }
+
+  // string baseboardSerialNumber = 11;
+  if (this->baseboardserialnumber().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_baseboardserialnumber());
+  }
+
+  // string baseboardVersion = 12;
+  if (this->baseboardversion().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_baseboardversion());
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
         _internal_metadata_, total_size, &_cached_size_);
@@ -4897,6 +5044,18 @@ void SystemInfoResponse_Result_Data::MergeFrom(const SystemInfoResponse_Result_D
   if (from.systemuuid().size() > 0) {
     _internal_set_systemuuid(from._internal_systemuuid());
   }
+  if (from.baseboardmanufacturer().size() > 0) {
+    _internal_set_baseboardmanufacturer(from._internal_baseboardmanufacturer());
+  }
+  if (from.baseboardproductname().size() > 0) {
+    _internal_set_baseboardproductname(from._internal_baseboardproductname());
+  }
+  if (from.baseboardserialnumber().size() > 0) {
+    _internal_set_baseboardserialnumber(from._internal_baseboardserialnumber());
+  }
+  if (from.baseboardversion().size() > 0) {
+    _internal_set_baseboardversion(from._internal_baseboardversion());
+  }
 }
 
 void SystemInfoResponse_Result_Data::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
@@ -4928,6 +5087,10 @@ void SystemInfoResponse_Result_Data::InternalSwap(SystemInfoResponse_Result_Data
   systemproductname_.Swap(&other->systemproductname_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   systemserialnumber_.Swap(&other->systemserialnumber_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   systemuuid_.Swap(&other->systemuuid_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  baseboardmanufacturer_.Swap(&other->baseboardmanufacturer_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  baseboardproductname_.Swap(&other->baseboardproductname_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  baseboardserialnumber_.Swap(&other->baseboardserialnumber_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  baseboardversion_.Swap(&other->baseboardversion_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata SystemInfoResponse_Result_Data::GetMetadata() const {

--- a/proto/generated/cpp/cli.pb.cc
+++ b/proto/generated/cpp/cli.pb.cc
@@ -62,7 +62,13 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SystemInfoRequestDefaultTypeInt
 constexpr SystemInfoResponse_Result_Data::SystemInfoResponse_Result_Data(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : version_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
-  , biosversion_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string){}
+  , biosversion_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , biosvendor_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , biosreleasedate_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , systemmanufacturer_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , systemproductname_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , systemserialnumber_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , systemuuid_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string){}
 struct SystemInfoResponse_Result_DataDefaultTypeInternal {
   constexpr SystemInfoResponse_Result_DataDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
@@ -1886,6 +1892,12 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_cli_2eproto::offsets[] PROTOBU
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, version_),
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, biosversion_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, biosvendor_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, biosreleasedate_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, systemmanufacturer_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, systemproductname_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, systemserialnumber_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, systemuuid_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -2916,131 +2928,131 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 15, -1, sizeof(::grpc_cli::PosInfo)},
   { 21, -1, sizeof(::grpc_cli::SystemInfoRequest)},
   { 29, -1, sizeof(::grpc_cli::SystemInfoResponse_Result_Data)},
-  { 36, -1, sizeof(::grpc_cli::SystemInfoResponse_Result)},
-  { 43, -1, sizeof(::grpc_cli::SystemInfoResponse)},
-  { 52, -1, sizeof(::grpc_cli::SystemStopRequest)},
-  { 60, -1, sizeof(::grpc_cli::SystemStopResponse_Result)},
-  { 66, -1, sizeof(::grpc_cli::SystemStopResponse)},
-  { 75, -1, sizeof(::grpc_cli::GetSystemPropertyRequest)},
-  { 83, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result_Data)},
-  { 89, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result)},
-  { 96, -1, sizeof(::grpc_cli::GetSystemPropertyResponse)},
-  { 105, -1, sizeof(::grpc_cli::SetSystemPropertyRequest_Param)},
-  { 111, -1, sizeof(::grpc_cli::SetSystemPropertyRequest)},
-  { 120, -1, sizeof(::grpc_cli::SetSystemPropertyResponse_Result)},
-  { 126, -1, sizeof(::grpc_cli::SetSystemPropertyResponse)},
-  { 135, -1, sizeof(::grpc_cli::StartTelemetryRequest)},
-  { 143, -1, sizeof(::grpc_cli::StartTelemetryResponse_Result)},
-  { 149, -1, sizeof(::grpc_cli::StartTelemetryResponse)},
-  { 158, -1, sizeof(::grpc_cli::StopTelemetryRequest)},
-  { 166, -1, sizeof(::grpc_cli::StopTelemetryResponse_Result)},
-  { 172, -1, sizeof(::grpc_cli::StopTelemetryResponse)},
-  { 181, -1, sizeof(::grpc_cli::ResetEventWrrRequest)},
-  { 189, -1, sizeof(::grpc_cli::ResetEventWrrResponse_Result)},
-  { 195, -1, sizeof(::grpc_cli::ResetEventWrrResponse)},
-  { 204, -1, sizeof(::grpc_cli::ResetMbrRequest)},
-  { 212, -1, sizeof(::grpc_cli::ResetMbrResponse_Result)},
-  { 218, -1, sizeof(::grpc_cli::ResetMbrResponse)},
-  { 227, -1, sizeof(::grpc_cli::StopRebuildingRequest_Param)},
-  { 233, -1, sizeof(::grpc_cli::StopRebuildingRequest)},
-  { 242, -1, sizeof(::grpc_cli::StopRebuildingResponse_Result)},
-  { 248, -1, sizeof(::grpc_cli::StopRebuildingResponse)},
-  { 257, -1, sizeof(::grpc_cli::UpdateEventWrrRequest_Param)},
-  { 264, -1, sizeof(::grpc_cli::UpdateEventWrrRequest)},
-  { 273, -1, sizeof(::grpc_cli::UpdateEventWrrResponse_Result)},
-  { 279, -1, sizeof(::grpc_cli::UpdateEventWrrResponse)},
-  { 288, -1, sizeof(::grpc_cli::AddSpareRequest_SpareDeviceName)},
-  { 294, -1, sizeof(::grpc_cli::AddSpareRequest_Param)},
-  { 301, -1, sizeof(::grpc_cli::AddSpareRequest)},
-  { 310, -1, sizeof(::grpc_cli::AddSpareResponse_Result)},
-  { 316, -1, sizeof(::grpc_cli::AddSpareResponse)},
-  { 325, -1, sizeof(::grpc_cli::DeviceNameList)},
-  { 331, -1, sizeof(::grpc_cli::RemoveSpareRequest_SpareDeviceName)},
-  { 337, -1, sizeof(::grpc_cli::RemoveSpareRequest_Param)},
-  { 344, -1, sizeof(::grpc_cli::RemoveSpareRequest)},
-  { 353, -1, sizeof(::grpc_cli::RemoveSpareResponse_Result)},
-  { 359, -1, sizeof(::grpc_cli::RemoveSpareResponse)},
-  { 368, -1, sizeof(::grpc_cli::CreateArrayRequest_Param)},
-  { 378, -1, sizeof(::grpc_cli::CreateArrayRequest)},
-  { 387, -1, sizeof(::grpc_cli::CreateArrayResponse_Result)},
-  { 393, -1, sizeof(::grpc_cli::CreateArrayResponse)},
-  { 402, -1, sizeof(::grpc_cli::AutocreateArrayRequest_Param)},
-  { 412, -1, sizeof(::grpc_cli::AutocreateArrayRequest)},
-  { 421, -1, sizeof(::grpc_cli::AutocreateArrayResponse_Result)},
-  { 427, -1, sizeof(::grpc_cli::AutocreateArrayResponse)},
-  { 436, -1, sizeof(::grpc_cli::DeleteArrayRequest_Param)},
-  { 442, -1, sizeof(::grpc_cli::DeleteArrayRequest)},
-  { 451, -1, sizeof(::grpc_cli::DeleteArrayResponse_Result)},
-  { 457, -1, sizeof(::grpc_cli::DeleteArrayResponse)},
-  { 466, 473, sizeof(::grpc_cli::MountArrayRequest_Param)},
-  { 475, -1, sizeof(::grpc_cli::MountArrayRequest)},
-  { 484, -1, sizeof(::grpc_cli::MountArrayResponse_Result)},
-  { 490, -1, sizeof(::grpc_cli::MountArrayResponse)},
-  { 499, -1, sizeof(::grpc_cli::UnmountArrayRequest_Param)},
-  { 505, -1, sizeof(::grpc_cli::UnmountArrayRequest)},
-  { 514, -1, sizeof(::grpc_cli::UnmountArrayResponse_Result)},
-  { 520, -1, sizeof(::grpc_cli::UnmountArrayResponse)},
-  { 529, -1, sizeof(::grpc_cli::Array)},
-  { 550, -1, sizeof(::grpc_cli::ListArrayRequest)},
-  { 558, -1, sizeof(::grpc_cli::ListArrayResponse_Result_ArrayList)},
-  { 564, -1, sizeof(::grpc_cli::ListArrayResponse_Result)},
-  { 571, -1, sizeof(::grpc_cli::ListArrayResponse)},
-  { 580, -1, sizeof(::grpc_cli::ArrayInfoRequest_Param)},
-  { 586, -1, sizeof(::grpc_cli::ArrayInfoRequest)},
-  { 595, -1, sizeof(::grpc_cli::ArrayInfoResponse_Result)},
-  { 602, -1, sizeof(::grpc_cli::ArrayInfoResponse)},
-  { 611, -1, sizeof(::grpc_cli::ListNodeRequest)},
-  { 619, -1, sizeof(::grpc_cli::ListNodeResponse_Result_Node)},
-  { 627, -1, sizeof(::grpc_cli::ListNodeResponse_Result)},
-  { 634, -1, sizeof(::grpc_cli::ListNodeResponse)},
-  { 643, -1, sizeof(::grpc_cli::ListHaVolumeRequest)},
-  { 651, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result_Volume)},
-  { 662, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result)},
-  { 669, -1, sizeof(::grpc_cli::ListHaVolumeResponse)},
-  { 678, -1, sizeof(::grpc_cli::ListHaReplicationRequest)},
-  { 686, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result_Replication)},
-  { 696, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result)},
-  { 703, -1, sizeof(::grpc_cli::ListHaReplicationResponse)},
-  { 712, -1, sizeof(::grpc_cli::StartHaReplicationRequest_Param)},
-  { 727, -1, sizeof(::grpc_cli::StartHaReplicationRequest)},
-  { 736, -1, sizeof(::grpc_cli::StartHaReplicationResponse_Result)},
-  { 742, -1, sizeof(::grpc_cli::StartHaReplicationResponse)},
-  { 751, -1, sizeof(::grpc_cli::SetLogLevelRequest_Param)},
-  { 757, -1, sizeof(::grpc_cli::SetLogLevelRequest)},
-  { 766, -1, sizeof(::grpc_cli::SetLogLevelResponse_Result)},
-  { 772, -1, sizeof(::grpc_cli::SetLogLevelResponse)},
-  { 781, -1, sizeof(::grpc_cli::SetLogPreferenceRequest_Param)},
-  { 787, -1, sizeof(::grpc_cli::SetLogPreferenceRequest)},
-  { 796, -1, sizeof(::grpc_cli::SetLogPreferenceResponse_Result)},
-  { 802, -1, sizeof(::grpc_cli::SetLogPreferenceResponse)},
-  { 811, -1, sizeof(::grpc_cli::LoggerInfoRequest)},
-  { 819, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result_LoggerInfo)},
-  { 833, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result)},
-  { 840, -1, sizeof(::grpc_cli::LoggerInfoResponse)},
-  { 849, -1, sizeof(::grpc_cli::GetLogLevelRequest)},
-  { 857, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result_LogLevel)},
-  { 863, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result)},
-  { 870, -1, sizeof(::grpc_cli::GetLogLevelResponse)},
-  { 879, -1, sizeof(::grpc_cli::ApplyLogFilterRequest)},
-  { 887, -1, sizeof(::grpc_cli::ApplyLogFilterResponse_Result)},
-  { 893, -1, sizeof(::grpc_cli::ApplyLogFilterResponse)},
-  { 902, -1, sizeof(::grpc_cli::CreateDeviceRequest_Param)},
-  { 912, -1, sizeof(::grpc_cli::CreateDeviceRequest)},
-  { 921, -1, sizeof(::grpc_cli::CreateDeviceResponse_Result)},
-  { 927, -1, sizeof(::grpc_cli::CreateDeviceResponse)},
-  { 936, -1, sizeof(::grpc_cli::ScanDeviceRequest)},
-  { 944, -1, sizeof(::grpc_cli::ScanDeviceResponse_Result)},
-  { 950, -1, sizeof(::grpc_cli::ScanDeviceResponse)},
-  { 959, -1, sizeof(::grpc_cli::Device)},
-  { 972, -1, sizeof(::grpc_cli::ListDeviceRequest)},
-  { 980, -1, sizeof(::grpc_cli::ListDeviceResponse_Result_DeviceList)},
-  { 986, -1, sizeof(::grpc_cli::ListDeviceResponse_Result)},
-  { 993, -1, sizeof(::grpc_cli::ListDeviceResponse)},
-  { 1002, -1, sizeof(::grpc_cli::SmartLog)},
-  { 1029, -1, sizeof(::grpc_cli::GetSmartLogRequest_Param)},
-  { 1035, -1, sizeof(::grpc_cli::GetSmartLogRequest)},
-  { 1044, -1, sizeof(::grpc_cli::GetSmartLogResponse_Result)},
-  { 1051, -1, sizeof(::grpc_cli::GetSmartLogResponse)},
+  { 42, -1, sizeof(::grpc_cli::SystemInfoResponse_Result)},
+  { 49, -1, sizeof(::grpc_cli::SystemInfoResponse)},
+  { 58, -1, sizeof(::grpc_cli::SystemStopRequest)},
+  { 66, -1, sizeof(::grpc_cli::SystemStopResponse_Result)},
+  { 72, -1, sizeof(::grpc_cli::SystemStopResponse)},
+  { 81, -1, sizeof(::grpc_cli::GetSystemPropertyRequest)},
+  { 89, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result_Data)},
+  { 95, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result)},
+  { 102, -1, sizeof(::grpc_cli::GetSystemPropertyResponse)},
+  { 111, -1, sizeof(::grpc_cli::SetSystemPropertyRequest_Param)},
+  { 117, -1, sizeof(::grpc_cli::SetSystemPropertyRequest)},
+  { 126, -1, sizeof(::grpc_cli::SetSystemPropertyResponse_Result)},
+  { 132, -1, sizeof(::grpc_cli::SetSystemPropertyResponse)},
+  { 141, -1, sizeof(::grpc_cli::StartTelemetryRequest)},
+  { 149, -1, sizeof(::grpc_cli::StartTelemetryResponse_Result)},
+  { 155, -1, sizeof(::grpc_cli::StartTelemetryResponse)},
+  { 164, -1, sizeof(::grpc_cli::StopTelemetryRequest)},
+  { 172, -1, sizeof(::grpc_cli::StopTelemetryResponse_Result)},
+  { 178, -1, sizeof(::grpc_cli::StopTelemetryResponse)},
+  { 187, -1, sizeof(::grpc_cli::ResetEventWrrRequest)},
+  { 195, -1, sizeof(::grpc_cli::ResetEventWrrResponse_Result)},
+  { 201, -1, sizeof(::grpc_cli::ResetEventWrrResponse)},
+  { 210, -1, sizeof(::grpc_cli::ResetMbrRequest)},
+  { 218, -1, sizeof(::grpc_cli::ResetMbrResponse_Result)},
+  { 224, -1, sizeof(::grpc_cli::ResetMbrResponse)},
+  { 233, -1, sizeof(::grpc_cli::StopRebuildingRequest_Param)},
+  { 239, -1, sizeof(::grpc_cli::StopRebuildingRequest)},
+  { 248, -1, sizeof(::grpc_cli::StopRebuildingResponse_Result)},
+  { 254, -1, sizeof(::grpc_cli::StopRebuildingResponse)},
+  { 263, -1, sizeof(::grpc_cli::UpdateEventWrrRequest_Param)},
+  { 270, -1, sizeof(::grpc_cli::UpdateEventWrrRequest)},
+  { 279, -1, sizeof(::grpc_cli::UpdateEventWrrResponse_Result)},
+  { 285, -1, sizeof(::grpc_cli::UpdateEventWrrResponse)},
+  { 294, -1, sizeof(::grpc_cli::AddSpareRequest_SpareDeviceName)},
+  { 300, -1, sizeof(::grpc_cli::AddSpareRequest_Param)},
+  { 307, -1, sizeof(::grpc_cli::AddSpareRequest)},
+  { 316, -1, sizeof(::grpc_cli::AddSpareResponse_Result)},
+  { 322, -1, sizeof(::grpc_cli::AddSpareResponse)},
+  { 331, -1, sizeof(::grpc_cli::DeviceNameList)},
+  { 337, -1, sizeof(::grpc_cli::RemoveSpareRequest_SpareDeviceName)},
+  { 343, -1, sizeof(::grpc_cli::RemoveSpareRequest_Param)},
+  { 350, -1, sizeof(::grpc_cli::RemoveSpareRequest)},
+  { 359, -1, sizeof(::grpc_cli::RemoveSpareResponse_Result)},
+  { 365, -1, sizeof(::grpc_cli::RemoveSpareResponse)},
+  { 374, -1, sizeof(::grpc_cli::CreateArrayRequest_Param)},
+  { 384, -1, sizeof(::grpc_cli::CreateArrayRequest)},
+  { 393, -1, sizeof(::grpc_cli::CreateArrayResponse_Result)},
+  { 399, -1, sizeof(::grpc_cli::CreateArrayResponse)},
+  { 408, -1, sizeof(::grpc_cli::AutocreateArrayRequest_Param)},
+  { 418, -1, sizeof(::grpc_cli::AutocreateArrayRequest)},
+  { 427, -1, sizeof(::grpc_cli::AutocreateArrayResponse_Result)},
+  { 433, -1, sizeof(::grpc_cli::AutocreateArrayResponse)},
+  { 442, -1, sizeof(::grpc_cli::DeleteArrayRequest_Param)},
+  { 448, -1, sizeof(::grpc_cli::DeleteArrayRequest)},
+  { 457, -1, sizeof(::grpc_cli::DeleteArrayResponse_Result)},
+  { 463, -1, sizeof(::grpc_cli::DeleteArrayResponse)},
+  { 472, 479, sizeof(::grpc_cli::MountArrayRequest_Param)},
+  { 481, -1, sizeof(::grpc_cli::MountArrayRequest)},
+  { 490, -1, sizeof(::grpc_cli::MountArrayResponse_Result)},
+  { 496, -1, sizeof(::grpc_cli::MountArrayResponse)},
+  { 505, -1, sizeof(::grpc_cli::UnmountArrayRequest_Param)},
+  { 511, -1, sizeof(::grpc_cli::UnmountArrayRequest)},
+  { 520, -1, sizeof(::grpc_cli::UnmountArrayResponse_Result)},
+  { 526, -1, sizeof(::grpc_cli::UnmountArrayResponse)},
+  { 535, -1, sizeof(::grpc_cli::Array)},
+  { 556, -1, sizeof(::grpc_cli::ListArrayRequest)},
+  { 564, -1, sizeof(::grpc_cli::ListArrayResponse_Result_ArrayList)},
+  { 570, -1, sizeof(::grpc_cli::ListArrayResponse_Result)},
+  { 577, -1, sizeof(::grpc_cli::ListArrayResponse)},
+  { 586, -1, sizeof(::grpc_cli::ArrayInfoRequest_Param)},
+  { 592, -1, sizeof(::grpc_cli::ArrayInfoRequest)},
+  { 601, -1, sizeof(::grpc_cli::ArrayInfoResponse_Result)},
+  { 608, -1, sizeof(::grpc_cli::ArrayInfoResponse)},
+  { 617, -1, sizeof(::grpc_cli::ListNodeRequest)},
+  { 625, -1, sizeof(::grpc_cli::ListNodeResponse_Result_Node)},
+  { 633, -1, sizeof(::grpc_cli::ListNodeResponse_Result)},
+  { 640, -1, sizeof(::grpc_cli::ListNodeResponse)},
+  { 649, -1, sizeof(::grpc_cli::ListHaVolumeRequest)},
+  { 657, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result_Volume)},
+  { 668, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result)},
+  { 675, -1, sizeof(::grpc_cli::ListHaVolumeResponse)},
+  { 684, -1, sizeof(::grpc_cli::ListHaReplicationRequest)},
+  { 692, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result_Replication)},
+  { 702, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result)},
+  { 709, -1, sizeof(::grpc_cli::ListHaReplicationResponse)},
+  { 718, -1, sizeof(::grpc_cli::StartHaReplicationRequest_Param)},
+  { 733, -1, sizeof(::grpc_cli::StartHaReplicationRequest)},
+  { 742, -1, sizeof(::grpc_cli::StartHaReplicationResponse_Result)},
+  { 748, -1, sizeof(::grpc_cli::StartHaReplicationResponse)},
+  { 757, -1, sizeof(::grpc_cli::SetLogLevelRequest_Param)},
+  { 763, -1, sizeof(::grpc_cli::SetLogLevelRequest)},
+  { 772, -1, sizeof(::grpc_cli::SetLogLevelResponse_Result)},
+  { 778, -1, sizeof(::grpc_cli::SetLogLevelResponse)},
+  { 787, -1, sizeof(::grpc_cli::SetLogPreferenceRequest_Param)},
+  { 793, -1, sizeof(::grpc_cli::SetLogPreferenceRequest)},
+  { 802, -1, sizeof(::grpc_cli::SetLogPreferenceResponse_Result)},
+  { 808, -1, sizeof(::grpc_cli::SetLogPreferenceResponse)},
+  { 817, -1, sizeof(::grpc_cli::LoggerInfoRequest)},
+  { 825, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result_LoggerInfo)},
+  { 839, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result)},
+  { 846, -1, sizeof(::grpc_cli::LoggerInfoResponse)},
+  { 855, -1, sizeof(::grpc_cli::GetLogLevelRequest)},
+  { 863, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result_LogLevel)},
+  { 869, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result)},
+  { 876, -1, sizeof(::grpc_cli::GetLogLevelResponse)},
+  { 885, -1, sizeof(::grpc_cli::ApplyLogFilterRequest)},
+  { 893, -1, sizeof(::grpc_cli::ApplyLogFilterResponse_Result)},
+  { 899, -1, sizeof(::grpc_cli::ApplyLogFilterResponse)},
+  { 908, -1, sizeof(::grpc_cli::CreateDeviceRequest_Param)},
+  { 918, -1, sizeof(::grpc_cli::CreateDeviceRequest)},
+  { 927, -1, sizeof(::grpc_cli::CreateDeviceResponse_Result)},
+  { 933, -1, sizeof(::grpc_cli::CreateDeviceResponse)},
+  { 942, -1, sizeof(::grpc_cli::ScanDeviceRequest)},
+  { 950, -1, sizeof(::grpc_cli::ScanDeviceResponse_Result)},
+  { 956, -1, sizeof(::grpc_cli::ScanDeviceResponse)},
+  { 965, -1, sizeof(::grpc_cli::Device)},
+  { 978, -1, sizeof(::grpc_cli::ListDeviceRequest)},
+  { 986, -1, sizeof(::grpc_cli::ListDeviceResponse_Result_DeviceList)},
+  { 992, -1, sizeof(::grpc_cli::ListDeviceResponse_Result)},
+  { 999, -1, sizeof(::grpc_cli::ListDeviceResponse)},
+  { 1008, -1, sizeof(::grpc_cli::SmartLog)},
+  { 1035, -1, sizeof(::grpc_cli::GetSmartLogRequest_Param)},
+  { 1041, -1, sizeof(::grpc_cli::GetSmartLogRequest)},
+  { 1050, -1, sizeof(::grpc_cli::GetSmartLogResponse_Result)},
+  { 1057, -1, sizeof(::grpc_cli::GetSmartLogResponse)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -3184,404 +3196,408 @@ const char descriptor_table_protodef_cli_2eproto[] PROTOBUF_SECTION_VARIABLE(pro
   "tionB\010\n\006_causeB\013\n\t_solution\"\032\n\007PosInfo\022\017"
   "\n\007version\030\001 \001(\t\"D\n\021SystemInfoRequest\022\017\n\007"
   "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030"
-  "\003 \001(\t\"\233\002\n\022SystemInfoResponse\022\017\n\007command\030"
+  "\003 \001(\t\"\260\003\n\022SystemInfoResponse\022\017\n\007command\030"
   "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grp"
   "c_cli.SystemInfoResponse.Result\022\037\n\004info\030"
-  "\004 \001(\0132\021.grpc_cli.PosInfo\032\220\001\n\006Result\022 \n\006s"
+  "\004 \001(\0132\021.grpc_cli.PosInfo\032\245\002\n\006Result\022 \n\006s"
   "tatus\030\001 \001(\0132\020.grpc_cli.Status\0226\n\004data\030\002 "
   "\001(\0132(.grpc_cli.SystemInfoResponse.Result"
-  ".Data\032,\n\004Data\022\017\n\007version\030\001 \001(\t\022\023\n\013biosVe"
-  "rsion\030\002 \001(\t\"D\n\021SystemStopRequest\022\017\n\007comm"
-  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001("
-  "\t\"\264\001\n\022SystemStopResponse\022\017\n\007command\030\001 \001("
-  "\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cl"
-  "i.SystemStopResponse.Result\022\037\n\004info\030\004 \001("
-  "\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006status"
-  "\030\001 \001(\0132\020.grpc_cli.Status\"K\n\030GetSystemPro"
+  ".Data\032\300\001\n\004Data\022\017\n\007version\030\001 \001(\t\022\023\n\013biosV"
+  "ersion\030\002 \001(\t\022\022\n\nbiosVendor\030\003 \001(\t\022\027\n\017bios"
+  "ReleaseDate\030\004 \001(\t\022\032\n\022systemManufacturer\030"
+  "\005 \001(\t\022\031\n\021systemProductName\030\006 \001(\t\022\032\n\022syst"
+  "emSerialNumber\030\007 \001(\t\022\022\n\nsystemUuid\030\010 \001(\t"
+  "\"D\n\021SystemStopRequest\022\017\n\007command\030\001 \001(\t\022\013"
+  "\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\264\001\n\022Syste"
+  "mStopResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 "
+  "\001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.SystemSto"
+  "pResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cl"
+  "i.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.gr"
+  "pc_cli.Status\"K\n\030GetSystemPropertyReques"
+  "t\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treque"
+  "stor\030\003 \001(\t\"\242\002\n\031GetSystemPropertyResponse"
+  "\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022:\n\006result"
+  "\030\003 \001(\0132*.grpc_cli.GetSystemPropertyRespo"
+  "nse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosI"
+  "nfo\032\211\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
+  "i.Status\022=\n\004data\030\002 \001(\0132/.grpc_cli.GetSys"
+  "temPropertyResponse.Result.Data\032\036\n\004Data\022"
+  "\026\n\016rebuild_policy\030\001 \001(\t\"\234\001\n\030SetSystemPro"
   "pertyRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001"
-  "(\t\022\021\n\trequestor\030\003 \001(\t\"\242\002\n\031GetSystemPrope"
-  "rtyResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001("
-  "\t\022:\n\006result\030\003 \001(\0132*.grpc_cli.GetSystemPr"
-  "opertyResponse.Result\022\037\n\004info\030\004 \001(\0132\021.gr"
-  "pc_cli.PosInfo\032\211\001\n\006Result\022 \n\006status\030\001 \001("
-  "\0132\020.grpc_cli.Status\022=\n\004data\030\002 \001(\0132/.grpc"
-  "_cli.GetSystemPropertyResponse.Result.Da"
-  "ta\032\036\n\004Data\022\026\n\016rebuild_policy\030\001 \001(\t\"\234\001\n\030S"
-  "etSystemPropertyRequest\022\017\n\007command\030\001 \001(\t"
-  "\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0227\n\005para"
-  "m\030\004 \001(\0132(.grpc_cli.SetSystemPropertyRequ"
-  "est.Param\032\026\n\005Param\022\r\n\005level\030\001 \001(\t\"\302\001\n\031Se"
-  "tSystemPropertyResponse\022\017\n\007command\030\001 \001(\t"
-  "\022\013\n\003rid\030\002 \001(\t\022:\n\006result\030\003 \001(\0132*.grpc_cli"
-  ".SetSystemPropertyResponse.Result\022\037\n\004inf"
-  "o\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006"
-  "status\030\001 \001(\0132\020.grpc_cli.Status\"H\n\025StartT"
-  "elemetryRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\274\001\n\026StartTeleme"
-  "tryResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001("
-  "\t\0227\n\006result\030\003 \001(\0132\'.grpc_cli.StartTeleme"
-  "tryResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_"
-  "cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020."
-  "grpc_cli.Status\"G\n\024StopTelemetryRequest\022"
-  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequest"
-  "or\030\003 \001(\t\"\272\001\n\025StopTelemetryResponse\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0226\n\006result\030\003 \001(\013"
-  "2&.grpc_cli.StopTelemetryResponse.Result"
-  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Res"
-  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"G\n"
-  "\024ResetEventWrrRequest\022\017\n\007command\030\001 \001(\t\022\013"
-  "\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\272\001\n\025Reset"
-  "EventWrrResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
-  "\030\002 \001(\t\0226\n\006result\030\003 \001(\0132&.grpc_cli.ResetE"
-  "ventWrrResponse.Result\022\037\n\004info\030\004 \001(\0132\021.g"
+  "(\t\022\021\n\trequestor\030\003 \001(\t\0227\n\005param\030\004 \001(\0132(.g"
+  "rpc_cli.SetSystemPropertyRequest.Param\032\026"
+  "\n\005Param\022\r\n\005level\030\001 \001(\t\"\302\001\n\031SetSystemProp"
+  "ertyResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001"
+  "(\t\022:\n\006result\030\003 \001(\0132*.grpc_cli.SetSystemP"
+  "ropertyResponse.Result\022\037\n\004info\030\004 \001(\0132\021.g"
   "rpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001("
-  "\0132\020.grpc_cli.Status\"B\n\017ResetMbrRequest\022\017"
-  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequesto"
-  "r\030\003 \001(\t\"\260\001\n\020ResetMbrResponse\022\017\n\007command\030"
-  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grp"
-  "c_cli.ResetMbrResponse.Result\022\037\n\004info\030\004 "
-  "\001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006stat"
-  "us\030\001 \001(\0132\020.grpc_cli.Status\"\225\001\n\025StopRebui"
-  "ldingRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001"
-  "(\t\022\021\n\trequestor\030\003 \001(\t\0224\n\005param\030\004 \001(\0132%.g"
-  "rpc_cli.StopRebuildingRequest.Param\032\025\n\005P"
-  "aram\022\014\n\004name\030\001 \001(\t\"\274\001\n\026StopRebuildingRes"
-  "ponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006r"
-  "esult\030\003 \001(\0132\'.grpc_cli.StopRebuildingRes"
-  "ponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Po"
-  "sInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_c"
-  "li.Status\"\245\001\n\025UpdateEventWrrRequest\022\017\n\007c"
-  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003"
-  " \001(\t\0224\n\005param\030\004 \001(\0132%.grpc_cli.UpdateEve"
-  "ntWrrRequest.Param\032%\n\005Param\022\014\n\004name\030\001 \001("
-  "\t\022\016\n\006weight\030\002 \001(\003\"\274\001\n\026UpdateEventWrrResp"
-  "onse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006re"
-  "sult\030\003 \001(\0132\'.grpc_cli.UpdateEventWrrResp"
-  "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
-  "Info\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
-  "i.Status\"\353\001\n\017AddSpareRequest\022\017\n\007command\030"
-  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022.\n"
-  "\005param\030\004 \001(\0132\037.grpc_cli.AddSpareRequest."
-  "Param\032%\n\017SpareDeviceName\022\022\n\ndeviceName\030\001"
-  " \001(\t\032P\n\005Param\022\r\n\005array\030\001 \001(\t\0228\n\005spare\030\003 "
-  "\003(\0132).grpc_cli.AddSpareRequest.SpareDevi"
-  "ceName\"\260\001\n\020AddSpareResponse\022\017\n\007command\030\001"
-  " \001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc"
-  "_cli.AddSpareResponse.Result\022\037\n\004info\030\004 \001"
-  "(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006statu"
-  "s\030\001 \001(\0132\020.grpc_cli.Status\"$\n\016DeviceNameL"
-  "ist\022\022\n\ndeviceName\030\001 \001(\t\"\364\001\n\022RemoveSpareR"
-  "equest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\t"
-  "requestor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cl"
-  "i.RemoveSpareRequest.Param\032%\n\017SpareDevic"
-  "eName\022\022\n\ndeviceName\030\001 \001(\t\032S\n\005Param\022\r\n\005ar"
-  "ray\030\001 \001(\t\022;\n\005spare\030\002 \003(\0132,.grpc_cli.Remo"
-  "veSpareRequest.SpareDeviceName\"\266\001\n\023Remov"
-  "eSpareResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
-  " \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.RemoveSp"
-  "areResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_"
-  "cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020."
-  "grpc_cli.Status\"\235\002\n\022CreateArrayRequest\022\017"
-  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequesto"
-  "r\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.Create"
-  "ArrayRequest.Param\032\242\001\n\005Param\022\014\n\004name\030\001 \001"
-  "(\t\022(\n\006buffer\030\002 \003(\0132\030.grpc_cli.DeviceName"
-  "List\022&\n\004data\030\003 \003(\0132\030.grpc_cli.DeviceName"
-  "List\022\'\n\005spare\030\004 \003(\0132\030.grpc_cli.DeviceNam"
-  "eList\022\020\n\010raidtype\030\005 \001(\t\"\266\001\n\023CreateArrayR"
-  "esponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n"
-  "\006result\030\003 \001(\0132$.grpc_cli.CreateArrayResp"
-  "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
-  "Info\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
-  "i.Status\"\366\001\n\026AutocreateArrayRequest\022\017\n\007c"
-  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003"
-  " \001(\t\0225\n\005param\030\004 \001(\0132&.grpc_cli.Autocreat"
-  "eArrayRequest.Param\032t\n\005Param\022\014\n\004name\030\001 \001"
-  "(\t\022(\n\006buffer\030\002 \003(\0132\030.grpc_cli.DeviceName"
-  "List\022\017\n\007numData\030\003 \001(\005\022\020\n\010numSpare\030\004 \001(\005\022"
-  "\020\n\010raidtype\030\005 \001(\t\"\276\001\n\027AutocreateArrayRes"
-  "ponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0228\n\006r"
-  "esult\030\003 \001(\0132(.grpc_cli.AutocreateArrayRe"
-  "sponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.P"
-  "osInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_"
-  "cli.Status\"\217\001\n\022DeleteArrayRequest\022\017\n\007com"
-  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001"
-  "(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.DeleteArray"
-  "Request.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\266\001\n"
-  "\023DeleteArrayResponse\022\017\n\007command\030\001 \001(\t\022\013\n"
-  "\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.De"
-  "leteArrayResponse.Result\022\037\n\004info\030\004 \001(\0132\021"
-  ".grpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 "
-  "\001(\0132\020.grpc_cli.Status\"\305\001\n\021MountArrayRequ"
-  "est\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treq"
-  "uestor\030\003 \001(\t\0220\n\005param\030\004 \001(\0132!.grpc_cli.M"
-  "ountArrayRequest.Param\032M\n\005Param\022\014\n\004name\030"
-  "\001 \001(\t\022\037\n\022enableWriteThrough\030\002 \001(\010H\000\210\001\001B\025"
-  "\n\023_enableWriteThrough\"\264\001\n\022MountArrayResp"
-  "onse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006re"
-  "sult\030\003 \001(\0132#.grpc_cli.MountArrayResponse"
+  "\0132\020.grpc_cli.Status\"H\n\025StartTelemetryReq"
+  "uest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tre"
+  "questor\030\003 \001(\t\"\274\001\n\026StartTelemetryResponse"
+  "\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result"
+  "\030\003 \001(\0132\'.grpc_cli.StartTelemetryResponse"
   ".Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo"
   "\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.St"
-  "atus\"\221\001\n\023UnmountArrayRequest\022\017\n\007command\030"
-  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n"
-  "\005param\030\004 \001(\0132#.grpc_cli.UnmountArrayRequ"
-  "est.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\270\001\n\024Unm"
-  "ountArrayResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
-  "d\030\002 \001(\t\0225\n\006result\030\003 \001(\0132%.grpc_cli.Unmou"
-  "ntArrayResponse.Result\022\037\n\004info\030\004 \001(\0132\021.g"
-  "rpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001("
-  "\0132\020.grpc_cli.Status\"\314\002\n\005Array\022\r\n\005index\030\001"
-  " \001(\005\022\021\n\tunique_id\030\002 \001(\005\022\014\n\004name\030\003 \001(\t\022\016\n"
-  "\006status\030\004 \001(\t\022\r\n\005state\030\005 \001(\t\022\021\n\tsituatio"
-  "n\030\006 \001(\t\022\026\n\016createDatetime\030\007 \001(\t\022\026\n\016updat"
-  "eDatetime\030\010 \001(\t\022\032\n\022rebuildingProgress\030\t "
-  "\001(\t\022\020\n\010capacity\030\n \001(\004\022\014\n\004used\030\013 \001(\004\022\016\n\006g"
-  "cMode\030\014 \001(\t\022\020\n\010metaRaid\030\r \001(\t\022\020\n\010dataRai"
-  "d\030\016 \001(\t\022\033\n\023writeThroughEnabled\030\017 \001(\010\022$\n\n"
-  "devicelist\030\020 \003(\0132\020.grpc_cli.Device\"C\n\020Li"
-  "stArrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
-  " \001(\t\022\021\n\trequestor\030\003 \001(\t\"\240\002\n\021ListArrayRes"
-  "ponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006r"
-  "esult\030\003 \001(\0132\".grpc_cli.ListArrayResponse"
-  ".Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo"
-  "\032\227\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.S"
-  "tatus\022:\n\004data\030\002 \001(\0132,.grpc_cli.ListArray"
-  "Response.Result.ArrayList\032/\n\tArrayList\022\""
-  "\n\tarrayList\030\001 \003(\0132\017.grpc_cli.Array\"\213\001\n\020A"
-  "rrayInfoRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022/\n\005param\030\004 \001(\0132"
-  " .grpc_cli.ArrayInfoRequest.Param\032\025\n\005Par"
-  "am\022\014\n\004name\030\001 \001(\t\"\321\001\n\021ArrayInfoResponse\022\017"
-  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003"
-  " \001(\0132\".grpc_cli.ArrayInfoResponse.Result"
-  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032I\n\006Res"
-  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022\035\n"
-  "\004data\030\002 \001(\0132\017.grpc_cli.Array\"B\n\017ListNode"
-  "Request\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n"
-  "\trequestor\030\003 \001(\t\"\233\002\n\020ListNodeResponse\022\017\n"
-  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006result\030\003 "
-  "\001(\0132!.grpc_cli.ListNodeResponse.Result\022\037"
-  "\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\224\001\n\006Resu"
-  "lt\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\0224\n\004"
-  "data\030\002 \003(\0132&.grpc_cli.ListNodeResponse.R"
-  "esult.Node\0322\n\004Node\022\014\n\004name\030\001 \001(\t\022\n\n\002ip\030\002"
-  " \001(\t\022\020\n\010lastseen\030\003 \001(\t\"F\n\023ListHaVolumeRe"
-  "quest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tr"
-  "equestor\030\003 \001(\t\"\336\002\n\024ListHaVolumeResponse\022"
-  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030"
-  "\003 \001(\0132%.grpc_cli.ListHaVolumeResponse.Re"
-  "sult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\317\001"
-  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
-  "us\022:\n\004data\030\002 \003(\0132,.grpc_cli.ListHaVolume"
-  "Response.Result.Volume\032g\n\006Volume\022\n\n\002id\030\001"
-  " \001(\005\022\014\n\004name\030\002 \001(\t\022\020\n\010nodeName\030\003 \001(\t\022\021\n\t"
-  "arrayName\030\004 \001(\t\022\014\n\004size\030\005 \001(\003\022\020\n\010lastsee"
-  "n\030\006 \001(\t\"K\n\030ListHaReplicationRequest\022\017\n\007c"
-  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003"
-  " \001(\t\"\226\003\n\031ListHaReplicationResponse\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022:\n\006result\030\003 \001(\013"
-  "2*.grpc_cli.ListHaReplicationResponse.Re"
-  "sult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\375\001"
-  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
-  "us\022D\n\004data\030\002 \003(\01326.grpc_cli.ListHaReplic"
-  "ationResponse.Result.Replication\032\212\001\n\013Rep"
-  "lication\022\n\n\002id\030\001 \001(\005\022\026\n\016sourceVolumeId\030\002"
-  " \001(\005\022\032\n\022sourceWalVolume_id\030\003 \001(\005\022\033\n\023dest"
-  "inationVolumeId\030\004 \001(\005\022\036\n\026destinationWalV"
-  "olumeId\030\005 \001(\005\"\223\003\n\031StartHaReplicationRequ"
-  "est\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treq"
-  "uestor\030\003 \001(\t\0228\n\005param\030\004 \001(\0132).grpc_cli.S"
-  "tartHaReplicationRequest.Param\032\212\002\n\005Param"
-  "\022\027\n\017primaryNodeName\030\001 \001(\t\022\030\n\020primaryArra"
-  "yName\030\002 \001(\t\022\031\n\021primaryVolumeName\030\003 \001(\t\022\034"
-  "\n\024primaryWalVolumeName\030\004 \001(\t\022\031\n\021secondar"
-  "yNodeName\030\005 \001(\t\022\032\n\022secondaryArrayName\030\006 "
-  "\001(\t\022\033\n\023secondaryVolumeName\030\007 \001(\t\022\036\n\026seco"
-  "ndaryWalVolumeName\030\010 \001(\t\022\016\n\006stuats\030\t \001(\t"
-  "\022\021\n\ttimestamp\030\n \001(\t\"\304\001\n\032StartHaReplicati"
-  "onResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t"
-  "\022;\n\006result\030\003 \001(\0132+.grpc_cli.StartHaRepli"
-  "cationResponse.Result\022\037\n\004info\030\004 \001(\0132\021.gr"
-  "pc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\013"
-  "2\020.grpc_cli.Status\"\220\001\n\022SetLogLevelReques"
-  "t\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treque"
-  "stor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.Set"
-  "LogLevelRequest.Param\032\026\n\005Param\022\r\n\005level\030"
-  "\001 \001(\t\"\266\001\n\023SetLogLevelResponse\022\017\n\007command"
-  "\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.gr"
-  "pc_cli.SetLogLevelResponse.Result\022\037\n\004inf"
-  "o\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006"
-  "status\030\001 \001(\0132\020.grpc_cli.Status\"\246\001\n\027SetLo"
-  "gPreferenceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003r"
-  "id\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0226\n\005param\030\004 \001"
-  "(\0132\'.grpc_cli.SetLogPreferenceRequest.Pa"
-  "ram\032\"\n\005Param\022\031\n\021structuredLogging\030\001 \001(\t\""
-  "\300\001\n\030SetLogPreferenceResponse\022\017\n\007command\030"
-  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0229\n\006result\030\003 \001(\0132).grp"
-  "c_cli.SetLogPreferenceResponse.Result\022\037\n"
-  "\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result"
-  "\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"D\n\021Lo"
-  "ggerInfoRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\345\003\n\022LoggerInfoR"
-  "esponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n"
-  "\006result\030\003 \001(\0132#.grpc_cli.LoggerInfoRespo"
-  "nse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosI"
-  "nfo\032\332\002\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
-  "i.Status\022<\n\004data\030\002 \001(\0132..grpc_cli.Logger"
-  "InfoResponse.Result.LoggerInfo\032\357\001\n\nLogge"
-  "rInfo\022\024\n\014minorLogPath\030\001 \001(\t\022\024\n\014majorLogP"
-  "ath\030\002 \001(\t\022\027\n\017logfileSizeInMb\030\003 \001(\t\022\034\n\024lo"
-  "gfileRotationCount\030\004 \001(\005\022\034\n\024minAllowable"
-  "LogLevel\030\005 \001(\t\022\025\n\rfilterEnabled\030\006 \001(\005\022\026\n"
-  "\016filterIncluded\030\007 \001(\t\022\026\n\016filterExcluded\030"
-  "\010 \001(\t\022\031\n\021structuredLogging\030\t \001(\010\"E\n\022GetL"
-  "ogLevelRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
-  " \001(\t\022\021\n\trequestor\030\003 \001(\t\"\217\002\n\023GetLogLevelR"
-  "esponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n"
-  "\006result\030\003 \001(\0132$.grpc_cli.GetLogLevelResp"
+  "atus\"G\n\024StopTelemetryRequest\022\017\n\007command\030"
+  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\272\001"
+  "\n\025StopTelemetryResponse\022\017\n\007command\030\001 \001(\t"
+  "\022\013\n\003rid\030\002 \001(\t\0226\n\006result\030\003 \001(\0132&.grpc_cli"
+  ".StopTelemetryResponse.Result\022\037\n\004info\030\004 "
+  "\001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006stat"
+  "us\030\001 \001(\0132\020.grpc_cli.Status\"G\n\024ResetEvent"
+  "WrrRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t"
+  "\022\021\n\trequestor\030\003 \001(\t\"\272\001\n\025ResetEventWrrRes"
+  "ponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0226\n\006r"
+  "esult\030\003 \001(\0132&.grpc_cli.ResetEventWrrResp"
   "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
-  "Info\032\202\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_c"
-  "li.Status\022;\n\004data\030\002 \001(\0132-.grpc_cli.GetLo"
-  "gLevelResponse.Result.LogLevel\032\031\n\010LogLev"
-  "el\022\r\n\005level\030\001 \001(\t\"H\n\025ApplyLogFilterReque"
-  "st\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequ"
-  "estor\030\003 \001(\t\"\274\001\n\026ApplyLogFilterResponse\022\017"
-  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003"
-  " \001(\0132\'.grpc_cli.ApplyLogFilterResponse.R"
-  "esult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*"
-  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
-  "us\"\326\001\n\023CreateDeviceRequest\022\017\n\007command\030\001 "
-  "\001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005p"
-  "aram\030\004 \001(\0132#.grpc_cli.CreateDeviceReques"
-  "t.Param\032Z\n\005Param\022\014\n\004name\030\001 \001(\t\022\021\n\tnumBlo"
-  "cks\030\002 \001(\r\022\021\n\tblockSize\030\003 \001(\r\022\017\n\007devType\030"
-  "\004 \001(\t\022\014\n\004numa\030\005 \001(\r\"\270\001\n\024CreateDeviceResp"
-  "onse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006re"
-  "sult\030\003 \001(\0132%.grpc_cli.CreateDeviceRespon"
-  "se.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosIn"
-  "fo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli."
-  "Status\"D\n\021ScanDeviceRequest\022\017\n\007command\030\001"
-  " \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\264\001\n"
-  "\022ScanDeviceResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003"
-  "rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.Sca"
-  "nDeviceResponse.Result\022\037\n\004info\030\004 \001(\0132\021.g"
+  "Info\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
+  "i.Status\"B\n\017ResetMbrRequest\022\017\n\007command\030\001"
+  " \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\260\001\n"
+  "\020ResetMbrResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
+  "d\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cli.Reset"
+  "MbrResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_"
+  "cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020."
+  "grpc_cli.Status\"\225\001\n\025StopRebuildingReques"
+  "t\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treque"
+  "stor\030\003 \001(\t\0224\n\005param\030\004 \001(\0132%.grpc_cli.Sto"
+  "pRebuildingRequest.Param\032\025\n\005Param\022\014\n\004nam"
+  "e\030\001 \001(\t\"\274\001\n\026StopRebuildingResponse\022\017\n\007co"
+  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\013"
+  "2\'.grpc_cli.StopRebuildingResponse.Resul"
+  "t\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Re"
+  "sult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\245"
+  "\001\n\025UpdateEventWrrRequest\022\017\n\007command\030\001 \001("
+  "\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0224\n\005par"
+  "am\030\004 \001(\0132%.grpc_cli.UpdateEventWrrReques"
+  "t.Param\032%\n\005Param\022\014\n\004name\030\001 \001(\t\022\016\n\006weight"
+  "\030\002 \001(\003\"\274\001\n\026UpdateEventWrrResponse\022\017\n\007com"
+  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132"
+  "\'.grpc_cli.UpdateEventWrrResponse.Result"
+  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Res"
+  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\353\001"
+  "\n\017AddSpareRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
+  "d\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022.\n\005param\030\004 \001("
+  "\0132\037.grpc_cli.AddSpareRequest.Param\032%\n\017Sp"
+  "areDeviceName\022\022\n\ndeviceName\030\001 \001(\t\032P\n\005Par"
+  "am\022\r\n\005array\030\001 \001(\t\0228\n\005spare\030\003 \003(\0132).grpc_"
+  "cli.AddSpareRequest.SpareDeviceName\"\260\001\n\020"
+  "AddSpareResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
+  "\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cli.AddSpa"
+  "reResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_c"
+  "li.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.g"
+  "rpc_cli.Status\"$\n\016DeviceNameList\022\022\n\ndevi"
+  "ceName\030\001 \001(\t\"\364\001\n\022RemoveSpareRequest\022\017\n\007c"
+  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003"
+  " \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.RemoveSpa"
+  "reRequest.Param\032%\n\017SpareDeviceName\022\022\n\nde"
+  "viceName\030\001 \001(\t\032S\n\005Param\022\r\n\005array\030\001 \001(\t\022;"
+  "\n\005spare\030\002 \003(\0132,.grpc_cli.RemoveSpareRequ"
+  "est.SpareDeviceName\"\266\001\n\023RemoveSpareRespo"
+  "nse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006res"
+  "ult\030\003 \001(\0132$.grpc_cli.RemoveSpareResponse"
+  ".Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo"
+  "\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.St"
+  "atus\"\235\002\n\022CreateArrayRequest\022\017\n\007command\030\001"
+  " \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005"
+  "param\030\004 \001(\0132\".grpc_cli.CreateArrayReques"
+  "t.Param\032\242\001\n\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006buffe"
+  "r\030\002 \003(\0132\030.grpc_cli.DeviceNameList\022&\n\004dat"
+  "a\030\003 \003(\0132\030.grpc_cli.DeviceNameList\022\'\n\005spa"
+  "re\030\004 \003(\0132\030.grpc_cli.DeviceNameList\022\020\n\010ra"
+  "idtype\030\005 \001(\t\"\266\001\n\023CreateArrayResponse\022\017\n\007"
+  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001"
+  "(\0132$.grpc_cli.CreateArrayResponse.Result"
+  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Res"
+  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\366\001"
+  "\n\026AutocreateArrayRequest\022\017\n\007command\030\001 \001("
+  "\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0225\n\005par"
+  "am\030\004 \001(\0132&.grpc_cli.AutocreateArrayReque"
+  "st.Param\032t\n\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006buffe"
+  "r\030\002 \003(\0132\030.grpc_cli.DeviceNameList\022\017\n\007num"
+  "Data\030\003 \001(\005\022\020\n\010numSpare\030\004 \001(\005\022\020\n\010raidtype"
+  "\030\005 \001(\t\"\276\001\n\027AutocreateArrayResponse\022\017\n\007co"
+  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0228\n\006result\030\003 \001(\013"
+  "2(.grpc_cli.AutocreateArrayResponse.Resu"
+  "lt\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006R"
+  "esult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\""
+  "\217\001\n\022DeleteArrayRequest\022\017\n\007command\030\001 \001(\t\022"
+  "\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005param"
+  "\030\004 \001(\0132\".grpc_cli.DeleteArrayRequest.Par"
+  "am\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\266\001\n\023DeleteArra"
+  "yResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022"
+  "4\n\006result\030\003 \001(\0132$.grpc_cli.DeleteArrayRe"
+  "sponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.P"
+  "osInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_"
+  "cli.Status\"\305\001\n\021MountArrayRequest\022\017\n\007comm"
+  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001("
+  "\t\0220\n\005param\030\004 \001(\0132!.grpc_cli.MountArrayRe"
+  "quest.Param\032M\n\005Param\022\014\n\004name\030\001 \001(\t\022\037\n\022en"
+  "ableWriteThrough\030\002 \001(\010H\000\210\001\001B\025\n\023_enableWr"
+  "iteThrough\"\264\001\n\022MountArrayResponse\022\017\n\007com"
+  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132"
+  "#.grpc_cli.MountArrayResponse.Result\022\037\n\004"
+  "info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022"
+  " \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\221\001\n\023Un"
+  "mountArrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
+  "d\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005param\030\004 \001("
+  "\0132#.grpc_cli.UnmountArrayRequest.Param\032\025"
+  "\n\005Param\022\014\n\004name\030\001 \001(\t\"\270\001\n\024UnmountArrayRe"
+  "sponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006"
+  "result\030\003 \001(\0132%.grpc_cli.UnmountArrayResp"
+  "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
+  "Info\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
+  "i.Status\"\314\002\n\005Array\022\r\n\005index\030\001 \001(\005\022\021\n\tuni"
+  "que_id\030\002 \001(\005\022\014\n\004name\030\003 \001(\t\022\016\n\006status\030\004 \001"
+  "(\t\022\r\n\005state\030\005 \001(\t\022\021\n\tsituation\030\006 \001(\t\022\026\n\016"
+  "createDatetime\030\007 \001(\t\022\026\n\016updateDatetime\030\010"
+  " \001(\t\022\032\n\022rebuildingProgress\030\t \001(\t\022\020\n\010capa"
+  "city\030\n \001(\004\022\014\n\004used\030\013 \001(\004\022\016\n\006gcMode\030\014 \001(\t"
+  "\022\020\n\010metaRaid\030\r \001(\t\022\020\n\010dataRaid\030\016 \001(\t\022\033\n\023"
+  "writeThroughEnabled\030\017 \001(\010\022$\n\ndevicelist\030"
+  "\020 \003(\0132\020.grpc_cli.Device\"C\n\020ListArrayRequ"
+  "est\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treq"
+  "uestor\030\003 \001(\t\"\240\002\n\021ListArrayResponse\022\017\n\007co"
+  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003 \001(\013"
+  "2\".grpc_cli.ListArrayResponse.Result\022\037\n\004"
+  "info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\227\001\n\006Result"
+  "\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022:\n\004da"
+  "ta\030\002 \001(\0132,.grpc_cli.ListArrayResponse.Re"
+  "sult.ArrayList\032/\n\tArrayList\022\"\n\tarrayList"
+  "\030\001 \003(\0132\017.grpc_cli.Array\"\213\001\n\020ArrayInfoReq"
+  "uest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tre"
+  "questor\030\003 \001(\t\022/\n\005param\030\004 \001(\0132 .grpc_cli."
+  "ArrayInfoRequest.Param\032\025\n\005Param\022\014\n\004name\030"
+  "\001 \001(\t\"\321\001\n\021ArrayInfoResponse\022\017\n\007command\030\001"
+  " \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003 \001(\0132\".grpc"
+  "_cli.ArrayInfoResponse.Result\022\037\n\004info\030\004 "
+  "\001(\0132\021.grpc_cli.PosInfo\032I\n\006Result\022 \n\006stat"
+  "us\030\001 \001(\0132\020.grpc_cli.Status\022\035\n\004data\030\002 \001(\013"
+  "2\017.grpc_cli.Array\"B\n\017ListNodeRequest\022\017\n\007"
+  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030"
+  "\003 \001(\t\"\233\002\n\020ListNodeResponse\022\017\n\007command\030\001 "
+  "\001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_"
+  "cli.ListNodeResponse.Result\022\037\n\004info\030\004 \001("
+  "\0132\021.grpc_cli.PosInfo\032\224\001\n\006Result\022 \n\006statu"
+  "s\030\001 \001(\0132\020.grpc_cli.Status\0224\n\004data\030\002 \003(\0132"
+  "&.grpc_cli.ListNodeResponse.Result.Node\032"
+  "2\n\004Node\022\014\n\004name\030\001 \001(\t\022\n\n\002ip\030\002 \001(\t\022\020\n\010las"
+  "tseen\030\003 \001(\t\"F\n\023ListHaVolumeRequest\022\017\n\007co"
+  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 "
+  "\001(\t\"\336\002\n\024ListHaVolumeResponse\022\017\n\007command\030"
+  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001(\0132%.grp"
+  "c_cli.ListHaVolumeResponse.Result\022\037\n\004inf"
+  "o\030\004 \001(\0132\021.grpc_cli.PosInfo\032\317\001\n\006Result\022 \n"
+  "\006status\030\001 \001(\0132\020.grpc_cli.Status\022:\n\004data\030"
+  "\002 \003(\0132,.grpc_cli.ListHaVolumeResponse.Re"
+  "sult.Volume\032g\n\006Volume\022\n\n\002id\030\001 \001(\005\022\014\n\004nam"
+  "e\030\002 \001(\t\022\020\n\010nodeName\030\003 \001(\t\022\021\n\tarrayName\030\004"
+  " \001(\t\022\014\n\004size\030\005 \001(\003\022\020\n\010lastseen\030\006 \001(\t\"K\n\030"
+  "ListHaReplicationRequest\022\017\n\007command\030\001 \001("
+  "\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\226\003\n\031Li"
+  "stHaReplicationResponse\022\017\n\007command\030\001 \001(\t"
+  "\022\013\n\003rid\030\002 \001(\t\022:\n\006result\030\003 \001(\0132*.grpc_cli"
+  ".ListHaReplicationResponse.Result\022\037\n\004inf"
+  "o\030\004 \001(\0132\021.grpc_cli.PosInfo\032\375\001\n\006Result\022 \n"
+  "\006status\030\001 \001(\0132\020.grpc_cli.Status\022D\n\004data\030"
+  "\002 \003(\01326.grpc_cli.ListHaReplicationRespon"
+  "se.Result.Replication\032\212\001\n\013Replication\022\n\n"
+  "\002id\030\001 \001(\005\022\026\n\016sourceVolumeId\030\002 \001(\005\022\032\n\022sou"
+  "rceWalVolume_id\030\003 \001(\005\022\033\n\023destinationVolu"
+  "meId\030\004 \001(\005\022\036\n\026destinationWalVolumeId\030\005 \001"
+  "(\005\"\223\003\n\031StartHaReplicationRequest\022\017\n\007comm"
+  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001("
+  "\t\0228\n\005param\030\004 \001(\0132).grpc_cli.StartHaRepli"
+  "cationRequest.Param\032\212\002\n\005Param\022\027\n\017primary"
+  "NodeName\030\001 \001(\t\022\030\n\020primaryArrayName\030\002 \001(\t"
+  "\022\031\n\021primaryVolumeName\030\003 \001(\t\022\034\n\024primaryWa"
+  "lVolumeName\030\004 \001(\t\022\031\n\021secondaryNodeName\030\005"
+  " \001(\t\022\032\n\022secondaryArrayName\030\006 \001(\t\022\033\n\023seco"
+  "ndaryVolumeName\030\007 \001(\t\022\036\n\026secondaryWalVol"
+  "umeName\030\010 \001(\t\022\016\n\006stuats\030\t \001(\t\022\021\n\ttimesta"
+  "mp\030\n \001(\t\"\304\001\n\032StartHaReplicationResponse\022"
+  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022;\n\006result\030"
+  "\003 \001(\0132+.grpc_cli.StartHaReplicationRespo"
+  "nse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosI"
+  "nfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli"
+  ".Status\"\220\001\n\022SetLogLevelRequest\022\017\n\007comman"
+  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022"
+  "1\n\005param\030\004 \001(\0132\".grpc_cli.SetLogLevelReq"
+  "uest.Param\032\026\n\005Param\022\r\n\005level\030\001 \001(\t\"\266\001\n\023S"
+  "etLogLevelResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003r"
+  "id\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.SetL"
+  "ogLevelResponse.Result\022\037\n\004info\030\004 \001(\0132\021.g"
   "rpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001("
-  "\0132\020.grpc_cli.Status\"\213\001\n\006Device\022\014\n\004name\030\001"
-  " \001(\t\022\014\n\004type\030\002 \001(\t\022\017\n\007address\030\003 \001(\t\022\r\n\005c"
-  "lass\030\004 \001(\t\022\023\n\013modelNumber\030\005 \001(\t\022\014\n\004numa\030"
-  "\006 \001(\t\022\014\n\004size\030\007 \001(\004\022\024\n\014serialNumber\030\010 \001("
-  "\t\"D\n\021ListDeviceRequest\022\017\n\007command\030\001 \001(\t\022"
-  "\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\247\002\n\022List"
-  "DeviceResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
-  " \001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.ListDevi"
-  "ceResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_c"
-  "li.PosInfo\032\234\001\n\006Result\022 \n\006status\030\001 \001(\0132\020."
-  "grpc_cli.Status\022<\n\004data\030\002 \001(\0132..grpc_cli"
-  ".ListDeviceResponse.Result.DeviceList\0322\n"
-  "\nDeviceList\022$\n\ndevicelist\030\001 \003(\0132\020.grpc_c"
-  "li.Device\"\335\004\n\010SmartLog\022\033\n\023availableSpare"
-  "Space\030\001 \001(\t\022\023\n\013temperature\030\002 \001(\t\022\031\n\021devi"
-  "ceReliability\030\003 \001(\t\022\020\n\010readOnly\030\004 \001(\t\022\034\n"
-  "\024volatileMemoryBackup\030\005 \001(\t\022\032\n\022currentTe"
-  "mperature\030\006 \001(\t\022\026\n\016availableSpare\030\007 \001(\t\022"
-  "\037\n\027availableSpareThreshold\030\010 \001(\t\022\032\n\022life"
-  "PercentageUsed\030\t \001(\t\022\025\n\rdataUnitsRead\030\n "
-  "\001(\t\022\030\n\020dataUnitsWritten\030\013 \001(\t\022\030\n\020hostRea"
-  "dCommands\030\014 \001(\t\022\031\n\021hostWriteCommands\030\r \001"
-  "(\t\022\032\n\022controllerBusyTime\030\016 \001(\t\022\023\n\013powerC"
-  "ycles\030\017 \001(\t\022\024\n\014powerOnHours\030\020 \001(\t\022\027\n\017uns"
-  "afeShutdowns\030\021 \001(\t\022 \n\030unrecoverableMedia"
-  "Errors\030\022 \001(\t\022\037\n\027lifetimeErrorLogEntries\030"
-  "\023 \001(\t\022\036\n\026warningTemperatureTime\030\024 \001(\t\022\037\n"
-  "\027criticalTemperatureTime\030\025 \001(\t\022\031\n\021temper"
-  "atureSensor\030\026 \003(\t\"\217\001\n\022GetSmartLogRequest"
-  "\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treques"
-  "tor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.GetS"
-  "martLogRequest.Param\032\025\n\005Param\022\014\n\004name\030\001 "
-  "\001(\t\"\330\001\n\023GetSmartLogResponse\022\017\n\007command\030\001"
-  " \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc"
-  "_cli.GetSmartLogResponse.Result\022\037\n\004info\030"
-  "\004 \001(\0132\021.grpc_cli.PosInfo\032L\n\006Result\022 \n\006st"
-  "atus\030\001 \001(\0132\020.grpc_cli.Status\022 \n\004data\030\002 \001"
-  "(\0132\022.grpc_cli.SmartLog2\221\026\n\006PosCli\022_\n\nSys"
-  "temInfo\022\033.grpc_cli.SystemInfoRequest\032\034.g"
-  "rpc_cli.SystemInfoResponse\"\026\202\323\344\223\002\020\022\016/v1/"
-  "systeminfo\022_\n\nSystemStop\022\033.grpc_cli.Syst"
-  "emStopRequest\032\034.grpc_cli.SystemStopRespo"
-  "nse\"\026\202\323\344\223\002\020\022\016/v1/systemstop\022}\n\021GetSystem"
-  "Property\022\".grpc_cli.GetSystemPropertyReq"
-  "uest\032#.grpc_cli.GetSystemPropertyRespons"
-  "e\"\037\202\323\344\223\002\031\022\027/v1/get_system_property\022\205\001\n\021S"
-  "etSystemProperty\022\".grpc_cli.SetSystemPro"
-  "pertyRequest\032#.grpc_cli.SetSystemPropert"
-  "yResponse\"\'\202\323\344\223\002!\022\037/v1/set_system_proper"
-  "ty/{level}\022p\n\016StartTelemetry\022\037.grpc_cli."
-  "StartTelemetryRequest\032 .grpc_cli.StartTe"
-  "lemetryResponse\"\033\202\323\344\223\002\025\022\023/v1/start_telem"
-  "etry\022l\n\rStopTelemetry\022\036.grpc_cli.StopTel"
-  "emetryRequest\032\037.grpc_cli.StopTelemetryRe"
-  "sponse\"\032\202\323\344\223\002\024\022\022/v1/stop_telemetry\022P\n\rRe"
-  "setEventWrr\022\036.grpc_cli.ResetEventWrrRequ"
-  "est\032\037.grpc_cli.ResetEventWrrResponse\022A\n\010"
-  "ResetMbr\022\031.grpc_cli.ResetMbrRequest\032\032.gr"
-  "pc_cli.ResetMbrResponse\022S\n\016StopRebuildin"
-  "g\022\037.grpc_cli.StopRebuildingRequest\032 .grp"
-  "c_cli.StopRebuildingResponse\022S\n\016UpdateEv"
-  "entWrr\022\037.grpc_cli.UpdateEventWrrRequest\032"
-  " .grpc_cli.UpdateEventWrrResponse\022W\n\010Add"
-  "Spare\022\031.grpc_cli.AddSpareRequest\032\032.grpc_"
-  "cli.AddSpareResponse\"\024\202\323\344\223\002\016\"\014/v1/addspa"
-  "re\022c\n\013RemoveSpare\022\034.grpc_cli.RemoveSpare"
-  "Request\032\035.grpc_cli.RemoveSpareResponse\"\027"
-  "\202\323\344\223\002\021\"\017/v1/removespare\022c\n\013CreateArray\022\034"
-  ".grpc_cli.CreateArrayRequest\032\035.grpc_cli."
-  "CreateArrayResponse\"\027\202\323\344\223\002\021\"\017/v1/createa"
-  "rray\022s\n\017AutocreateArray\022 .grpc_cli.Autoc"
-  "reateArrayRequest\032!.grpc_cli.AutocreateA"
-  "rrayResponse\"\033\202\323\344\223\002\025\"\023/v1/autocreatearra"
-  "y\022d\n\013DeleteArray\022\034.grpc_cli.DeleteArrayR"
-  "equest\032\035.grpc_cli.DeleteArrayResponse\"\030\202"
-  "\323\344\223\002\022\"\020/v1/deletearray/\022_\n\nMountArray\022\033."
-  "grpc_cli.MountArrayRequest\032\034.grpc_cli.Mo"
-  "untArrayResponse\"\026\202\323\344\223\002\020\"\016/v1/mountarray"
-  "\022g\n\014UnmountArray\022\035.grpc_cli.UnmountArray"
-  "Request\032\036.grpc_cli.UnmountArrayResponse\""
-  "\030\202\323\344\223\002\022\"\020/v1/unmountarray\022[\n\tListArray\022\032"
-  ".grpc_cli.ListArrayRequest\032\033.grpc_cli.Li"
-  "stArrayResponse\"\025\202\323\344\223\002\017\"\r/v1/listarray\022["
-  "\n\tArrayInfo\022\032.grpc_cli.ArrayInfoRequest\032"
-  "\033.grpc_cli.ArrayInfoResponse\"\025\202\323\344\223\002\017\"\r/v"
-  "1/arrayinfo\022w\n\020SetLogPreference\022!.grpc_c"
-  "li.SetLogPreferenceRequest\032\".grpc_cli.Se"
-  "tLogPreferenceResponse\"\034\202\323\344\223\002\026\"\024/v1/setl"
-  "ogpreference\022c\n\013SetLogLevel\022\034.grpc_cli.S"
-  "etLogLevelRequest\032\035.grpc_cli.SetLogLevel"
-  "Response\"\027\202\323\344\223\002\021\"\017/v1/setloglevel\022_\n\nLog"
-  "gerInfo\022\033.grpc_cli.LoggerInfoRequest\032\034.g"
-  "rpc_cli.LoggerInfoResponse\"\026\202\323\344\223\002\020\"\016/v1/"
-  "loggerinfo\022c\n\013GetLogLevel\022\034.grpc_cli.Get"
-  "LogLevelRequest\032\035.grpc_cli.GetLogLevelRe"
-  "sponse\"\027\202\323\344\223\002\021\"\017/v1/getloglevel\022l\n\016Apply"
-  "LogFilter\022\037.grpc_cli.ApplyLogFilterReque"
-  "st\032 .grpc_cli.ApplyLogFilterResponse\"\027\202\323"
-  "\344\223\002\021\"\017/v1/applyfilter\022g\n\014CreateDevice\022\035."
-  "grpc_cli.CreateDeviceRequest\032\036.grpc_cli."
-  "CreateDeviceResponse\"\030\202\323\344\223\002\022\"\020/v1/create"
-  "device\022_\n\nScanDevice\022\033.grpc_cli.ScanDevi"
-  "ceRequest\032\034.grpc_cli.ScanDeviceResponse\""
-  "\026\202\323\344\223\002\020\"\016/v1/scandevice\022_\n\nListDevice\022\033."
-  "grpc_cli.ListDeviceRequest\032\034.grpc_cli.Li"
-  "stDeviceResponse\"\026\202\323\344\223\002\020\"\016/v1/listdevice"
-  "\022`\n\013GetSmartLog\022\034.grpc_cli.GetSmartLogRe"
-  "quest\032\035.grpc_cli.GetSmartLogResponse\"\024\202\323"
-  "\344\223\002\016\"\014/v1/smartlogB\tZ\007cli/apib\006proto3"
+  "\0132\020.grpc_cli.Status\"\246\001\n\027SetLogPreference"
+  "Request\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n"
+  "\trequestor\030\003 \001(\t\0226\n\005param\030\004 \001(\0132\'.grpc_c"
+  "li.SetLogPreferenceRequest.Param\032\"\n\005Para"
+  "m\022\031\n\021structuredLogging\030\001 \001(\t\"\300\001\n\030SetLogP"
+  "referenceResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
+  "d\030\002 \001(\t\0229\n\006result\030\003 \001(\0132).grpc_cli.SetLo"
+  "gPreferenceResponse.Result\022\037\n\004info\030\004 \001(\013"
+  "2\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030"
+  "\001 \001(\0132\020.grpc_cli.Status\"D\n\021LoggerInfoReq"
+  "uest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tre"
+  "questor\030\003 \001(\t\"\345\003\n\022LoggerInfoResponse\022\017\n\007"
+  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001"
+  "(\0132#.grpc_cli.LoggerInfoResponse.Result\022"
+  "\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\332\002\n\006Res"
+  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022<\n"
+  "\004data\030\002 \001(\0132..grpc_cli.LoggerInfoRespons"
+  "e.Result.LoggerInfo\032\357\001\n\nLoggerInfo\022\024\n\014mi"
+  "norLogPath\030\001 \001(\t\022\024\n\014majorLogPath\030\002 \001(\t\022\027"
+  "\n\017logfileSizeInMb\030\003 \001(\t\022\034\n\024logfileRotati"
+  "onCount\030\004 \001(\005\022\034\n\024minAllowableLogLevel\030\005 "
+  "\001(\t\022\025\n\rfilterEnabled\030\006 \001(\005\022\026\n\016filterIncl"
+  "uded\030\007 \001(\t\022\026\n\016filterExcluded\030\010 \001(\t\022\031\n\021st"
+  "ructuredLogging\030\t \001(\010\"E\n\022GetLogLevelRequ"
+  "est\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treq"
+  "uestor\030\003 \001(\t\"\217\002\n\023GetLogLevelResponse\022\017\n\007"
+  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001"
+  "(\0132$.grpc_cli.GetLogLevelResponse.Result"
+  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\202\001\n\006Re"
+  "sult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022;"
+  "\n\004data\030\002 \001(\0132-.grpc_cli.GetLogLevelRespo"
+  "nse.Result.LogLevel\032\031\n\010LogLevel\022\r\n\005level"
+  "\030\001 \001(\t\"H\n\025ApplyLogFilterRequest\022\017\n\007comma"
+  "nd\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t"
+  "\"\274\001\n\026ApplyLogFilterResponse\022\017\n\007command\030\001"
+  " \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'.grpc"
+  "_cli.ApplyLogFilterResponse.Result\022\037\n\004in"
+  "fo\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n"
+  "\006status\030\001 \001(\0132\020.grpc_cli.Status\"\326\001\n\023Crea"
+  "teDeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
+  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005param\030\004 \001(\0132"
+  "#.grpc_cli.CreateDeviceRequest.Param\032Z\n\005"
+  "Param\022\014\n\004name\030\001 \001(\t\022\021\n\tnumBlocks\030\002 \001(\r\022\021"
+  "\n\tblockSize\030\003 \001(\r\022\017\n\007devType\030\004 \001(\t\022\014\n\004nu"
+  "ma\030\005 \001(\r\"\270\001\n\024CreateDeviceResponse\022\017\n\007com"
+  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001(\0132"
+  "%.grpc_cli.CreateDeviceResponse.Result\022\037"
+  "\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Resul"
+  "t\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"D\n\021S"
+  "canDeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
+  "\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\264\001\n\022ScanDevice"
+  "Response\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223"
+  "\n\006result\030\003 \001(\0132#.grpc_cli.ScanDeviceResp"
+  "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
+  "Info\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
+  "i.Status\"\213\001\n\006Device\022\014\n\004name\030\001 \001(\t\022\014\n\004typ"
+  "e\030\002 \001(\t\022\017\n\007address\030\003 \001(\t\022\r\n\005class\030\004 \001(\t\022"
+  "\023\n\013modelNumber\030\005 \001(\t\022\014\n\004numa\030\006 \001(\t\022\014\n\004si"
+  "ze\030\007 \001(\004\022\024\n\014serialNumber\030\010 \001(\t\"D\n\021ListDe"
+  "viceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001("
+  "\t\022\021\n\trequestor\030\003 \001(\t\"\247\002\n\022ListDeviceRespo"
+  "nse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006res"
+  "ult\030\003 \001(\0132#.grpc_cli.ListDeviceResponse."
+  "Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032"
+  "\234\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.St"
+  "atus\022<\n\004data\030\002 \001(\0132..grpc_cli.ListDevice"
+  "Response.Result.DeviceList\0322\n\nDeviceList"
+  "\022$\n\ndevicelist\030\001 \003(\0132\020.grpc_cli.Device\"\335"
+  "\004\n\010SmartLog\022\033\n\023availableSpareSpace\030\001 \001(\t"
+  "\022\023\n\013temperature\030\002 \001(\t\022\031\n\021deviceReliabili"
+  "ty\030\003 \001(\t\022\020\n\010readOnly\030\004 \001(\t\022\034\n\024volatileMe"
+  "moryBackup\030\005 \001(\t\022\032\n\022currentTemperature\030\006"
+  " \001(\t\022\026\n\016availableSpare\030\007 \001(\t\022\037\n\027availabl"
+  "eSpareThreshold\030\010 \001(\t\022\032\n\022lifePercentageU"
+  "sed\030\t \001(\t\022\025\n\rdataUnitsRead\030\n \001(\t\022\030\n\020data"
+  "UnitsWritten\030\013 \001(\t\022\030\n\020hostReadCommands\030\014"
+  " \001(\t\022\031\n\021hostWriteCommands\030\r \001(\t\022\032\n\022contr"
+  "ollerBusyTime\030\016 \001(\t\022\023\n\013powerCycles\030\017 \001(\t"
+  "\022\024\n\014powerOnHours\030\020 \001(\t\022\027\n\017unsafeShutdown"
+  "s\030\021 \001(\t\022 \n\030unrecoverableMediaErrors\030\022 \001("
+  "\t\022\037\n\027lifetimeErrorLogEntries\030\023 \001(\t\022\036\n\026wa"
+  "rningTemperatureTime\030\024 \001(\t\022\037\n\027criticalTe"
+  "mperatureTime\030\025 \001(\t\022\031\n\021temperatureSensor"
+  "\030\026 \003(\t\"\217\001\n\022GetSmartLogRequest\022\017\n\007command"
+  "\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221"
+  "\n\005param\030\004 \001(\0132\".grpc_cli.GetSmartLogRequ"
+  "est.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\330\001\n\023Get"
+  "SmartLogResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
+  "\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.GetSma"
+  "rtLogResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grp"
+  "c_cli.PosInfo\032L\n\006Result\022 \n\006status\030\001 \001(\0132"
+  "\020.grpc_cli.Status\022 \n\004data\030\002 \001(\0132\022.grpc_c"
+  "li.SmartLog2\221\026\n\006PosCli\022_\n\nSystemInfo\022\033.g"
+  "rpc_cli.SystemInfoRequest\032\034.grpc_cli.Sys"
+  "temInfoResponse\"\026\202\323\344\223\002\020\022\016/v1/systeminfo\022"
+  "_\n\nSystemStop\022\033.grpc_cli.SystemStopReque"
+  "st\032\034.grpc_cli.SystemStopResponse\"\026\202\323\344\223\002\020"
+  "\022\016/v1/systemstop\022}\n\021GetSystemProperty\022\"."
+  "grpc_cli.GetSystemPropertyRequest\032#.grpc"
+  "_cli.GetSystemPropertyResponse\"\037\202\323\344\223\002\031\022\027"
+  "/v1/get_system_property\022\205\001\n\021SetSystemPro"
+  "perty\022\".grpc_cli.SetSystemPropertyReques"
+  "t\032#.grpc_cli.SetSystemPropertyResponse\"\'"
+  "\202\323\344\223\002!\022\037/v1/set_system_property/{level}\022"
+  "p\n\016StartTelemetry\022\037.grpc_cli.StartTeleme"
+  "tryRequest\032 .grpc_cli.StartTelemetryResp"
+  "onse\"\033\202\323\344\223\002\025\022\023/v1/start_telemetry\022l\n\rSto"
+  "pTelemetry\022\036.grpc_cli.StopTelemetryReque"
+  "st\032\037.grpc_cli.StopTelemetryResponse\"\032\202\323\344"
+  "\223\002\024\022\022/v1/stop_telemetry\022P\n\rResetEventWrr"
+  "\022\036.grpc_cli.ResetEventWrrRequest\032\037.grpc_"
+  "cli.ResetEventWrrResponse\022A\n\010ResetMbr\022\031."
+  "grpc_cli.ResetMbrRequest\032\032.grpc_cli.Rese"
+  "tMbrResponse\022S\n\016StopRebuilding\022\037.grpc_cl"
+  "i.StopRebuildingRequest\032 .grpc_cli.StopR"
+  "ebuildingResponse\022S\n\016UpdateEventWrr\022\037.gr"
+  "pc_cli.UpdateEventWrrRequest\032 .grpc_cli."
+  "UpdateEventWrrResponse\022W\n\010AddSpare\022\031.grp"
+  "c_cli.AddSpareRequest\032\032.grpc_cli.AddSpar"
+  "eResponse\"\024\202\323\344\223\002\016\"\014/v1/addspare\022c\n\013Remov"
+  "eSpare\022\034.grpc_cli.RemoveSpareRequest\032\035.g"
+  "rpc_cli.RemoveSpareResponse\"\027\202\323\344\223\002\021\"\017/v1"
+  "/removespare\022c\n\013CreateArray\022\034.grpc_cli.C"
+  "reateArrayRequest\032\035.grpc_cli.CreateArray"
+  "Response\"\027\202\323\344\223\002\021\"\017/v1/createarray\022s\n\017Aut"
+  "ocreateArray\022 .grpc_cli.AutocreateArrayR"
+  "equest\032!.grpc_cli.AutocreateArrayRespons"
+  "e\"\033\202\323\344\223\002\025\"\023/v1/autocreatearray\022d\n\013Delete"
+  "Array\022\034.grpc_cli.DeleteArrayRequest\032\035.gr"
+  "pc_cli.DeleteArrayResponse\"\030\202\323\344\223\002\022\"\020/v1/"
+  "deletearray/\022_\n\nMountArray\022\033.grpc_cli.Mo"
+  "untArrayRequest\032\034.grpc_cli.MountArrayRes"
+  "ponse\"\026\202\323\344\223\002\020\"\016/v1/mountarray\022g\n\014Unmount"
+  "Array\022\035.grpc_cli.UnmountArrayRequest\032\036.g"
+  "rpc_cli.UnmountArrayResponse\"\030\202\323\344\223\002\022\"\020/v"
+  "1/unmountarray\022[\n\tListArray\022\032.grpc_cli.L"
+  "istArrayRequest\032\033.grpc_cli.ListArrayResp"
+  "onse\"\025\202\323\344\223\002\017\"\r/v1/listarray\022[\n\tArrayInfo"
+  "\022\032.grpc_cli.ArrayInfoRequest\032\033.grpc_cli."
+  "ArrayInfoResponse\"\025\202\323\344\223\002\017\"\r/v1/arrayinfo"
+  "\022w\n\020SetLogPreference\022!.grpc_cli.SetLogPr"
+  "eferenceRequest\032\".grpc_cli.SetLogPrefere"
+  "nceResponse\"\034\202\323\344\223\002\026\"\024/v1/setlogpreferenc"
+  "e\022c\n\013SetLogLevel\022\034.grpc_cli.SetLogLevelR"
+  "equest\032\035.grpc_cli.SetLogLevelResponse\"\027\202"
+  "\323\344\223\002\021\"\017/v1/setloglevel\022_\n\nLoggerInfo\022\033.g"
+  "rpc_cli.LoggerInfoRequest\032\034.grpc_cli.Log"
+  "gerInfoResponse\"\026\202\323\344\223\002\020\"\016/v1/loggerinfo\022"
+  "c\n\013GetLogLevel\022\034.grpc_cli.GetLogLevelReq"
+  "uest\032\035.grpc_cli.GetLogLevelResponse\"\027\202\323\344"
+  "\223\002\021\"\017/v1/getloglevel\022l\n\016ApplyLogFilter\022\037"
+  ".grpc_cli.ApplyLogFilterRequest\032 .grpc_c"
+  "li.ApplyLogFilterResponse\"\027\202\323\344\223\002\021\"\017/v1/a"
+  "pplyfilter\022g\n\014CreateDevice\022\035.grpc_cli.Cr"
+  "eateDeviceRequest\032\036.grpc_cli.CreateDevic"
+  "eResponse\"\030\202\323\344\223\002\022\"\020/v1/createdevice\022_\n\nS"
+  "canDevice\022\033.grpc_cli.ScanDeviceRequest\032\034"
+  ".grpc_cli.ScanDeviceResponse\"\026\202\323\344\223\002\020\"\016/v"
+  "1/scandevice\022_\n\nListDevice\022\033.grpc_cli.Li"
+  "stDeviceRequest\032\034.grpc_cli.ListDeviceRes"
+  "ponse\"\026\202\323\344\223\002\020\"\016/v1/listdevice\022`\n\013GetSmar"
+  "tLog\022\034.grpc_cli.GetSmartLogRequest\032\035.grp"
+  "c_cli.GetSmartLogResponse\"\024\202\323\344\223\002\016\"\014/v1/s"
+  "martlogB\tZ\007cli/apib\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_cli_2eproto_deps[1] = {
   &::descriptor_table_annotations_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_cli_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_cli_2eproto = {
-  false, false, 15957, descriptor_table_protodef_cli_2eproto, "cli.proto", 
+  false, false, 16106, descriptor_table_protodef_cli_2eproto, "cli.proto", 
   &descriptor_table_cli_2eproto_once, descriptor_table_cli_2eproto_deps, 1, 129,
   schemas, file_default_instances, TableStruct_cli_2eproto::offsets,
   file_level_metadata_cli_2eproto, file_level_enum_descriptors_cli_2eproto, file_level_service_descriptors_cli_2eproto,
@@ -4478,12 +4494,48 @@ SystemInfoResponse_Result_Data::SystemInfoResponse_Result_Data(const SystemInfoR
     biosversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_biosversion(), 
       GetArena());
   }
+  biosvendor_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_biosvendor().empty()) {
+    biosvendor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_biosvendor(), 
+      GetArena());
+  }
+  biosreleasedate_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_biosreleasedate().empty()) {
+    biosreleasedate_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_biosreleasedate(), 
+      GetArena());
+  }
+  systemmanufacturer_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_systemmanufacturer().empty()) {
+    systemmanufacturer_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_systemmanufacturer(), 
+      GetArena());
+  }
+  systemproductname_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_systemproductname().empty()) {
+    systemproductname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_systemproductname(), 
+      GetArena());
+  }
+  systemserialnumber_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_systemserialnumber().empty()) {
+    systemserialnumber_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_systemserialnumber(), 
+      GetArena());
+  }
+  systemuuid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_systemuuid().empty()) {
+    systemuuid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_systemuuid(), 
+      GetArena());
+  }
   // @@protoc_insertion_point(copy_constructor:grpc_cli.SystemInfoResponse.Result.Data)
 }
 
 void SystemInfoResponse_Result_Data::SharedCtor() {
 version_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 biosversion_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+biosvendor_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+biosreleasedate_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+systemmanufacturer_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+systemproductname_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+systemserialnumber_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+systemuuid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 }
 
 SystemInfoResponse_Result_Data::~SystemInfoResponse_Result_Data() {
@@ -4496,6 +4548,12 @@ void SystemInfoResponse_Result_Data::SharedDtor() {
   GOOGLE_DCHECK(GetArena() == nullptr);
   version_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   biosversion_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  biosvendor_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  biosreleasedate_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  systemmanufacturer_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  systemproductname_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  systemserialnumber_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  systemuuid_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 }
 
 void SystemInfoResponse_Result_Data::ArenaDtor(void* object) {
@@ -4516,6 +4574,12 @@ void SystemInfoResponse_Result_Data::Clear() {
 
   version_.ClearToEmpty();
   biosversion_.ClearToEmpty();
+  biosvendor_.ClearToEmpty();
+  biosreleasedate_.ClearToEmpty();
+  systemmanufacturer_.ClearToEmpty();
+  systemproductname_.ClearToEmpty();
+  systemserialnumber_.ClearToEmpty();
+  systemuuid_.ClearToEmpty();
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -4541,6 +4605,60 @@ const char* SystemInfoResponse_Result_Data::_InternalParse(const char* ptr, ::PR
           auto str = _internal_mutable_biosversion();
           ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.biosVersion"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string biosVendor = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          auto str = _internal_mutable_biosvendor();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.biosVendor"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string biosReleaseDate = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 34)) {
+          auto str = _internal_mutable_biosreleasedate();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.biosReleaseDate"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string systemManufacturer = 5;
+      case 5:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 42)) {
+          auto str = _internal_mutable_systemmanufacturer();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.systemManufacturer"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string systemProductName = 6;
+      case 6:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 50)) {
+          auto str = _internal_mutable_systemproductname();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.systemProductName"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string systemSerialNumber = 7;
+      case 7:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 58)) {
+          auto str = _internal_mutable_systemserialnumber();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.systemSerialNumber"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string systemUuid = 8;
+      case 8:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 66)) {
+          auto str = _internal_mutable_systemuuid();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.systemUuid"));
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -4592,6 +4710,66 @@ failure:
         2, this->_internal_biosversion(), target);
   }
 
+  // string biosVendor = 3;
+  if (this->biosvendor().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_biosvendor().data(), static_cast<int>(this->_internal_biosvendor().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.biosVendor");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_biosvendor(), target);
+  }
+
+  // string biosReleaseDate = 4;
+  if (this->biosreleasedate().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_biosreleasedate().data(), static_cast<int>(this->_internal_biosreleasedate().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.biosReleaseDate");
+    target = stream->WriteStringMaybeAliased(
+        4, this->_internal_biosreleasedate(), target);
+  }
+
+  // string systemManufacturer = 5;
+  if (this->systemmanufacturer().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_systemmanufacturer().data(), static_cast<int>(this->_internal_systemmanufacturer().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.systemManufacturer");
+    target = stream->WriteStringMaybeAliased(
+        5, this->_internal_systemmanufacturer(), target);
+  }
+
+  // string systemProductName = 6;
+  if (this->systemproductname().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_systemproductname().data(), static_cast<int>(this->_internal_systemproductname().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.systemProductName");
+    target = stream->WriteStringMaybeAliased(
+        6, this->_internal_systemproductname(), target);
+  }
+
+  // string systemSerialNumber = 7;
+  if (this->systemserialnumber().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_systemserialnumber().data(), static_cast<int>(this->_internal_systemserialnumber().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.systemSerialNumber");
+    target = stream->WriteStringMaybeAliased(
+        7, this->_internal_systemserialnumber(), target);
+  }
+
+  // string systemUuid = 8;
+  if (this->systemuuid().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_systemuuid().data(), static_cast<int>(this->_internal_systemuuid().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.systemUuid");
+    target = stream->WriteStringMaybeAliased(
+        8, this->_internal_systemuuid(), target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -4620,6 +4798,48 @@ size_t SystemInfoResponse_Result_Data::ByteSizeLong() const {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
         this->_internal_biosversion());
+  }
+
+  // string biosVendor = 3;
+  if (this->biosvendor().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_biosvendor());
+  }
+
+  // string biosReleaseDate = 4;
+  if (this->biosreleasedate().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_biosreleasedate());
+  }
+
+  // string systemManufacturer = 5;
+  if (this->systemmanufacturer().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_systemmanufacturer());
+  }
+
+  // string systemProductName = 6;
+  if (this->systemproductname().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_systemproductname());
+  }
+
+  // string systemSerialNumber = 7;
+  if (this->systemserialnumber().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_systemserialnumber());
+  }
+
+  // string systemUuid = 8;
+  if (this->systemuuid().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_systemuuid());
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -4659,6 +4879,24 @@ void SystemInfoResponse_Result_Data::MergeFrom(const SystemInfoResponse_Result_D
   if (from.biosversion().size() > 0) {
     _internal_set_biosversion(from._internal_biosversion());
   }
+  if (from.biosvendor().size() > 0) {
+    _internal_set_biosvendor(from._internal_biosvendor());
+  }
+  if (from.biosreleasedate().size() > 0) {
+    _internal_set_biosreleasedate(from._internal_biosreleasedate());
+  }
+  if (from.systemmanufacturer().size() > 0) {
+    _internal_set_systemmanufacturer(from._internal_systemmanufacturer());
+  }
+  if (from.systemproductname().size() > 0) {
+    _internal_set_systemproductname(from._internal_systemproductname());
+  }
+  if (from.systemserialnumber().size() > 0) {
+    _internal_set_systemserialnumber(from._internal_systemserialnumber());
+  }
+  if (from.systemuuid().size() > 0) {
+    _internal_set_systemuuid(from._internal_systemuuid());
+  }
 }
 
 void SystemInfoResponse_Result_Data::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
@@ -4684,6 +4922,12 @@ void SystemInfoResponse_Result_Data::InternalSwap(SystemInfoResponse_Result_Data
   _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
   version_.Swap(&other->version_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   biosversion_.Swap(&other->biosversion_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  biosvendor_.Swap(&other->biosvendor_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  biosreleasedate_.Swap(&other->biosreleasedate_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  systemmanufacturer_.Swap(&other->systemmanufacturer_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  systemproductname_.Swap(&other->systemproductname_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  systemserialnumber_.Swap(&other->systemserialnumber_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  systemuuid_.Swap(&other->systemuuid_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata SystemInfoResponse_Result_Data::GetMetadata() const {

--- a/proto/generated/cpp/cli.pb.cc
+++ b/proto/generated/cpp/cli.pb.cc
@@ -72,7 +72,10 @@ constexpr SystemInfoResponse_Result_Data::SystemInfoResponse_Result_Data(
   , baseboardmanufacturer_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
   , baseboardproductname_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
   , baseboardserialnumber_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
-  , baseboardversion_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string){}
+  , baseboardversion_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , processormanufacturer_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , processorversion_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , processorfrequency_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string){}
 struct SystemInfoResponse_Result_DataDefaultTypeInternal {
   constexpr SystemInfoResponse_Result_DataDefaultTypeInternal()
     : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
@@ -1906,6 +1909,9 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_cli_2eproto::offsets[] PROTOBU
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, baseboardproductname_),
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, baseboardserialnumber_),
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, baseboardversion_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, processormanufacturer_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, processorversion_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result_Data, processorfrequency_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::grpc_cli::SystemInfoResponse_Result, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -2936,131 +2942,131 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 15, -1, sizeof(::grpc_cli::PosInfo)},
   { 21, -1, sizeof(::grpc_cli::SystemInfoRequest)},
   { 29, -1, sizeof(::grpc_cli::SystemInfoResponse_Result_Data)},
-  { 46, -1, sizeof(::grpc_cli::SystemInfoResponse_Result)},
-  { 53, -1, sizeof(::grpc_cli::SystemInfoResponse)},
-  { 62, -1, sizeof(::grpc_cli::SystemStopRequest)},
-  { 70, -1, sizeof(::grpc_cli::SystemStopResponse_Result)},
-  { 76, -1, sizeof(::grpc_cli::SystemStopResponse)},
-  { 85, -1, sizeof(::grpc_cli::GetSystemPropertyRequest)},
-  { 93, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result_Data)},
-  { 99, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result)},
-  { 106, -1, sizeof(::grpc_cli::GetSystemPropertyResponse)},
-  { 115, -1, sizeof(::grpc_cli::SetSystemPropertyRequest_Param)},
-  { 121, -1, sizeof(::grpc_cli::SetSystemPropertyRequest)},
-  { 130, -1, sizeof(::grpc_cli::SetSystemPropertyResponse_Result)},
-  { 136, -1, sizeof(::grpc_cli::SetSystemPropertyResponse)},
-  { 145, -1, sizeof(::grpc_cli::StartTelemetryRequest)},
-  { 153, -1, sizeof(::grpc_cli::StartTelemetryResponse_Result)},
-  { 159, -1, sizeof(::grpc_cli::StartTelemetryResponse)},
-  { 168, -1, sizeof(::grpc_cli::StopTelemetryRequest)},
-  { 176, -1, sizeof(::grpc_cli::StopTelemetryResponse_Result)},
-  { 182, -1, sizeof(::grpc_cli::StopTelemetryResponse)},
-  { 191, -1, sizeof(::grpc_cli::ResetEventWrrRequest)},
-  { 199, -1, sizeof(::grpc_cli::ResetEventWrrResponse_Result)},
-  { 205, -1, sizeof(::grpc_cli::ResetEventWrrResponse)},
-  { 214, -1, sizeof(::grpc_cli::ResetMbrRequest)},
-  { 222, -1, sizeof(::grpc_cli::ResetMbrResponse_Result)},
-  { 228, -1, sizeof(::grpc_cli::ResetMbrResponse)},
-  { 237, -1, sizeof(::grpc_cli::StopRebuildingRequest_Param)},
-  { 243, -1, sizeof(::grpc_cli::StopRebuildingRequest)},
-  { 252, -1, sizeof(::grpc_cli::StopRebuildingResponse_Result)},
-  { 258, -1, sizeof(::grpc_cli::StopRebuildingResponse)},
-  { 267, -1, sizeof(::grpc_cli::UpdateEventWrrRequest_Param)},
-  { 274, -1, sizeof(::grpc_cli::UpdateEventWrrRequest)},
-  { 283, -1, sizeof(::grpc_cli::UpdateEventWrrResponse_Result)},
-  { 289, -1, sizeof(::grpc_cli::UpdateEventWrrResponse)},
-  { 298, -1, sizeof(::grpc_cli::AddSpareRequest_SpareDeviceName)},
-  { 304, -1, sizeof(::grpc_cli::AddSpareRequest_Param)},
-  { 311, -1, sizeof(::grpc_cli::AddSpareRequest)},
-  { 320, -1, sizeof(::grpc_cli::AddSpareResponse_Result)},
-  { 326, -1, sizeof(::grpc_cli::AddSpareResponse)},
-  { 335, -1, sizeof(::grpc_cli::DeviceNameList)},
-  { 341, -1, sizeof(::grpc_cli::RemoveSpareRequest_SpareDeviceName)},
-  { 347, -1, sizeof(::grpc_cli::RemoveSpareRequest_Param)},
-  { 354, -1, sizeof(::grpc_cli::RemoveSpareRequest)},
-  { 363, -1, sizeof(::grpc_cli::RemoveSpareResponse_Result)},
-  { 369, -1, sizeof(::grpc_cli::RemoveSpareResponse)},
-  { 378, -1, sizeof(::grpc_cli::CreateArrayRequest_Param)},
-  { 388, -1, sizeof(::grpc_cli::CreateArrayRequest)},
-  { 397, -1, sizeof(::grpc_cli::CreateArrayResponse_Result)},
-  { 403, -1, sizeof(::grpc_cli::CreateArrayResponse)},
-  { 412, -1, sizeof(::grpc_cli::AutocreateArrayRequest_Param)},
-  { 422, -1, sizeof(::grpc_cli::AutocreateArrayRequest)},
-  { 431, -1, sizeof(::grpc_cli::AutocreateArrayResponse_Result)},
-  { 437, -1, sizeof(::grpc_cli::AutocreateArrayResponse)},
-  { 446, -1, sizeof(::grpc_cli::DeleteArrayRequest_Param)},
-  { 452, -1, sizeof(::grpc_cli::DeleteArrayRequest)},
-  { 461, -1, sizeof(::grpc_cli::DeleteArrayResponse_Result)},
-  { 467, -1, sizeof(::grpc_cli::DeleteArrayResponse)},
-  { 476, 483, sizeof(::grpc_cli::MountArrayRequest_Param)},
-  { 485, -1, sizeof(::grpc_cli::MountArrayRequest)},
-  { 494, -1, sizeof(::grpc_cli::MountArrayResponse_Result)},
-  { 500, -1, sizeof(::grpc_cli::MountArrayResponse)},
-  { 509, -1, sizeof(::grpc_cli::UnmountArrayRequest_Param)},
-  { 515, -1, sizeof(::grpc_cli::UnmountArrayRequest)},
-  { 524, -1, sizeof(::grpc_cli::UnmountArrayResponse_Result)},
-  { 530, -1, sizeof(::grpc_cli::UnmountArrayResponse)},
-  { 539, -1, sizeof(::grpc_cli::Array)},
-  { 560, -1, sizeof(::grpc_cli::ListArrayRequest)},
-  { 568, -1, sizeof(::grpc_cli::ListArrayResponse_Result_ArrayList)},
-  { 574, -1, sizeof(::grpc_cli::ListArrayResponse_Result)},
-  { 581, -1, sizeof(::grpc_cli::ListArrayResponse)},
-  { 590, -1, sizeof(::grpc_cli::ArrayInfoRequest_Param)},
-  { 596, -1, sizeof(::grpc_cli::ArrayInfoRequest)},
-  { 605, -1, sizeof(::grpc_cli::ArrayInfoResponse_Result)},
-  { 612, -1, sizeof(::grpc_cli::ArrayInfoResponse)},
-  { 621, -1, sizeof(::grpc_cli::ListNodeRequest)},
-  { 629, -1, sizeof(::grpc_cli::ListNodeResponse_Result_Node)},
-  { 637, -1, sizeof(::grpc_cli::ListNodeResponse_Result)},
-  { 644, -1, sizeof(::grpc_cli::ListNodeResponse)},
-  { 653, -1, sizeof(::grpc_cli::ListHaVolumeRequest)},
-  { 661, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result_Volume)},
-  { 672, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result)},
-  { 679, -1, sizeof(::grpc_cli::ListHaVolumeResponse)},
-  { 688, -1, sizeof(::grpc_cli::ListHaReplicationRequest)},
-  { 696, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result_Replication)},
-  { 706, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result)},
-  { 713, -1, sizeof(::grpc_cli::ListHaReplicationResponse)},
-  { 722, -1, sizeof(::grpc_cli::StartHaReplicationRequest_Param)},
-  { 737, -1, sizeof(::grpc_cli::StartHaReplicationRequest)},
-  { 746, -1, sizeof(::grpc_cli::StartHaReplicationResponse_Result)},
-  { 752, -1, sizeof(::grpc_cli::StartHaReplicationResponse)},
-  { 761, -1, sizeof(::grpc_cli::SetLogLevelRequest_Param)},
-  { 767, -1, sizeof(::grpc_cli::SetLogLevelRequest)},
-  { 776, -1, sizeof(::grpc_cli::SetLogLevelResponse_Result)},
-  { 782, -1, sizeof(::grpc_cli::SetLogLevelResponse)},
-  { 791, -1, sizeof(::grpc_cli::SetLogPreferenceRequest_Param)},
-  { 797, -1, sizeof(::grpc_cli::SetLogPreferenceRequest)},
-  { 806, -1, sizeof(::grpc_cli::SetLogPreferenceResponse_Result)},
-  { 812, -1, sizeof(::grpc_cli::SetLogPreferenceResponse)},
-  { 821, -1, sizeof(::grpc_cli::LoggerInfoRequest)},
-  { 829, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result_LoggerInfo)},
-  { 843, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result)},
-  { 850, -1, sizeof(::grpc_cli::LoggerInfoResponse)},
-  { 859, -1, sizeof(::grpc_cli::GetLogLevelRequest)},
-  { 867, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result_LogLevel)},
-  { 873, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result)},
-  { 880, -1, sizeof(::grpc_cli::GetLogLevelResponse)},
-  { 889, -1, sizeof(::grpc_cli::ApplyLogFilterRequest)},
-  { 897, -1, sizeof(::grpc_cli::ApplyLogFilterResponse_Result)},
-  { 903, -1, sizeof(::grpc_cli::ApplyLogFilterResponse)},
-  { 912, -1, sizeof(::grpc_cli::CreateDeviceRequest_Param)},
-  { 922, -1, sizeof(::grpc_cli::CreateDeviceRequest)},
-  { 931, -1, sizeof(::grpc_cli::CreateDeviceResponse_Result)},
-  { 937, -1, sizeof(::grpc_cli::CreateDeviceResponse)},
-  { 946, -1, sizeof(::grpc_cli::ScanDeviceRequest)},
-  { 954, -1, sizeof(::grpc_cli::ScanDeviceResponse_Result)},
-  { 960, -1, sizeof(::grpc_cli::ScanDeviceResponse)},
-  { 969, -1, sizeof(::grpc_cli::Device)},
-  { 982, -1, sizeof(::grpc_cli::ListDeviceRequest)},
-  { 990, -1, sizeof(::grpc_cli::ListDeviceResponse_Result_DeviceList)},
-  { 996, -1, sizeof(::grpc_cli::ListDeviceResponse_Result)},
-  { 1003, -1, sizeof(::grpc_cli::ListDeviceResponse)},
-  { 1012, -1, sizeof(::grpc_cli::SmartLog)},
-  { 1039, -1, sizeof(::grpc_cli::GetSmartLogRequest_Param)},
-  { 1045, -1, sizeof(::grpc_cli::GetSmartLogRequest)},
-  { 1054, -1, sizeof(::grpc_cli::GetSmartLogResponse_Result)},
-  { 1061, -1, sizeof(::grpc_cli::GetSmartLogResponse)},
+  { 49, -1, sizeof(::grpc_cli::SystemInfoResponse_Result)},
+  { 56, -1, sizeof(::grpc_cli::SystemInfoResponse)},
+  { 65, -1, sizeof(::grpc_cli::SystemStopRequest)},
+  { 73, -1, sizeof(::grpc_cli::SystemStopResponse_Result)},
+  { 79, -1, sizeof(::grpc_cli::SystemStopResponse)},
+  { 88, -1, sizeof(::grpc_cli::GetSystemPropertyRequest)},
+  { 96, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result_Data)},
+  { 102, -1, sizeof(::grpc_cli::GetSystemPropertyResponse_Result)},
+  { 109, -1, sizeof(::grpc_cli::GetSystemPropertyResponse)},
+  { 118, -1, sizeof(::grpc_cli::SetSystemPropertyRequest_Param)},
+  { 124, -1, sizeof(::grpc_cli::SetSystemPropertyRequest)},
+  { 133, -1, sizeof(::grpc_cli::SetSystemPropertyResponse_Result)},
+  { 139, -1, sizeof(::grpc_cli::SetSystemPropertyResponse)},
+  { 148, -1, sizeof(::grpc_cli::StartTelemetryRequest)},
+  { 156, -1, sizeof(::grpc_cli::StartTelemetryResponse_Result)},
+  { 162, -1, sizeof(::grpc_cli::StartTelemetryResponse)},
+  { 171, -1, sizeof(::grpc_cli::StopTelemetryRequest)},
+  { 179, -1, sizeof(::grpc_cli::StopTelemetryResponse_Result)},
+  { 185, -1, sizeof(::grpc_cli::StopTelemetryResponse)},
+  { 194, -1, sizeof(::grpc_cli::ResetEventWrrRequest)},
+  { 202, -1, sizeof(::grpc_cli::ResetEventWrrResponse_Result)},
+  { 208, -1, sizeof(::grpc_cli::ResetEventWrrResponse)},
+  { 217, -1, sizeof(::grpc_cli::ResetMbrRequest)},
+  { 225, -1, sizeof(::grpc_cli::ResetMbrResponse_Result)},
+  { 231, -1, sizeof(::grpc_cli::ResetMbrResponse)},
+  { 240, -1, sizeof(::grpc_cli::StopRebuildingRequest_Param)},
+  { 246, -1, sizeof(::grpc_cli::StopRebuildingRequest)},
+  { 255, -1, sizeof(::grpc_cli::StopRebuildingResponse_Result)},
+  { 261, -1, sizeof(::grpc_cli::StopRebuildingResponse)},
+  { 270, -1, sizeof(::grpc_cli::UpdateEventWrrRequest_Param)},
+  { 277, -1, sizeof(::grpc_cli::UpdateEventWrrRequest)},
+  { 286, -1, sizeof(::grpc_cli::UpdateEventWrrResponse_Result)},
+  { 292, -1, sizeof(::grpc_cli::UpdateEventWrrResponse)},
+  { 301, -1, sizeof(::grpc_cli::AddSpareRequest_SpareDeviceName)},
+  { 307, -1, sizeof(::grpc_cli::AddSpareRequest_Param)},
+  { 314, -1, sizeof(::grpc_cli::AddSpareRequest)},
+  { 323, -1, sizeof(::grpc_cli::AddSpareResponse_Result)},
+  { 329, -1, sizeof(::grpc_cli::AddSpareResponse)},
+  { 338, -1, sizeof(::grpc_cli::DeviceNameList)},
+  { 344, -1, sizeof(::grpc_cli::RemoveSpareRequest_SpareDeviceName)},
+  { 350, -1, sizeof(::grpc_cli::RemoveSpareRequest_Param)},
+  { 357, -1, sizeof(::grpc_cli::RemoveSpareRequest)},
+  { 366, -1, sizeof(::grpc_cli::RemoveSpareResponse_Result)},
+  { 372, -1, sizeof(::grpc_cli::RemoveSpareResponse)},
+  { 381, -1, sizeof(::grpc_cli::CreateArrayRequest_Param)},
+  { 391, -1, sizeof(::grpc_cli::CreateArrayRequest)},
+  { 400, -1, sizeof(::grpc_cli::CreateArrayResponse_Result)},
+  { 406, -1, sizeof(::grpc_cli::CreateArrayResponse)},
+  { 415, -1, sizeof(::grpc_cli::AutocreateArrayRequest_Param)},
+  { 425, -1, sizeof(::grpc_cli::AutocreateArrayRequest)},
+  { 434, -1, sizeof(::grpc_cli::AutocreateArrayResponse_Result)},
+  { 440, -1, sizeof(::grpc_cli::AutocreateArrayResponse)},
+  { 449, -1, sizeof(::grpc_cli::DeleteArrayRequest_Param)},
+  { 455, -1, sizeof(::grpc_cli::DeleteArrayRequest)},
+  { 464, -1, sizeof(::grpc_cli::DeleteArrayResponse_Result)},
+  { 470, -1, sizeof(::grpc_cli::DeleteArrayResponse)},
+  { 479, 486, sizeof(::grpc_cli::MountArrayRequest_Param)},
+  { 488, -1, sizeof(::grpc_cli::MountArrayRequest)},
+  { 497, -1, sizeof(::grpc_cli::MountArrayResponse_Result)},
+  { 503, -1, sizeof(::grpc_cli::MountArrayResponse)},
+  { 512, -1, sizeof(::grpc_cli::UnmountArrayRequest_Param)},
+  { 518, -1, sizeof(::grpc_cli::UnmountArrayRequest)},
+  { 527, -1, sizeof(::grpc_cli::UnmountArrayResponse_Result)},
+  { 533, -1, sizeof(::grpc_cli::UnmountArrayResponse)},
+  { 542, -1, sizeof(::grpc_cli::Array)},
+  { 563, -1, sizeof(::grpc_cli::ListArrayRequest)},
+  { 571, -1, sizeof(::grpc_cli::ListArrayResponse_Result_ArrayList)},
+  { 577, -1, sizeof(::grpc_cli::ListArrayResponse_Result)},
+  { 584, -1, sizeof(::grpc_cli::ListArrayResponse)},
+  { 593, -1, sizeof(::grpc_cli::ArrayInfoRequest_Param)},
+  { 599, -1, sizeof(::grpc_cli::ArrayInfoRequest)},
+  { 608, -1, sizeof(::grpc_cli::ArrayInfoResponse_Result)},
+  { 615, -1, sizeof(::grpc_cli::ArrayInfoResponse)},
+  { 624, -1, sizeof(::grpc_cli::ListNodeRequest)},
+  { 632, -1, sizeof(::grpc_cli::ListNodeResponse_Result_Node)},
+  { 640, -1, sizeof(::grpc_cli::ListNodeResponse_Result)},
+  { 647, -1, sizeof(::grpc_cli::ListNodeResponse)},
+  { 656, -1, sizeof(::grpc_cli::ListHaVolumeRequest)},
+  { 664, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result_Volume)},
+  { 675, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result)},
+  { 682, -1, sizeof(::grpc_cli::ListHaVolumeResponse)},
+  { 691, -1, sizeof(::grpc_cli::ListHaReplicationRequest)},
+  { 699, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result_Replication)},
+  { 709, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result)},
+  { 716, -1, sizeof(::grpc_cli::ListHaReplicationResponse)},
+  { 725, -1, sizeof(::grpc_cli::StartHaReplicationRequest_Param)},
+  { 740, -1, sizeof(::grpc_cli::StartHaReplicationRequest)},
+  { 749, -1, sizeof(::grpc_cli::StartHaReplicationResponse_Result)},
+  { 755, -1, sizeof(::grpc_cli::StartHaReplicationResponse)},
+  { 764, -1, sizeof(::grpc_cli::SetLogLevelRequest_Param)},
+  { 770, -1, sizeof(::grpc_cli::SetLogLevelRequest)},
+  { 779, -1, sizeof(::grpc_cli::SetLogLevelResponse_Result)},
+  { 785, -1, sizeof(::grpc_cli::SetLogLevelResponse)},
+  { 794, -1, sizeof(::grpc_cli::SetLogPreferenceRequest_Param)},
+  { 800, -1, sizeof(::grpc_cli::SetLogPreferenceRequest)},
+  { 809, -1, sizeof(::grpc_cli::SetLogPreferenceResponse_Result)},
+  { 815, -1, sizeof(::grpc_cli::SetLogPreferenceResponse)},
+  { 824, -1, sizeof(::grpc_cli::LoggerInfoRequest)},
+  { 832, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result_LoggerInfo)},
+  { 846, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result)},
+  { 853, -1, sizeof(::grpc_cli::LoggerInfoResponse)},
+  { 862, -1, sizeof(::grpc_cli::GetLogLevelRequest)},
+  { 870, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result_LogLevel)},
+  { 876, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result)},
+  { 883, -1, sizeof(::grpc_cli::GetLogLevelResponse)},
+  { 892, -1, sizeof(::grpc_cli::ApplyLogFilterRequest)},
+  { 900, -1, sizeof(::grpc_cli::ApplyLogFilterResponse_Result)},
+  { 906, -1, sizeof(::grpc_cli::ApplyLogFilterResponse)},
+  { 915, -1, sizeof(::grpc_cli::CreateDeviceRequest_Param)},
+  { 925, -1, sizeof(::grpc_cli::CreateDeviceRequest)},
+  { 934, -1, sizeof(::grpc_cli::CreateDeviceResponse_Result)},
+  { 940, -1, sizeof(::grpc_cli::CreateDeviceResponse)},
+  { 949, -1, sizeof(::grpc_cli::ScanDeviceRequest)},
+  { 957, -1, sizeof(::grpc_cli::ScanDeviceResponse_Result)},
+  { 963, -1, sizeof(::grpc_cli::ScanDeviceResponse)},
+  { 972, -1, sizeof(::grpc_cli::Device)},
+  { 985, -1, sizeof(::grpc_cli::ListDeviceRequest)},
+  { 993, -1, sizeof(::grpc_cli::ListDeviceResponse_Result_DeviceList)},
+  { 999, -1, sizeof(::grpc_cli::ListDeviceResponse_Result)},
+  { 1006, -1, sizeof(::grpc_cli::ListDeviceResponse)},
+  { 1015, -1, sizeof(::grpc_cli::SmartLog)},
+  { 1042, -1, sizeof(::grpc_cli::GetSmartLogRequest_Param)},
+  { 1048, -1, sizeof(::grpc_cli::GetSmartLogRequest)},
+  { 1057, -1, sizeof(::grpc_cli::GetSmartLogResponse_Result)},
+  { 1064, -1, sizeof(::grpc_cli::GetSmartLogResponse)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -3204,411 +3210,413 @@ const char descriptor_table_protodef_cli_2eproto[] PROTOBUF_SECTION_VARIABLE(pro
   "tionB\010\n\006_causeB\013\n\t_solution\"\032\n\007PosInfo\022\017"
   "\n\007version\030\001 \001(\t\"D\n\021SystemInfoRequest\022\017\n\007"
   "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030"
-  "\003 \001(\t\"\246\004\n\022SystemInfoResponse\022\017\n\007command\030"
+  "\003 \001(\t\"\373\004\n\022SystemInfoResponse\022\017\n\007command\030"
   "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grp"
   "c_cli.SystemInfoResponse.Result\022\037\n\004info\030"
-  "\004 \001(\0132\021.grpc_cli.PosInfo\032\233\003\n\006Result\022 \n\006s"
+  "\004 \001(\0132\021.grpc_cli.PosInfo\032\360\003\n\006Result\022 \n\006s"
   "tatus\030\001 \001(\0132\020.grpc_cli.Status\0226\n\004data\030\002 "
   "\001(\0132(.grpc_cli.SystemInfoResponse.Result"
-  ".Data\032\266\002\n\004Data\022\017\n\007version\030\001 \001(\t\022\023\n\013biosV"
+  ".Data\032\213\003\n\004Data\022\017\n\007version\030\001 \001(\t\022\023\n\013biosV"
   "ersion\030\002 \001(\t\022\022\n\nbiosVendor\030\003 \001(\t\022\027\n\017bios"
   "ReleaseDate\030\004 \001(\t\022\032\n\022systemManufacturer\030"
   "\005 \001(\t\022\031\n\021systemProductName\030\006 \001(\t\022\032\n\022syst"
   "emSerialNumber\030\007 \001(\t\022\022\n\nsystemUuid\030\010 \001(\t"
   "\022\035\n\025baseboardManufacturer\030\t \001(\t\022\034\n\024baseb"
   "oardProductName\030\n \001(\t\022\035\n\025baseboardSerial"
-  "Number\030\013 \001(\t\022\030\n\020baseboardVersion\030\014 \001(\t\"D"
-  "\n\021SystemStopRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003"
-  "rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\264\001\n\022SystemS"
-  "topResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001("
-  "\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.SystemStopR"
+  "Number\030\013 \001(\t\022\030\n\020baseboardVersion\030\014 \001(\t\022\035"
+  "\n\025processorManufacturer\030\r \001(\t\022\030\n\020process"
+  "orVersion\030\016 \001(\t\022\032\n\022processorFrequency\030\017 "
+  "\001(\t\"D\n\021SystemStopRequest\022\017\n\007command\030\001 \001("
+  "\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\264\001\n\022Sy"
+  "stemStopResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
+  "\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.System"
+  "StopResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc"
+  "_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020"
+  ".grpc_cli.Status\"K\n\030GetSystemPropertyReq"
+  "uest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tre"
+  "questor\030\003 \001(\t\"\242\002\n\031GetSystemPropertyRespo"
+  "nse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022:\n\006res"
+  "ult\030\003 \001(\0132*.grpc_cli.GetSystemPropertyRe"
+  "sponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.P"
+  "osInfo\032\211\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc"
+  "_cli.Status\022=\n\004data\030\002 \001(\0132/.grpc_cli.Get"
+  "SystemPropertyResponse.Result.Data\032\036\n\004Da"
+  "ta\022\026\n\016rebuild_policy\030\001 \001(\t\"\234\001\n\030SetSystem"
+  "PropertyRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
+  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0227\n\005param\030\004 \001(\0132"
+  "(.grpc_cli.SetSystemPropertyRequest.Para"
+  "m\032\026\n\005Param\022\r\n\005level\030\001 \001(\t\"\302\001\n\031SetSystemP"
+  "ropertyResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
+  "\002 \001(\t\022:\n\006result\030\003 \001(\0132*.grpc_cli.SetSyst"
+  "emPropertyResponse.Result\022\037\n\004info\030\004 \001(\0132"
+  "\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001"
+  " \001(\0132\020.grpc_cli.Status\"H\n\025StartTelemetry"
+  "Request\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n"
+  "\trequestor\030\003 \001(\t\"\274\001\n\026StartTelemetryRespo"
+  "nse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006res"
+  "ult\030\003 \001(\0132\'.grpc_cli.StartTelemetryRespo"
+  "nse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosI"
+  "nfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli"
+  ".Status\"G\n\024StopTelemetryRequest\022\017\n\007comma"
+  "nd\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t"
+  "\"\272\001\n\025StopTelemetryResponse\022\017\n\007command\030\001 "
+  "\001(\t\022\013\n\003rid\030\002 \001(\t\0226\n\006result\030\003 \001(\0132&.grpc_"
+  "cli.StopTelemetryResponse.Result\022\037\n\004info"
+  "\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006s"
+  "tatus\030\001 \001(\0132\020.grpc_cli.Status\"G\n\024ResetEv"
+  "entWrrRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 "
+  "\001(\t\022\021\n\trequestor\030\003 \001(\t\"\272\001\n\025ResetEventWrr"
+  "Response\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0226"
+  "\n\006result\030\003 \001(\0132&.grpc_cli.ResetEventWrrR"
   "esponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli."
   "PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc"
-  "_cli.Status\"K\n\030GetSystemPropertyRequest\022"
-  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequest"
-  "or\030\003 \001(\t\"\242\002\n\031GetSystemPropertyResponse\022\017"
-  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022:\n\006result\030\003"
-  " \001(\0132*.grpc_cli.GetSystemPropertyRespons"
-  "e.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInf"
-  "o\032\211\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli."
-  "Status\022=\n\004data\030\002 \001(\0132/.grpc_cli.GetSyste"
-  "mPropertyResponse.Result.Data\032\036\n\004Data\022\026\n"
-  "\016rebuild_policy\030\001 \001(\t\"\234\001\n\030SetSystemPrope"
-  "rtyRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t"
-  "\022\021\n\trequestor\030\003 \001(\t\0227\n\005param\030\004 \001(\0132(.grp"
-  "c_cli.SetSystemPropertyRequest.Param\032\026\n\005"
-  "Param\022\r\n\005level\030\001 \001(\t\"\302\001\n\031SetSystemProper"
-  "tyResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t"
-  "\022:\n\006result\030\003 \001(\0132*.grpc_cli.SetSystemPro"
-  "pertyResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grp"
+  "_cli.Status\"B\n\017ResetMbrRequest\022\017\n\007comman"
+  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\""
+  "\260\001\n\020ResetMbrResponse\022\017\n\007command\030\001 \001(\t\022\013\n"
+  "\003rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cli.Re"
+  "setMbrResponse.Result\022\037\n\004info\030\004 \001(\0132\021.gr"
+  "pc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\013"
+  "2\020.grpc_cli.Status\"\225\001\n\025StopRebuildingReq"
+  "uest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tre"
+  "questor\030\003 \001(\t\0224\n\005param\030\004 \001(\0132%.grpc_cli."
+  "StopRebuildingRequest.Param\032\025\n\005Param\022\014\n\004"
+  "name\030\001 \001(\t\"\274\001\n\026StopRebuildingResponse\022\017\n"
+  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 "
+  "\001(\0132\'.grpc_cli.StopRebuildingResponse.Re"
+  "sult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n"
+  "\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Statu"
+  "s\"\245\001\n\025UpdateEventWrrRequest\022\017\n\007command\030\001"
+  " \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0224\n\005"
+  "param\030\004 \001(\0132%.grpc_cli.UpdateEventWrrReq"
+  "uest.Param\032%\n\005Param\022\014\n\004name\030\001 \001(\t\022\016\n\006wei"
+  "ght\030\002 \001(\003\"\274\001\n\026UpdateEventWrrResponse\022\017\n\007"
+  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001"
+  "(\0132\'.grpc_cli.UpdateEventWrrResponse.Res"
+  "ult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006"
+  "Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status"
+  "\"\353\001\n\017AddSpareRequest\022\017\n\007command\030\001 \001(\t\022\013\n"
+  "\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022.\n\005param\030\004"
+  " \001(\0132\037.grpc_cli.AddSpareRequest.Param\032%\n"
+  "\017SpareDeviceName\022\022\n\ndeviceName\030\001 \001(\t\032P\n\005"
+  "Param\022\r\n\005array\030\001 \001(\t\0228\n\005spare\030\003 \003(\0132).gr"
+  "pc_cli.AddSpareRequest.SpareDeviceName\"\260"
+  "\001\n\020AddSpareResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003"
+  "rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cli.Add"
+  "SpareResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grp"
   "c_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132"
-  "\020.grpc_cli.Status\"H\n\025StartTelemetryReque"
-  "st\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequ"
-  "estor\030\003 \001(\t\"\274\001\n\026StartTelemetryResponse\022\017"
-  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003"
-  " \001(\0132\'.grpc_cli.StartTelemetryResponse.R"
+  "\020.grpc_cli.Status\"$\n\016DeviceNameList\022\022\n\nd"
+  "eviceName\030\001 \001(\t\"\364\001\n\022RemoveSpareRequest\022\017"
+  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequesto"
+  "r\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.Remove"
+  "SpareRequest.Param\032%\n\017SpareDeviceName\022\022\n"
+  "\ndeviceName\030\001 \001(\t\032S\n\005Param\022\r\n\005array\030\001 \001("
+  "\t\022;\n\005spare\030\002 \003(\0132,.grpc_cli.RemoveSpareR"
+  "equest.SpareDeviceName\"\266\001\n\023RemoveSpareRe"
+  "sponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006"
+  "result\030\003 \001(\0132$.grpc_cli.RemoveSpareRespo"
+  "nse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosI"
+  "nfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli"
+  ".Status\"\235\002\n\022CreateArrayRequest\022\017\n\007comman"
+  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022"
+  "1\n\005param\030\004 \001(\0132\".grpc_cli.CreateArrayReq"
+  "uest.Param\032\242\001\n\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006bu"
+  "ffer\030\002 \003(\0132\030.grpc_cli.DeviceNameList\022&\n\004"
+  "data\030\003 \003(\0132\030.grpc_cli.DeviceNameList\022\'\n\005"
+  "spare\030\004 \003(\0132\030.grpc_cli.DeviceNameList\022\020\n"
+  "\010raidtype\030\005 \001(\t\"\266\001\n\023CreateArrayResponse\022"
+  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030"
+  "\003 \001(\0132$.grpc_cli.CreateArrayResponse.Res"
+  "ult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006"
+  "Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status"
+  "\"\366\001\n\026AutocreateArrayRequest\022\017\n\007command\030\001"
+  " \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0225\n\005"
+  "param\030\004 \001(\0132&.grpc_cli.AutocreateArrayRe"
+  "quest.Param\032t\n\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006bu"
+  "ffer\030\002 \003(\0132\030.grpc_cli.DeviceNameList\022\017\n\007"
+  "numData\030\003 \001(\005\022\020\n\010numSpare\030\004 \001(\005\022\020\n\010raidt"
+  "ype\030\005 \001(\t\"\276\001\n\027AutocreateArrayResponse\022\017\n"
+  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0228\n\006result\030\003 "
+  "\001(\0132(.grpc_cli.AutocreateArrayResponse.R"
   "esult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*"
   "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
-  "us\"G\n\024StopTelemetryRequest\022\017\n\007command\030\001 "
-  "\001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\272\001\n\025"
-  "StopTelemetryResponse\022\017\n\007command\030\001 \001(\t\022\013"
-  "\n\003rid\030\002 \001(\t\0226\n\006result\030\003 \001(\0132&.grpc_cli.S"
-  "topTelemetryResponse.Result\022\037\n\004info\030\004 \001("
-  "\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006status"
-  "\030\001 \001(\0132\020.grpc_cli.Status\"G\n\024ResetEventWr"
-  "rRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021"
-  "\n\trequestor\030\003 \001(\t\"\272\001\n\025ResetEventWrrRespo"
-  "nse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0226\n\006res"
-  "ult\030\003 \001(\0132&.grpc_cli.ResetEventWrrRespon"
-  "se.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosIn"
-  "fo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli."
-  "Status\"B\n\017ResetMbrRequest\022\017\n\007command\030\001 \001"
-  "(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\260\001\n\020R"
-  "esetMbrResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cli.ResetMb"
-  "rResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cl"
-  "i.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.gr"
-  "pc_cli.Status\"\225\001\n\025StopRebuildingRequest\022"
-  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequest"
-  "or\030\003 \001(\t\0224\n\005param\030\004 \001(\0132%.grpc_cli.StopR"
-  "ebuildingRequest.Param\032\025\n\005Param\022\014\n\004name\030"
-  "\001 \001(\t\"\274\001\n\026StopRebuildingResponse\022\017\n\007comm"
-  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'"
-  ".grpc_cli.StopRebuildingResponse.Result\022"
-  "\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Resu"
-  "lt\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\245\001\n"
-  "\025UpdateEventWrrRequest\022\017\n\007command\030\001 \001(\t\022"
-  "\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0224\n\005param"
-  "\030\004 \001(\0132%.grpc_cli.UpdateEventWrrRequest."
-  "Param\032%\n\005Param\022\014\n\004name\030\001 \001(\t\022\016\n\006weight\030\002"
-  " \001(\003\"\274\001\n\026UpdateEventWrrResponse\022\017\n\007comma"
-  "nd\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'."
-  "grpc_cli.UpdateEventWrrResponse.Result\022\037"
-  "\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Resul"
-  "t\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\353\001\n\017"
-  "AddSpareRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022.\n\005param\030\004 \001(\0132"
-  "\037.grpc_cli.AddSpareRequest.Param\032%\n\017Spar"
-  "eDeviceName\022\022\n\ndeviceName\030\001 \001(\t\032P\n\005Param"
-  "\022\r\n\005array\030\001 \001(\t\0228\n\005spare\030\003 \003(\0132).grpc_cl"
-  "i.AddSpareRequest.SpareDeviceName\"\260\001\n\020Ad"
-  "dSpareResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
-  " \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cli.AddSpare"
-  "Response.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli"
-  ".PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grp"
-  "c_cli.Status\"$\n\016DeviceNameList\022\022\n\ndevice"
-  "Name\030\001 \001(\t\"\364\001\n\022RemoveSpareRequest\022\017\n\007com"
-  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001"
-  "(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.RemoveSpare"
-  "Request.Param\032%\n\017SpareDeviceName\022\022\n\ndevi"
-  "ceName\030\001 \001(\t\032S\n\005Param\022\r\n\005array\030\001 \001(\t\022;\n\005"
-  "spare\030\002 \003(\0132,.grpc_cli.RemoveSpareReques"
-  "t.SpareDeviceName\"\266\001\n\023RemoveSpareRespons"
-  "e\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006resul"
-  "t\030\003 \001(\0132$.grpc_cli.RemoveSpareResponse.R"
-  "esult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*"
-  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
-  "us\"\235\002\n\022CreateArrayRequest\022\017\n\007command\030\001 \001"
+  "us\"\217\001\n\022DeleteArrayRequest\022\017\n\007command\030\001 \001"
   "(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005pa"
-  "ram\030\004 \001(\0132\".grpc_cli.CreateArrayRequest."
-  "Param\032\242\001\n\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006buffer\030"
-  "\002 \003(\0132\030.grpc_cli.DeviceNameList\022&\n\004data\030"
-  "\003 \003(\0132\030.grpc_cli.DeviceNameList\022\'\n\005spare"
-  "\030\004 \003(\0132\030.grpc_cli.DeviceNameList\022\020\n\010raid"
-  "type\030\005 \001(\t\"\266\001\n\023CreateArrayResponse\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\013"
-  "2$.grpc_cli.CreateArrayResponse.Result\022\037"
-  "\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Resul"
-  "t\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\366\001\n\026"
-  "AutocreateArrayRequest\022\017\n\007command\030\001 \001(\t\022"
-  "\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0225\n\005param"
-  "\030\004 \001(\0132&.grpc_cli.AutocreateArrayRequest"
-  ".Param\032t\n\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006buffer\030"
-  "\002 \003(\0132\030.grpc_cli.DeviceNameList\022\017\n\007numDa"
-  "ta\030\003 \001(\005\022\020\n\010numSpare\030\004 \001(\005\022\020\n\010raidtype\030\005"
-  " \001(\t\"\276\001\n\027AutocreateArrayResponse\022\017\n\007comm"
-  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0228\n\006result\030\003 \001(\0132("
-  ".grpc_cli.AutocreateArrayResponse.Result"
-  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Res"
-  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\217\001"
-  "\n\022DeleteArrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n"
-  "\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005param\030\004"
-  " \001(\0132\".grpc_cli.DeleteArrayRequest.Param"
-  "\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\266\001\n\023DeleteArrayR"
-  "esponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n"
-  "\006result\030\003 \001(\0132$.grpc_cli.DeleteArrayResp"
-  "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
-  "Info\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
-  "i.Status\"\305\001\n\021MountArrayRequest\022\017\n\007comman"
-  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022"
-  "0\n\005param\030\004 \001(\0132!.grpc_cli.MountArrayRequ"
-  "est.Param\032M\n\005Param\022\014\n\004name\030\001 \001(\t\022\037\n\022enab"
-  "leWriteThrough\030\002 \001(\010H\000\210\001\001B\025\n\023_enableWrit"
-  "eThrough\"\264\001\n\022MountArrayResponse\022\017\n\007comma"
-  "nd\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#."
-  "grpc_cli.MountArrayResponse.Result\022\037\n\004in"
-  "fo\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n"
-  "\006status\030\001 \001(\0132\020.grpc_cli.Status\"\221\001\n\023Unmo"
-  "untArrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005param\030\004 \001(\0132"
-  "#.grpc_cli.UnmountArrayRequest.Param\032\025\n\005"
-  "Param\022\014\n\004name\030\001 \001(\t\"\270\001\n\024UnmountArrayResp"
-  "onse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006re"
-  "sult\030\003 \001(\0132%.grpc_cli.UnmountArrayRespon"
-  "se.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosIn"
-  "fo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli."
-  "Status\"\314\002\n\005Array\022\r\n\005index\030\001 \001(\005\022\021\n\tuniqu"
-  "e_id\030\002 \001(\005\022\014\n\004name\030\003 \001(\t\022\016\n\006status\030\004 \001(\t"
-  "\022\r\n\005state\030\005 \001(\t\022\021\n\tsituation\030\006 \001(\t\022\026\n\016cr"
-  "eateDatetime\030\007 \001(\t\022\026\n\016updateDatetime\030\010 \001"
-  "(\t\022\032\n\022rebuildingProgress\030\t \001(\t\022\020\n\010capaci"
-  "ty\030\n \001(\004\022\014\n\004used\030\013 \001(\004\022\016\n\006gcMode\030\014 \001(\t\022\020"
-  "\n\010metaRaid\030\r \001(\t\022\020\n\010dataRaid\030\016 \001(\t\022\033\n\023wr"
-  "iteThroughEnabled\030\017 \001(\010\022$\n\ndevicelist\030\020 "
-  "\003(\0132\020.grpc_cli.Device\"C\n\020ListArrayReques"
-  "t\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treque"
-  "stor\030\003 \001(\t\"\240\002\n\021ListArrayResponse\022\017\n\007comm"
-  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003 \001(\0132\""
-  ".grpc_cli.ListArrayResponse.Result\022\037\n\004in"
-  "fo\030\004 \001(\0132\021.grpc_cli.PosInfo\032\227\001\n\006Result\022 "
-  "\n\006status\030\001 \001(\0132\020.grpc_cli.Status\022:\n\004data"
-  "\030\002 \001(\0132,.grpc_cli.ListArrayResponse.Resu"
-  "lt.ArrayList\032/\n\tArrayList\022\"\n\tarrayList\030\001"
-  " \003(\0132\017.grpc_cli.Array\"\213\001\n\020ArrayInfoReque"
-  "st\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequ"
-  "estor\030\003 \001(\t\022/\n\005param\030\004 \001(\0132 .grpc_cli.Ar"
-  "rayInfoRequest.Param\032\025\n\005Param\022\014\n\004name\030\001 "
-  "\001(\t\"\321\001\n\021ArrayInfoResponse\022\017\n\007command\030\001 \001"
-  "(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003 \001(\0132\".grpc_c"
-  "li.ArrayInfoResponse.Result\022\037\n\004info\030\004 \001("
-  "\0132\021.grpc_cli.PosInfo\032I\n\006Result\022 \n\006status"
-  "\030\001 \001(\0132\020.grpc_cli.Status\022\035\n\004data\030\002 \001(\0132\017"
-  ".grpc_cli.Array\"B\n\017ListNodeRequest\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 "
-  "\001(\t\"\233\002\n\020ListNodeResponse\022\017\n\007command\030\001 \001("
-  "\t\022\013\n\003rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cl"
-  "i.ListNodeResponse.Result\022\037\n\004info\030\004 \001(\0132"
-  "\021.grpc_cli.PosInfo\032\224\001\n\006Result\022 \n\006status\030"
-  "\001 \001(\0132\020.grpc_cli.Status\0224\n\004data\030\002 \003(\0132&."
-  "grpc_cli.ListNodeResponse.Result.Node\0322\n"
-  "\004Node\022\014\n\004name\030\001 \001(\t\022\n\n\002ip\030\002 \001(\t\022\020\n\010lasts"
-  "een\030\003 \001(\t\"F\n\023ListHaVolumeRequest\022\017\n\007comm"
-  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001("
-  "\t\"\336\002\n\024ListHaVolumeResponse\022\017\n\007command\030\001 "
-  "\001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001(\0132%.grpc_"
-  "cli.ListHaVolumeResponse.Result\022\037\n\004info\030"
-  "\004 \001(\0132\021.grpc_cli.PosInfo\032\317\001\n\006Result\022 \n\006s"
-  "tatus\030\001 \001(\0132\020.grpc_cli.Status\022:\n\004data\030\002 "
-  "\003(\0132,.grpc_cli.ListHaVolumeResponse.Resu"
-  "lt.Volume\032g\n\006Volume\022\n\n\002id\030\001 \001(\005\022\014\n\004name\030"
-  "\002 \001(\t\022\020\n\010nodeName\030\003 \001(\t\022\021\n\tarrayName\030\004 \001"
-  "(\t\022\014\n\004size\030\005 \001(\003\022\020\n\010lastseen\030\006 \001(\t\"K\n\030Li"
-  "stHaReplicationRequest\022\017\n\007command\030\001 \001(\t\022"
-  "\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\226\003\n\031List"
-  "HaReplicationResponse\022\017\n\007command\030\001 \001(\t\022\013"
-  "\n\003rid\030\002 \001(\t\022:\n\006result\030\003 \001(\0132*.grpc_cli.L"
-  "istHaReplicationResponse.Result\022\037\n\004info\030"
-  "\004 \001(\0132\021.grpc_cli.PosInfo\032\375\001\n\006Result\022 \n\006s"
-  "tatus\030\001 \001(\0132\020.grpc_cli.Status\022D\n\004data\030\002 "
-  "\003(\01326.grpc_cli.ListHaReplicationResponse"
-  ".Result.Replication\032\212\001\n\013Replication\022\n\n\002i"
-  "d\030\001 \001(\005\022\026\n\016sourceVolumeId\030\002 \001(\005\022\032\n\022sourc"
-  "eWalVolume_id\030\003 \001(\005\022\033\n\023destinationVolume"
-  "Id\030\004 \001(\005\022\036\n\026destinationWalVolumeId\030\005 \001(\005"
-  "\"\223\003\n\031StartHaReplicationRequest\022\017\n\007comman"
-  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022"
-  "8\n\005param\030\004 \001(\0132).grpc_cli.StartHaReplica"
-  "tionRequest.Param\032\212\002\n\005Param\022\027\n\017primaryNo"
-  "deName\030\001 \001(\t\022\030\n\020primaryArrayName\030\002 \001(\t\022\031"
-  "\n\021primaryVolumeName\030\003 \001(\t\022\034\n\024primaryWalV"
-  "olumeName\030\004 \001(\t\022\031\n\021secondaryNodeName\030\005 \001"
-  "(\t\022\032\n\022secondaryArrayName\030\006 \001(\t\022\033\n\023second"
-  "aryVolumeName\030\007 \001(\t\022\036\n\026secondaryWalVolum"
-  "eName\030\010 \001(\t\022\016\n\006stuats\030\t \001(\t\022\021\n\ttimestamp"
-  "\030\n \001(\t\"\304\001\n\032StartHaReplicationResponse\022\017\n"
-  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022;\n\006result\030\003 "
-  "\001(\0132+.grpc_cli.StartHaReplicationRespons"
-  "e.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInf"
-  "o\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.S"
-  "tatus\"\220\001\n\022SetLogLevelRequest\022\017\n\007command\030"
-  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n"
-  "\005param\030\004 \001(\0132\".grpc_cli.SetLogLevelReque"
-  "st.Param\032\026\n\005Param\022\r\n\005level\030\001 \001(\t\"\266\001\n\023Set"
-  "LogLevelResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
-  "\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.SetLog"
-  "LevelResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grp"
-  "c_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132"
-  "\020.grpc_cli.Status\"\246\001\n\027SetLogPreferenceRe"
-  "quest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tr"
-  "equestor\030\003 \001(\t\0226\n\005param\030\004 \001(\0132\'.grpc_cli"
-  ".SetLogPreferenceRequest.Param\032\"\n\005Param\022"
-  "\031\n\021structuredLogging\030\001 \001(\t\"\300\001\n\030SetLogPre"
-  "ferenceResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\0229\n\006result\030\003 \001(\0132).grpc_cli.SetLogP"
-  "referenceResponse.Result\022\037\n\004info\030\004 \001(\0132\021"
-  ".grpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 "
-  "\001(\0132\020.grpc_cli.Status\"D\n\021LoggerInfoReque"
-  "st\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequ"
-  "estor\030\003 \001(\t\"\345\003\n\022LoggerInfoResponse\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\013"
-  "2#.grpc_cli.LoggerInfoResponse.Result\022\037\n"
-  "\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\332\002\n\006Resul"
-  "t\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022<\n\004d"
-  "ata\030\002 \001(\0132..grpc_cli.LoggerInfoResponse."
-  "Result.LoggerInfo\032\357\001\n\nLoggerInfo\022\024\n\014mino"
-  "rLogPath\030\001 \001(\t\022\024\n\014majorLogPath\030\002 \001(\t\022\027\n\017"
-  "logfileSizeInMb\030\003 \001(\t\022\034\n\024logfileRotation"
-  "Count\030\004 \001(\005\022\034\n\024minAllowableLogLevel\030\005 \001("
-  "\t\022\025\n\rfilterEnabled\030\006 \001(\005\022\026\n\016filterInclud"
-  "ed\030\007 \001(\t\022\026\n\016filterExcluded\030\010 \001(\t\022\031\n\021stru"
-  "cturedLogging\030\t \001(\010\"E\n\022GetLogLevelReques"
-  "t\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treque"
-  "stor\030\003 \001(\t\"\217\002\n\023GetLogLevelResponse\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\013"
-  "2$.grpc_cli.GetLogLevelResponse.Result\022\037"
-  "\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\202\001\n\006Resu"
-  "lt\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022;\n\004"
-  "data\030\002 \001(\0132-.grpc_cli.GetLogLevelRespons"
-  "e.Result.LogLevel\032\031\n\010LogLevel\022\r\n\005level\030\001"
-  " \001(\t\"H\n\025ApplyLogFilterRequest\022\017\n\007command"
-  "\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\274"
-  "\001\n\026ApplyLogFilterResponse\022\017\n\007command\030\001 \001"
-  "(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'.grpc_c"
-  "li.ApplyLogFilterResponse.Result\022\037\n\004info"
-  "\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006s"
-  "tatus\030\001 \001(\0132\020.grpc_cli.Status\"\326\001\n\023Create"
-  "DeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 "
-  "\001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005param\030\004 \001(\0132#."
-  "grpc_cli.CreateDeviceRequest.Param\032Z\n\005Pa"
-  "ram\022\014\n\004name\030\001 \001(\t\022\021\n\tnumBlocks\030\002 \001(\r\022\021\n\t"
-  "blockSize\030\003 \001(\r\022\017\n\007devType\030\004 \001(\t\022\014\n\004numa"
-  "\030\005 \001(\r\"\270\001\n\024CreateDeviceResponse\022\017\n\007comma"
+  "ram\030\004 \001(\0132\".grpc_cli.DeleteArrayRequest."
+  "Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\266\001\n\023DeleteA"
+  "rrayResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001"
+  "(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.DeleteArra"
+  "yResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cl"
+  "i.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.gr"
+  "pc_cli.Status\"\305\001\n\021MountArrayRequest\022\017\n\007c"
+  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003"
+  " \001(\t\0220\n\005param\030\004 \001(\0132!.grpc_cli.MountArra"
+  "yRequest.Param\032M\n\005Param\022\014\n\004name\030\001 \001(\t\022\037\n"
+  "\022enableWriteThrough\030\002 \001(\010H\000\210\001\001B\025\n\023_enabl"
+  "eWriteThrough\"\264\001\n\022MountArrayResponse\022\017\n\007"
+  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001"
+  "(\0132#.grpc_cli.MountArrayResponse.Result\022"
+  "\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Resu"
+  "lt\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\221\001\n"
+  "\023UnmountArrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n"
+  "\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005param\030\004"
+  " \001(\0132#.grpc_cli.UnmountArrayRequest.Para"
+  "m\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\270\001\n\024UnmountArra"
+  "yResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022"
+  "5\n\006result\030\003 \001(\0132%.grpc_cli.UnmountArrayR"
+  "esponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli."
+  "PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc"
+  "_cli.Status\"\314\002\n\005Array\022\r\n\005index\030\001 \001(\005\022\021\n\t"
+  "unique_id\030\002 \001(\005\022\014\n\004name\030\003 \001(\t\022\016\n\006status\030"
+  "\004 \001(\t\022\r\n\005state\030\005 \001(\t\022\021\n\tsituation\030\006 \001(\t\022"
+  "\026\n\016createDatetime\030\007 \001(\t\022\026\n\016updateDatetim"
+  "e\030\010 \001(\t\022\032\n\022rebuildingProgress\030\t \001(\t\022\020\n\010c"
+  "apacity\030\n \001(\004\022\014\n\004used\030\013 \001(\004\022\016\n\006gcMode\030\014 "
+  "\001(\t\022\020\n\010metaRaid\030\r \001(\t\022\020\n\010dataRaid\030\016 \001(\t\022"
+  "\033\n\023writeThroughEnabled\030\017 \001(\010\022$\n\ndeviceli"
+  "st\030\020 \003(\0132\020.grpc_cli.Device\"C\n\020ListArrayR"
+  "equest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\t"
+  "requestor\030\003 \001(\t\"\240\002\n\021ListArrayResponse\022\017\n"
+  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003 "
+  "\001(\0132\".grpc_cli.ListArrayResponse.Result\022"
+  "\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\227\001\n\006Res"
+  "ult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022:\n"
+  "\004data\030\002 \001(\0132,.grpc_cli.ListArrayResponse"
+  ".Result.ArrayList\032/\n\tArrayList\022\"\n\tarrayL"
+  "ist\030\001 \003(\0132\017.grpc_cli.Array\"\213\001\n\020ArrayInfo"
+  "Request\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n"
+  "\trequestor\030\003 \001(\t\022/\n\005param\030\004 \001(\0132 .grpc_c"
+  "li.ArrayInfoRequest.Param\032\025\n\005Param\022\014\n\004na"
+  "me\030\001 \001(\t\"\321\001\n\021ArrayInfoResponse\022\017\n\007comman"
+  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003 \001(\0132\".g"
+  "rpc_cli.ArrayInfoResponse.Result\022\037\n\004info"
+  "\030\004 \001(\0132\021.grpc_cli.PosInfo\032I\n\006Result\022 \n\006s"
+  "tatus\030\001 \001(\0132\020.grpc_cli.Status\022\035\n\004data\030\002 "
+  "\001(\0132\017.grpc_cli.Array\"B\n\017ListNodeRequest\022"
+  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequest"
+  "or\030\003 \001(\t\"\233\002\n\020ListNodeResponse\022\017\n\007command"
+  "\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.gr"
+  "pc_cli.ListNodeResponse.Result\022\037\n\004info\030\004"
+  " \001(\0132\021.grpc_cli.PosInfo\032\224\001\n\006Result\022 \n\006st"
+  "atus\030\001 \001(\0132\020.grpc_cli.Status\0224\n\004data\030\002 \003"
+  "(\0132&.grpc_cli.ListNodeResponse.Result.No"
+  "de\0322\n\004Node\022\014\n\004name\030\001 \001(\t\022\n\n\002ip\030\002 \001(\t\022\020\n\010"
+  "lastseen\030\003 \001(\t\"F\n\023ListHaVolumeRequest\022\017\n"
+  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor"
+  "\030\003 \001(\t\"\336\002\n\024ListHaVolumeResponse\022\017\n\007comma"
   "nd\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001(\0132%."
-  "grpc_cli.CreateDeviceResponse.Result\022\037\n\004"
-  "info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022"
-  " \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"D\n\021Sca"
-  "nDeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
-  " \001(\t\022\021\n\trequestor\030\003 \001(\t\"\264\001\n\022ScanDeviceRe"
+  "grpc_cli.ListHaVolumeResponse.Result\022\037\n\004"
+  "info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\317\001\n\006Result"
+  "\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022:\n\004da"
+  "ta\030\002 \003(\0132,.grpc_cli.ListHaVolumeResponse"
+  ".Result.Volume\032g\n\006Volume\022\n\n\002id\030\001 \001(\005\022\014\n\004"
+  "name\030\002 \001(\t\022\020\n\010nodeName\030\003 \001(\t\022\021\n\tarrayNam"
+  "e\030\004 \001(\t\022\014\n\004size\030\005 \001(\003\022\020\n\010lastseen\030\006 \001(\t\""
+  "K\n\030ListHaReplicationRequest\022\017\n\007command\030\001"
+  " \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\226\003\n"
+  "\031ListHaReplicationResponse\022\017\n\007command\030\001 "
+  "\001(\t\022\013\n\003rid\030\002 \001(\t\022:\n\006result\030\003 \001(\0132*.grpc_"
+  "cli.ListHaReplicationResponse.Result\022\037\n\004"
+  "info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\375\001\n\006Result"
+  "\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022D\n\004da"
+  "ta\030\002 \003(\01326.grpc_cli.ListHaReplicationRes"
+  "ponse.Result.Replication\032\212\001\n\013Replication"
+  "\022\n\n\002id\030\001 \001(\005\022\026\n\016sourceVolumeId\030\002 \001(\005\022\032\n\022"
+  "sourceWalVolume_id\030\003 \001(\005\022\033\n\023destinationV"
+  "olumeId\030\004 \001(\005\022\036\n\026destinationWalVolumeId\030"
+  "\005 \001(\005\"\223\003\n\031StartHaReplicationRequest\022\017\n\007c"
+  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003"
+  " \001(\t\0228\n\005param\030\004 \001(\0132).grpc_cli.StartHaRe"
+  "plicationRequest.Param\032\212\002\n\005Param\022\027\n\017prim"
+  "aryNodeName\030\001 \001(\t\022\030\n\020primaryArrayName\030\002 "
+  "\001(\t\022\031\n\021primaryVolumeName\030\003 \001(\t\022\034\n\024primar"
+  "yWalVolumeName\030\004 \001(\t\022\031\n\021secondaryNodeNam"
+  "e\030\005 \001(\t\022\032\n\022secondaryArrayName\030\006 \001(\t\022\033\n\023s"
+  "econdaryVolumeName\030\007 \001(\t\022\036\n\026secondaryWal"
+  "VolumeName\030\010 \001(\t\022\016\n\006stuats\030\t \001(\t\022\021\n\ttime"
+  "stamp\030\n \001(\t\"\304\001\n\032StartHaReplicationRespon"
+  "se\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022;\n\006resu"
+  "lt\030\003 \001(\0132+.grpc_cli.StartHaReplicationRe"
+  "sponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.P"
+  "osInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_"
+  "cli.Status\"\220\001\n\022SetLogLevelRequest\022\017\n\007com"
+  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001"
+  "(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.SetLogLevel"
+  "Request.Param\032\026\n\005Param\022\r\n\005level\030\001 \001(\t\"\266\001"
+  "\n\023SetLogLevelResponse\022\017\n\007command\030\001 \001(\t\022\013"
+  "\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.S"
+  "etLogLevelResponse.Result\022\037\n\004info\030\004 \001(\0132"
+  "\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001"
+  " \001(\0132\020.grpc_cli.Status\"\246\001\n\027SetLogPrefere"
+  "nceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t"
+  "\022\021\n\trequestor\030\003 \001(\t\0226\n\005param\030\004 \001(\0132\'.grp"
+  "c_cli.SetLogPreferenceRequest.Param\032\"\n\005P"
+  "aram\022\031\n\021structuredLogging\030\001 \001(\t\"\300\001\n\030SetL"
+  "ogPreferenceResponse\022\017\n\007command\030\001 \001(\t\022\013\n"
+  "\003rid\030\002 \001(\t\0229\n\006result\030\003 \001(\0132).grpc_cli.Se"
+  "tLogPreferenceResponse.Result\022\037\n\004info\030\004 "
+  "\001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006stat"
+  "us\030\001 \001(\0132\020.grpc_cli.Status\"D\n\021LoggerInfo"
+  "Request\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n"
+  "\trequestor\030\003 \001(\t\"\345\003\n\022LoggerInfoResponse\022"
+  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030"
+  "\003 \001(\0132#.grpc_cli.LoggerInfoResponse.Resu"
+  "lt\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\332\002\n\006"
+  "Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status"
+  "\022<\n\004data\030\002 \001(\0132..grpc_cli.LoggerInfoResp"
+  "onse.Result.LoggerInfo\032\357\001\n\nLoggerInfo\022\024\n"
+  "\014minorLogPath\030\001 \001(\t\022\024\n\014majorLogPath\030\002 \001("
+  "\t\022\027\n\017logfileSizeInMb\030\003 \001(\t\022\034\n\024logfileRot"
+  "ationCount\030\004 \001(\005\022\034\n\024minAllowableLogLevel"
+  "\030\005 \001(\t\022\025\n\rfilterEnabled\030\006 \001(\005\022\026\n\016filterI"
+  "ncluded\030\007 \001(\t\022\026\n\016filterExcluded\030\010 \001(\t\022\031\n"
+  "\021structuredLogging\030\t \001(\010\"E\n\022GetLogLevelR"
+  "equest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\t"
+  "requestor\030\003 \001(\t\"\217\002\n\023GetLogLevelResponse\022"
+  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030"
+  "\003 \001(\0132$.grpc_cli.GetLogLevelResponse.Res"
+  "ult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\202\001\n"
+  "\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Statu"
+  "s\022;\n\004data\030\002 \001(\0132-.grpc_cli.GetLogLevelRe"
+  "sponse.Result.LogLevel\032\031\n\010LogLevel\022\r\n\005le"
+  "vel\030\001 \001(\t\"H\n\025ApplyLogFilterRequest\022\017\n\007co"
+  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 "
+  "\001(\t\"\274\001\n\026ApplyLogFilterResponse\022\017\n\007comman"
+  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'.g"
+  "rpc_cli.ApplyLogFilterResponse.Result\022\037\n"
+  "\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result"
+  "\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\326\001\n\023C"
+  "reateDeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003r"
+  "id\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005param\030\004 \001"
+  "(\0132#.grpc_cli.CreateDeviceRequest.Param\032"
+  "Z\n\005Param\022\014\n\004name\030\001 \001(\t\022\021\n\tnumBlocks\030\002 \001("
+  "\r\022\021\n\tblockSize\030\003 \001(\r\022\017\n\007devType\030\004 \001(\t\022\014\n"
+  "\004numa\030\005 \001(\r\"\270\001\n\024CreateDeviceResponse\022\017\n\007"
+  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001"
+  "(\0132%.grpc_cli.CreateDeviceResponse.Resul"
+  "t\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Re"
+  "sult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"D"
+  "\n\021ScanDeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003"
+  "rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\264\001\n\022ScanDev"
+  "iceResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001("
+  "\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.ScanDeviceR"
+  "esponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli."
+  "PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc"
+  "_cli.Status\"\213\001\n\006Device\022\014\n\004name\030\001 \001(\t\022\014\n\004"
+  "type\030\002 \001(\t\022\017\n\007address\030\003 \001(\t\022\r\n\005class\030\004 \001"
+  "(\t\022\023\n\013modelNumber\030\005 \001(\t\022\014\n\004numa\030\006 \001(\t\022\014\n"
+  "\004size\030\007 \001(\004\022\024\n\014serialNumber\030\010 \001(\t\"D\n\021Lis"
+  "tDeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
+  " \001(\t\022\021\n\trequestor\030\003 \001(\t\"\247\002\n\022ListDeviceRe"
   "sponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006"
-  "result\030\003 \001(\0132#.grpc_cli.ScanDeviceRespon"
+  "result\030\003 \001(\0132#.grpc_cli.ListDeviceRespon"
   "se.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosIn"
-  "fo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli."
-  "Status\"\213\001\n\006Device\022\014\n\004name\030\001 \001(\t\022\014\n\004type\030"
-  "\002 \001(\t\022\017\n\007address\030\003 \001(\t\022\r\n\005class\030\004 \001(\t\022\023\n"
-  "\013modelNumber\030\005 \001(\t\022\014\n\004numa\030\006 \001(\t\022\014\n\004size"
-  "\030\007 \001(\004\022\024\n\014serialNumber\030\010 \001(\t\"D\n\021ListDevi"
-  "ceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022"
-  "\021\n\trequestor\030\003 \001(\t\"\247\002\n\022ListDeviceRespons"
-  "e\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006resul"
-  "t\030\003 \001(\0132#.grpc_cli.ListDeviceResponse.Re"
-  "sult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\234\001"
-  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
-  "us\022<\n\004data\030\002 \001(\0132..grpc_cli.ListDeviceRe"
-  "sponse.Result.DeviceList\0322\n\nDeviceList\022$"
-  "\n\ndevicelist\030\001 \003(\0132\020.grpc_cli.Device\"\335\004\n"
-  "\010SmartLog\022\033\n\023availableSpareSpace\030\001 \001(\t\022\023"
-  "\n\013temperature\030\002 \001(\t\022\031\n\021deviceReliability"
-  "\030\003 \001(\t\022\020\n\010readOnly\030\004 \001(\t\022\034\n\024volatileMemo"
-  "ryBackup\030\005 \001(\t\022\032\n\022currentTemperature\030\006 \001"
-  "(\t\022\026\n\016availableSpare\030\007 \001(\t\022\037\n\027availableS"
-  "pareThreshold\030\010 \001(\t\022\032\n\022lifePercentageUse"
-  "d\030\t \001(\t\022\025\n\rdataUnitsRead\030\n \001(\t\022\030\n\020dataUn"
-  "itsWritten\030\013 \001(\t\022\030\n\020hostReadCommands\030\014 \001"
-  "(\t\022\031\n\021hostWriteCommands\030\r \001(\t\022\032\n\022control"
-  "lerBusyTime\030\016 \001(\t\022\023\n\013powerCycles\030\017 \001(\t\022\024"
-  "\n\014powerOnHours\030\020 \001(\t\022\027\n\017unsafeShutdowns\030"
-  "\021 \001(\t\022 \n\030unrecoverableMediaErrors\030\022 \001(\t\022"
-  "\037\n\027lifetimeErrorLogEntries\030\023 \001(\t\022\036\n\026warn"
-  "ingTemperatureTime\030\024 \001(\t\022\037\n\027criticalTemp"
-  "eratureTime\030\025 \001(\t\022\031\n\021temperatureSensor\030\026"
-  " \003(\t\"\217\001\n\022GetSmartLogRequest\022\017\n\007command\030\001"
-  " \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005"
-  "param\030\004 \001(\0132\".grpc_cli.GetSmartLogReques"
-  "t.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\330\001\n\023GetSm"
-  "artLogResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
-  " \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.GetSmart"
-  "LogResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_"
-  "cli.PosInfo\032L\n\006Result\022 \n\006status\030\001 \001(\0132\020."
-  "grpc_cli.Status\022 \n\004data\030\002 \001(\0132\022.grpc_cli"
-  ".SmartLog2\221\026\n\006PosCli\022_\n\nSystemInfo\022\033.grp"
-  "c_cli.SystemInfoRequest\032\034.grpc_cli.Syste"
-  "mInfoResponse\"\026\202\323\344\223\002\020\022\016/v1/systeminfo\022_\n"
-  "\nSystemStop\022\033.grpc_cli.SystemStopRequest"
-  "\032\034.grpc_cli.SystemStopResponse\"\026\202\323\344\223\002\020\022\016"
-  "/v1/systemstop\022}\n\021GetSystemProperty\022\".gr"
-  "pc_cli.GetSystemPropertyRequest\032#.grpc_c"
-  "li.GetSystemPropertyResponse\"\037\202\323\344\223\002\031\022\027/v"
-  "1/get_system_property\022\205\001\n\021SetSystemPrope"
-  "rty\022\".grpc_cli.SetSystemPropertyRequest\032"
-  "#.grpc_cli.SetSystemPropertyResponse\"\'\202\323"
-  "\344\223\002!\022\037/v1/set_system_property/{level}\022p\n"
-  "\016StartTelemetry\022\037.grpc_cli.StartTelemetr"
-  "yRequest\032 .grpc_cli.StartTelemetryRespon"
-  "se\"\033\202\323\344\223\002\025\022\023/v1/start_telemetry\022l\n\rStopT"
-  "elemetry\022\036.grpc_cli.StopTelemetryRequest"
-  "\032\037.grpc_cli.StopTelemetryResponse\"\032\202\323\344\223\002"
-  "\024\022\022/v1/stop_telemetry\022P\n\rResetEventWrr\022\036"
-  ".grpc_cli.ResetEventWrrRequest\032\037.grpc_cl"
-  "i.ResetEventWrrResponse\022A\n\010ResetMbr\022\031.gr"
-  "pc_cli.ResetMbrRequest\032\032.grpc_cli.ResetM"
-  "brResponse\022S\n\016StopRebuilding\022\037.grpc_cli."
-  "StopRebuildingRequest\032 .grpc_cli.StopReb"
-  "uildingResponse\022S\n\016UpdateEventWrr\022\037.grpc"
-  "_cli.UpdateEventWrrRequest\032 .grpc_cli.Up"
-  "dateEventWrrResponse\022W\n\010AddSpare\022\031.grpc_"
-  "cli.AddSpareRequest\032\032.grpc_cli.AddSpareR"
-  "esponse\"\024\202\323\344\223\002\016\"\014/v1/addspare\022c\n\013RemoveS"
-  "pare\022\034.grpc_cli.RemoveSpareRequest\032\035.grp"
-  "c_cli.RemoveSpareResponse\"\027\202\323\344\223\002\021\"\017/v1/r"
-  "emovespare\022c\n\013CreateArray\022\034.grpc_cli.Cre"
-  "ateArrayRequest\032\035.grpc_cli.CreateArrayRe"
-  "sponse\"\027\202\323\344\223\002\021\"\017/v1/createarray\022s\n\017Autoc"
-  "reateArray\022 .grpc_cli.AutocreateArrayReq"
-  "uest\032!.grpc_cli.AutocreateArrayResponse\""
-  "\033\202\323\344\223\002\025\"\023/v1/autocreatearray\022d\n\013DeleteAr"
-  "ray\022\034.grpc_cli.DeleteArrayRequest\032\035.grpc"
-  "_cli.DeleteArrayResponse\"\030\202\323\344\223\002\022\"\020/v1/de"
-  "letearray/\022_\n\nMountArray\022\033.grpc_cli.Moun"
-  "tArrayRequest\032\034.grpc_cli.MountArrayRespo"
-  "nse\"\026\202\323\344\223\002\020\"\016/v1/mountarray\022g\n\014UnmountAr"
-  "ray\022\035.grpc_cli.UnmountArrayRequest\032\036.grp"
-  "c_cli.UnmountArrayResponse\"\030\202\323\344\223\002\022\"\020/v1/"
-  "unmountarray\022[\n\tListArray\022\032.grpc_cli.Lis"
-  "tArrayRequest\032\033.grpc_cli.ListArrayRespon"
-  "se\"\025\202\323\344\223\002\017\"\r/v1/listarray\022[\n\tArrayInfo\022\032"
-  ".grpc_cli.ArrayInfoRequest\032\033.grpc_cli.Ar"
-  "rayInfoResponse\"\025\202\323\344\223\002\017\"\r/v1/arrayinfo\022w"
-  "\n\020SetLogPreference\022!.grpc_cli.SetLogPref"
-  "erenceRequest\032\".grpc_cli.SetLogPreferenc"
-  "eResponse\"\034\202\323\344\223\002\026\"\024/v1/setlogpreference\022"
-  "c\n\013SetLogLevel\022\034.grpc_cli.SetLogLevelReq"
-  "uest\032\035.grpc_cli.SetLogLevelResponse\"\027\202\323\344"
-  "\223\002\021\"\017/v1/setloglevel\022_\n\nLoggerInfo\022\033.grp"
-  "c_cli.LoggerInfoRequest\032\034.grpc_cli.Logge"
-  "rInfoResponse\"\026\202\323\344\223\002\020\"\016/v1/loggerinfo\022c\n"
-  "\013GetLogLevel\022\034.grpc_cli.GetLogLevelReque"
-  "st\032\035.grpc_cli.GetLogLevelResponse\"\027\202\323\344\223\002"
-  "\021\"\017/v1/getloglevel\022l\n\016ApplyLogFilter\022\037.g"
-  "rpc_cli.ApplyLogFilterRequest\032 .grpc_cli"
-  ".ApplyLogFilterResponse\"\027\202\323\344\223\002\021\"\017/v1/app"
-  "lyfilter\022g\n\014CreateDevice\022\035.grpc_cli.Crea"
-  "teDeviceRequest\032\036.grpc_cli.CreateDeviceR"
-  "esponse\"\030\202\323\344\223\002\022\"\020/v1/createdevice\022_\n\nSca"
-  "nDevice\022\033.grpc_cli.ScanDeviceRequest\032\034.g"
-  "rpc_cli.ScanDeviceResponse\"\026\202\323\344\223\002\020\"\016/v1/"
-  "scandevice\022_\n\nListDevice\022\033.grpc_cli.List"
-  "DeviceRequest\032\034.grpc_cli.ListDeviceRespo"
-  "nse\"\026\202\323\344\223\002\020\"\016/v1/listdevice\022`\n\013GetSmartL"
-  "og\022\034.grpc_cli.GetSmartLogRequest\032\035.grpc_"
-  "cli.GetSmartLogResponse\"\024\202\323\344\223\002\016\"\014/v1/sma"
-  "rtlogB\tZ\007cli/apib\006proto3"
+  "fo\032\234\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli"
+  ".Status\022<\n\004data\030\002 \001(\0132..grpc_cli.ListDev"
+  "iceResponse.Result.DeviceList\0322\n\nDeviceL"
+  "ist\022$\n\ndevicelist\030\001 \003(\0132\020.grpc_cli.Devic"
+  "e\"\335\004\n\010SmartLog\022\033\n\023availableSpareSpace\030\001 "
+  "\001(\t\022\023\n\013temperature\030\002 \001(\t\022\031\n\021deviceReliab"
+  "ility\030\003 \001(\t\022\020\n\010readOnly\030\004 \001(\t\022\034\n\024volatil"
+  "eMemoryBackup\030\005 \001(\t\022\032\n\022currentTemperatur"
+  "e\030\006 \001(\t\022\026\n\016availableSpare\030\007 \001(\t\022\037\n\027avail"
+  "ableSpareThreshold\030\010 \001(\t\022\032\n\022lifePercenta"
+  "geUsed\030\t \001(\t\022\025\n\rdataUnitsRead\030\n \001(\t\022\030\n\020d"
+  "ataUnitsWritten\030\013 \001(\t\022\030\n\020hostReadCommand"
+  "s\030\014 \001(\t\022\031\n\021hostWriteCommands\030\r \001(\t\022\032\n\022co"
+  "ntrollerBusyTime\030\016 \001(\t\022\023\n\013powerCycles\030\017 "
+  "\001(\t\022\024\n\014powerOnHours\030\020 \001(\t\022\027\n\017unsafeShutd"
+  "owns\030\021 \001(\t\022 \n\030unrecoverableMediaErrors\030\022"
+  " \001(\t\022\037\n\027lifetimeErrorLogEntries\030\023 \001(\t\022\036\n"
+  "\026warningTemperatureTime\030\024 \001(\t\022\037\n\027critica"
+  "lTemperatureTime\030\025 \001(\t\022\031\n\021temperatureSen"
+  "sor\030\026 \003(\t\"\217\001\n\022GetSmartLogRequest\022\017\n\007comm"
+  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001("
+  "\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.GetSmartLogR"
+  "equest.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\330\001\n\023"
+  "GetSmartLogResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003"
+  "rid\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.Get"
+  "SmartLogResponse.Result\022\037\n\004info\030\004 \001(\0132\021."
+  "grpc_cli.PosInfo\032L\n\006Result\022 \n\006status\030\001 \001"
+  "(\0132\020.grpc_cli.Status\022 \n\004data\030\002 \001(\0132\022.grp"
+  "c_cli.SmartLog2\221\026\n\006PosCli\022_\n\nSystemInfo\022"
+  "\033.grpc_cli.SystemInfoRequest\032\034.grpc_cli."
+  "SystemInfoResponse\"\026\202\323\344\223\002\020\022\016/v1/systemin"
+  "fo\022_\n\nSystemStop\022\033.grpc_cli.SystemStopRe"
+  "quest\032\034.grpc_cli.SystemStopResponse\"\026\202\323\344"
+  "\223\002\020\022\016/v1/systemstop\022}\n\021GetSystemProperty"
+  "\022\".grpc_cli.GetSystemPropertyRequest\032#.g"
+  "rpc_cli.GetSystemPropertyResponse\"\037\202\323\344\223\002"
+  "\031\022\027/v1/get_system_property\022\205\001\n\021SetSystem"
+  "Property\022\".grpc_cli.SetSystemPropertyReq"
+  "uest\032#.grpc_cli.SetSystemPropertyRespons"
+  "e\"\'\202\323\344\223\002!\022\037/v1/set_system_property/{leve"
+  "l}\022p\n\016StartTelemetry\022\037.grpc_cli.StartTel"
+  "emetryRequest\032 .grpc_cli.StartTelemetryR"
+  "esponse\"\033\202\323\344\223\002\025\022\023/v1/start_telemetry\022l\n\r"
+  "StopTelemetry\022\036.grpc_cli.StopTelemetryRe"
+  "quest\032\037.grpc_cli.StopTelemetryResponse\"\032"
+  "\202\323\344\223\002\024\022\022/v1/stop_telemetry\022P\n\rResetEvent"
+  "Wrr\022\036.grpc_cli.ResetEventWrrRequest\032\037.gr"
+  "pc_cli.ResetEventWrrResponse\022A\n\010ResetMbr"
+  "\022\031.grpc_cli.ResetMbrRequest\032\032.grpc_cli.R"
+  "esetMbrResponse\022S\n\016StopRebuilding\022\037.grpc"
+  "_cli.StopRebuildingRequest\032 .grpc_cli.St"
+  "opRebuildingResponse\022S\n\016UpdateEventWrr\022\037"
+  ".grpc_cli.UpdateEventWrrRequest\032 .grpc_c"
+  "li.UpdateEventWrrResponse\022W\n\010AddSpare\022\031."
+  "grpc_cli.AddSpareRequest\032\032.grpc_cli.AddS"
+  "pareResponse\"\024\202\323\344\223\002\016\"\014/v1/addspare\022c\n\013Re"
+  "moveSpare\022\034.grpc_cli.RemoveSpareRequest\032"
+  "\035.grpc_cli.RemoveSpareResponse\"\027\202\323\344\223\002\021\"\017"
+  "/v1/removespare\022c\n\013CreateArray\022\034.grpc_cl"
+  "i.CreateArrayRequest\032\035.grpc_cli.CreateAr"
+  "rayResponse\"\027\202\323\344\223\002\021\"\017/v1/createarray\022s\n\017"
+  "AutocreateArray\022 .grpc_cli.AutocreateArr"
+  "ayRequest\032!.grpc_cli.AutocreateArrayResp"
+  "onse\"\033\202\323\344\223\002\025\"\023/v1/autocreatearray\022d\n\013Del"
+  "eteArray\022\034.grpc_cli.DeleteArrayRequest\032\035"
+  ".grpc_cli.DeleteArrayResponse\"\030\202\323\344\223\002\022\"\020/"
+  "v1/deletearray/\022_\n\nMountArray\022\033.grpc_cli"
+  ".MountArrayRequest\032\034.grpc_cli.MountArray"
+  "Response\"\026\202\323\344\223\002\020\"\016/v1/mountarray\022g\n\014Unmo"
+  "untArray\022\035.grpc_cli.UnmountArrayRequest\032"
+  "\036.grpc_cli.UnmountArrayResponse\"\030\202\323\344\223\002\022\""
+  "\020/v1/unmountarray\022[\n\tListArray\022\032.grpc_cl"
+  "i.ListArrayRequest\032\033.grpc_cli.ListArrayR"
+  "esponse\"\025\202\323\344\223\002\017\"\r/v1/listarray\022[\n\tArrayI"
+  "nfo\022\032.grpc_cli.ArrayInfoRequest\032\033.grpc_c"
+  "li.ArrayInfoResponse\"\025\202\323\344\223\002\017\"\r/v1/arrayi"
+  "nfo\022w\n\020SetLogPreference\022!.grpc_cli.SetLo"
+  "gPreferenceRequest\032\".grpc_cli.SetLogPref"
+  "erenceResponse\"\034\202\323\344\223\002\026\"\024/v1/setlogprefer"
+  "ence\022c\n\013SetLogLevel\022\034.grpc_cli.SetLogLev"
+  "elRequest\032\035.grpc_cli.SetLogLevelResponse"
+  "\"\027\202\323\344\223\002\021\"\017/v1/setloglevel\022_\n\nLoggerInfo\022"
+  "\033.grpc_cli.LoggerInfoRequest\032\034.grpc_cli."
+  "LoggerInfoResponse\"\026\202\323\344\223\002\020\"\016/v1/loggerin"
+  "fo\022c\n\013GetLogLevel\022\034.grpc_cli.GetLogLevel"
+  "Request\032\035.grpc_cli.GetLogLevelResponse\"\027"
+  "\202\323\344\223\002\021\"\017/v1/getloglevel\022l\n\016ApplyLogFilte"
+  "r\022\037.grpc_cli.ApplyLogFilterRequest\032 .grp"
+  "c_cli.ApplyLogFilterResponse\"\027\202\323\344\223\002\021\"\017/v"
+  "1/applyfilter\022g\n\014CreateDevice\022\035.grpc_cli"
+  ".CreateDeviceRequest\032\036.grpc_cli.CreateDe"
+  "viceResponse\"\030\202\323\344\223\002\022\"\020/v1/createdevice\022_"
+  "\n\nScanDevice\022\033.grpc_cli.ScanDeviceReques"
+  "t\032\034.grpc_cli.ScanDeviceResponse\"\026\202\323\344\223\002\020\""
+  "\016/v1/scandevice\022_\n\nListDevice\022\033.grpc_cli"
+  ".ListDeviceRequest\032\034.grpc_cli.ListDevice"
+  "Response\"\026\202\323\344\223\002\020\"\016/v1/listdevice\022`\n\013GetS"
+  "martLog\022\034.grpc_cli.GetSmartLogRequest\032\035."
+  "grpc_cli.GetSmartLogResponse\"\024\202\323\344\223\002\016\"\014/v"
+  "1/smartlogB\tZ\007cli/apib\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_cli_2eproto_deps[1] = {
   &::descriptor_table_annotations_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_cli_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_cli_2eproto = {
-  false, false, 16224, descriptor_table_protodef_cli_2eproto, "cli.proto", 
+  false, false, 16309, descriptor_table_protodef_cli_2eproto, "cli.proto", 
   &descriptor_table_cli_2eproto_once, descriptor_table_cli_2eproto_deps, 1, 129,
   schemas, file_default_instances, TableStruct_cli_2eproto::offsets,
   file_level_metadata_cli_2eproto, file_level_enum_descriptors_cli_2eproto, file_level_service_descriptors_cli_2eproto,
@@ -4555,6 +4563,21 @@ SystemInfoResponse_Result_Data::SystemInfoResponse_Result_Data(const SystemInfoR
     baseboardversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_baseboardversion(), 
       GetArena());
   }
+  processormanufacturer_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_processormanufacturer().empty()) {
+    processormanufacturer_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_processormanufacturer(), 
+      GetArena());
+  }
+  processorversion_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_processorversion().empty()) {
+    processorversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_processorversion(), 
+      GetArena());
+  }
+  processorfrequency_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_processorfrequency().empty()) {
+    processorfrequency_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_processorfrequency(), 
+      GetArena());
+  }
   // @@protoc_insertion_point(copy_constructor:grpc_cli.SystemInfoResponse.Result.Data)
 }
 
@@ -4571,6 +4594,9 @@ baseboardmanufacturer_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetE
 baseboardproductname_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 baseboardserialnumber_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 baseboardversion_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+processormanufacturer_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+processorversion_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+processorfrequency_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 }
 
 SystemInfoResponse_Result_Data::~SystemInfoResponse_Result_Data() {
@@ -4593,6 +4619,9 @@ void SystemInfoResponse_Result_Data::SharedDtor() {
   baseboardproductname_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   baseboardserialnumber_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
   baseboardversion_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  processormanufacturer_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  processorversion_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  processorfrequency_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
 }
 
 void SystemInfoResponse_Result_Data::ArenaDtor(void* object) {
@@ -4623,6 +4652,9 @@ void SystemInfoResponse_Result_Data::Clear() {
   baseboardproductname_.ClearToEmpty();
   baseboardserialnumber_.ClearToEmpty();
   baseboardversion_.ClearToEmpty();
+  processormanufacturer_.ClearToEmpty();
+  processorversion_.ClearToEmpty();
+  processorfrequency_.ClearToEmpty();
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -4738,6 +4770,33 @@ const char* SystemInfoResponse_Result_Data::_InternalParse(const char* ptr, ::PR
           auto str = _internal_mutable_baseboardversion();
           ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
           CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.baseboardVersion"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string processorManufacturer = 13;
+      case 13:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 106)) {
+          auto str = _internal_mutable_processormanufacturer();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.processorManufacturer"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string processorVersion = 14;
+      case 14:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 114)) {
+          auto str = _internal_mutable_processorversion();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.processorVersion"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string processorFrequency = 15;
+      case 15:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 122)) {
+          auto str = _internal_mutable_processorfrequency();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SystemInfoResponse.Result.Data.processorFrequency"));
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -4889,6 +4948,36 @@ failure:
         12, this->_internal_baseboardversion(), target);
   }
 
+  // string processorManufacturer = 13;
+  if (this->processormanufacturer().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_processormanufacturer().data(), static_cast<int>(this->_internal_processormanufacturer().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.processorManufacturer");
+    target = stream->WriteStringMaybeAliased(
+        13, this->_internal_processormanufacturer(), target);
+  }
+
+  // string processorVersion = 14;
+  if (this->processorversion().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_processorversion().data(), static_cast<int>(this->_internal_processorversion().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.processorVersion");
+    target = stream->WriteStringMaybeAliased(
+        14, this->_internal_processorversion(), target);
+  }
+
+  // string processorFrequency = 15;
+  if (this->processorfrequency().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_processorfrequency().data(), static_cast<int>(this->_internal_processorfrequency().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SystemInfoResponse.Result.Data.processorFrequency");
+    target = stream->WriteStringMaybeAliased(
+        15, this->_internal_processorfrequency(), target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -4989,6 +5078,27 @@ size_t SystemInfoResponse_Result_Data::ByteSizeLong() const {
         this->_internal_baseboardversion());
   }
 
+  // string processorManufacturer = 13;
+  if (this->processormanufacturer().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_processormanufacturer());
+  }
+
+  // string processorVersion = 14;
+  if (this->processorversion().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_processorversion());
+  }
+
+  // string processorFrequency = 15;
+  if (this->processorfrequency().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_processorfrequency());
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
         _internal_metadata_, total_size, &_cached_size_);
@@ -5056,6 +5166,15 @@ void SystemInfoResponse_Result_Data::MergeFrom(const SystemInfoResponse_Result_D
   if (from.baseboardversion().size() > 0) {
     _internal_set_baseboardversion(from._internal_baseboardversion());
   }
+  if (from.processormanufacturer().size() > 0) {
+    _internal_set_processormanufacturer(from._internal_processormanufacturer());
+  }
+  if (from.processorversion().size() > 0) {
+    _internal_set_processorversion(from._internal_processorversion());
+  }
+  if (from.processorfrequency().size() > 0) {
+    _internal_set_processorfrequency(from._internal_processorfrequency());
+  }
 }
 
 void SystemInfoResponse_Result_Data::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
@@ -5091,6 +5210,9 @@ void SystemInfoResponse_Result_Data::InternalSwap(SystemInfoResponse_Result_Data
   baseboardproductname_.Swap(&other->baseboardproductname_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   baseboardserialnumber_.Swap(&other->baseboardserialnumber_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
   baseboardversion_.Swap(&other->baseboardversion_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  processormanufacturer_.Swap(&other->processormanufacturer_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  processorversion_.Swap(&other->processorversion_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  processorfrequency_.Swap(&other->processorfrequency_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata SystemInfoResponse_Result_Data::GetMetadata() const {

--- a/proto/generated/cpp/cli.pb.h
+++ b/proto/generated/cpp/cli.pb.h
@@ -1254,6 +1254,10 @@ class SystemInfoResponse_Result_Data PROTOBUF_FINAL :
     kSystemProductNameFieldNumber = 6,
     kSystemSerialNumberFieldNumber = 7,
     kSystemUuidFieldNumber = 8,
+    kBaseboardManufacturerFieldNumber = 9,
+    kBaseboardProductNameFieldNumber = 10,
+    kBaseboardSerialNumberFieldNumber = 11,
+    kBaseboardVersionFieldNumber = 12,
   };
   // string version = 1;
   void clear_version();
@@ -1383,6 +1387,70 @@ class SystemInfoResponse_Result_Data PROTOBUF_FINAL :
   std::string* _internal_mutable_systemuuid();
   public:
 
+  // string baseboardManufacturer = 9;
+  void clear_baseboardmanufacturer();
+  const std::string& baseboardmanufacturer() const;
+  void set_baseboardmanufacturer(const std::string& value);
+  void set_baseboardmanufacturer(std::string&& value);
+  void set_baseboardmanufacturer(const char* value);
+  void set_baseboardmanufacturer(const char* value, size_t size);
+  std::string* mutable_baseboardmanufacturer();
+  std::string* release_baseboardmanufacturer();
+  void set_allocated_baseboardmanufacturer(std::string* baseboardmanufacturer);
+  private:
+  const std::string& _internal_baseboardmanufacturer() const;
+  void _internal_set_baseboardmanufacturer(const std::string& value);
+  std::string* _internal_mutable_baseboardmanufacturer();
+  public:
+
+  // string baseboardProductName = 10;
+  void clear_baseboardproductname();
+  const std::string& baseboardproductname() const;
+  void set_baseboardproductname(const std::string& value);
+  void set_baseboardproductname(std::string&& value);
+  void set_baseboardproductname(const char* value);
+  void set_baseboardproductname(const char* value, size_t size);
+  std::string* mutable_baseboardproductname();
+  std::string* release_baseboardproductname();
+  void set_allocated_baseboardproductname(std::string* baseboardproductname);
+  private:
+  const std::string& _internal_baseboardproductname() const;
+  void _internal_set_baseboardproductname(const std::string& value);
+  std::string* _internal_mutable_baseboardproductname();
+  public:
+
+  // string baseboardSerialNumber = 11;
+  void clear_baseboardserialnumber();
+  const std::string& baseboardserialnumber() const;
+  void set_baseboardserialnumber(const std::string& value);
+  void set_baseboardserialnumber(std::string&& value);
+  void set_baseboardserialnumber(const char* value);
+  void set_baseboardserialnumber(const char* value, size_t size);
+  std::string* mutable_baseboardserialnumber();
+  std::string* release_baseboardserialnumber();
+  void set_allocated_baseboardserialnumber(std::string* baseboardserialnumber);
+  private:
+  const std::string& _internal_baseboardserialnumber() const;
+  void _internal_set_baseboardserialnumber(const std::string& value);
+  std::string* _internal_mutable_baseboardserialnumber();
+  public:
+
+  // string baseboardVersion = 12;
+  void clear_baseboardversion();
+  const std::string& baseboardversion() const;
+  void set_baseboardversion(const std::string& value);
+  void set_baseboardversion(std::string&& value);
+  void set_baseboardversion(const char* value);
+  void set_baseboardversion(const char* value, size_t size);
+  std::string* mutable_baseboardversion();
+  std::string* release_baseboardversion();
+  void set_allocated_baseboardversion(std::string* baseboardversion);
+  private:
+  const std::string& _internal_baseboardversion() const;
+  void _internal_set_baseboardversion(const std::string& value);
+  std::string* _internal_mutable_baseboardversion();
+  public:
+
   // @@protoc_insertion_point(class_scope:grpc_cli.SystemInfoResponse.Result.Data)
  private:
   class _Internal;
@@ -1398,6 +1466,10 @@ class SystemInfoResponse_Result_Data PROTOBUF_FINAL :
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr systemproductname_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr systemserialnumber_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr systemuuid_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr baseboardmanufacturer_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr baseboardproductname_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr baseboardserialnumber_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr baseboardversion_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_cli_2eproto;
 };
@@ -25602,6 +25674,250 @@ inline void SystemInfoResponse_Result_Data::set_allocated_systemuuid(std::string
   systemuuid_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), systemuuid,
       GetArena());
   // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.systemUuid)
+}
+
+// string baseboardManufacturer = 9;
+inline void SystemInfoResponse_Result_Data::clear_baseboardmanufacturer() {
+  baseboardmanufacturer_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::baseboardmanufacturer() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.baseboardManufacturer)
+  return _internal_baseboardmanufacturer();
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardmanufacturer(const std::string& value) {
+  _internal_set_baseboardmanufacturer(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.baseboardManufacturer)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_baseboardmanufacturer() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.baseboardManufacturer)
+  return _internal_mutable_baseboardmanufacturer();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_baseboardmanufacturer() const {
+  return baseboardmanufacturer_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_baseboardmanufacturer(const std::string& value) {
+  
+  baseboardmanufacturer_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardmanufacturer(std::string&& value) {
+  
+  baseboardmanufacturer_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.baseboardManufacturer)
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardmanufacturer(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  baseboardmanufacturer_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.baseboardManufacturer)
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardmanufacturer(const char* value,
+    size_t size) {
+  
+  baseboardmanufacturer_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.baseboardManufacturer)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_baseboardmanufacturer() {
+  
+  return baseboardmanufacturer_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_baseboardmanufacturer() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.baseboardManufacturer)
+  return baseboardmanufacturer_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_baseboardmanufacturer(std::string* baseboardmanufacturer) {
+  if (baseboardmanufacturer != nullptr) {
+    
+  } else {
+    
+  }
+  baseboardmanufacturer_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), baseboardmanufacturer,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.baseboardManufacturer)
+}
+
+// string baseboardProductName = 10;
+inline void SystemInfoResponse_Result_Data::clear_baseboardproductname() {
+  baseboardproductname_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::baseboardproductname() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.baseboardProductName)
+  return _internal_baseboardproductname();
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardproductname(const std::string& value) {
+  _internal_set_baseboardproductname(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.baseboardProductName)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_baseboardproductname() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.baseboardProductName)
+  return _internal_mutable_baseboardproductname();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_baseboardproductname() const {
+  return baseboardproductname_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_baseboardproductname(const std::string& value) {
+  
+  baseboardproductname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardproductname(std::string&& value) {
+  
+  baseboardproductname_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.baseboardProductName)
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardproductname(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  baseboardproductname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.baseboardProductName)
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardproductname(const char* value,
+    size_t size) {
+  
+  baseboardproductname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.baseboardProductName)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_baseboardproductname() {
+  
+  return baseboardproductname_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_baseboardproductname() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.baseboardProductName)
+  return baseboardproductname_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_baseboardproductname(std::string* baseboardproductname) {
+  if (baseboardproductname != nullptr) {
+    
+  } else {
+    
+  }
+  baseboardproductname_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), baseboardproductname,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.baseboardProductName)
+}
+
+// string baseboardSerialNumber = 11;
+inline void SystemInfoResponse_Result_Data::clear_baseboardserialnumber() {
+  baseboardserialnumber_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::baseboardserialnumber() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.baseboardSerialNumber)
+  return _internal_baseboardserialnumber();
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardserialnumber(const std::string& value) {
+  _internal_set_baseboardserialnumber(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.baseboardSerialNumber)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_baseboardserialnumber() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.baseboardSerialNumber)
+  return _internal_mutable_baseboardserialnumber();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_baseboardserialnumber() const {
+  return baseboardserialnumber_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_baseboardserialnumber(const std::string& value) {
+  
+  baseboardserialnumber_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardserialnumber(std::string&& value) {
+  
+  baseboardserialnumber_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.baseboardSerialNumber)
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardserialnumber(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  baseboardserialnumber_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.baseboardSerialNumber)
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardserialnumber(const char* value,
+    size_t size) {
+  
+  baseboardserialnumber_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.baseboardSerialNumber)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_baseboardserialnumber() {
+  
+  return baseboardserialnumber_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_baseboardserialnumber() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.baseboardSerialNumber)
+  return baseboardserialnumber_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_baseboardserialnumber(std::string* baseboardserialnumber) {
+  if (baseboardserialnumber != nullptr) {
+    
+  } else {
+    
+  }
+  baseboardserialnumber_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), baseboardserialnumber,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.baseboardSerialNumber)
+}
+
+// string baseboardVersion = 12;
+inline void SystemInfoResponse_Result_Data::clear_baseboardversion() {
+  baseboardversion_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::baseboardversion() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.baseboardVersion)
+  return _internal_baseboardversion();
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardversion(const std::string& value) {
+  _internal_set_baseboardversion(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.baseboardVersion)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_baseboardversion() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.baseboardVersion)
+  return _internal_mutable_baseboardversion();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_baseboardversion() const {
+  return baseboardversion_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_baseboardversion(const std::string& value) {
+  
+  baseboardversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardversion(std::string&& value) {
+  
+  baseboardversion_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.baseboardVersion)
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardversion(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  baseboardversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.baseboardVersion)
+}
+inline void SystemInfoResponse_Result_Data::set_baseboardversion(const char* value,
+    size_t size) {
+  
+  baseboardversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.baseboardVersion)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_baseboardversion() {
+  
+  return baseboardversion_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_baseboardversion() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.baseboardVersion)
+  return baseboardversion_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_baseboardversion(std::string* baseboardversion) {
+  if (baseboardversion != nullptr) {
+    
+  } else {
+    
+  }
+  baseboardversion_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), baseboardversion,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.baseboardVersion)
 }
 
 // -------------------------------------------------------------------

--- a/proto/generated/cpp/cli.pb.h
+++ b/proto/generated/cpp/cli.pb.h
@@ -47,7 +47,7 @@ struct TableStruct_cli_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[121]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[129]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -209,6 +209,18 @@ extern ListDeviceResponse_ResultDefaultTypeInternal _ListDeviceResponse_Result_d
 class ListDeviceResponse_Result_DeviceList;
 struct ListDeviceResponse_Result_DeviceListDefaultTypeInternal;
 extern ListDeviceResponse_Result_DeviceListDefaultTypeInternal _ListDeviceResponse_Result_DeviceList_default_instance_;
+class ListHaReplicationRequest;
+struct ListHaReplicationRequestDefaultTypeInternal;
+extern ListHaReplicationRequestDefaultTypeInternal _ListHaReplicationRequest_default_instance_;
+class ListHaReplicationResponse;
+struct ListHaReplicationResponseDefaultTypeInternal;
+extern ListHaReplicationResponseDefaultTypeInternal _ListHaReplicationResponse_default_instance_;
+class ListHaReplicationResponse_Result;
+struct ListHaReplicationResponse_ResultDefaultTypeInternal;
+extern ListHaReplicationResponse_ResultDefaultTypeInternal _ListHaReplicationResponse_Result_default_instance_;
+class ListHaReplicationResponse_Result_Replication;
+struct ListHaReplicationResponse_Result_ReplicationDefaultTypeInternal;
+extern ListHaReplicationResponse_Result_ReplicationDefaultTypeInternal _ListHaReplicationResponse_Result_Replication_default_instance_;
 class ListHaVolumeRequest;
 struct ListHaVolumeRequestDefaultTypeInternal;
 extern ListHaVolumeRequestDefaultTypeInternal _ListHaVolumeRequest_default_instance_;
@@ -341,6 +353,18 @@ extern SetSystemPropertyResponse_ResultDefaultTypeInternal _SetSystemPropertyRes
 class SmartLog;
 struct SmartLogDefaultTypeInternal;
 extern SmartLogDefaultTypeInternal _SmartLog_default_instance_;
+class StartHaReplicationRequest;
+struct StartHaReplicationRequestDefaultTypeInternal;
+extern StartHaReplicationRequestDefaultTypeInternal _StartHaReplicationRequest_default_instance_;
+class StartHaReplicationRequest_Param;
+struct StartHaReplicationRequest_ParamDefaultTypeInternal;
+extern StartHaReplicationRequest_ParamDefaultTypeInternal _StartHaReplicationRequest_Param_default_instance_;
+class StartHaReplicationResponse;
+struct StartHaReplicationResponseDefaultTypeInternal;
+extern StartHaReplicationResponseDefaultTypeInternal _StartHaReplicationResponse_default_instance_;
+class StartHaReplicationResponse_Result;
+struct StartHaReplicationResponse_ResultDefaultTypeInternal;
+extern StartHaReplicationResponse_ResultDefaultTypeInternal _StartHaReplicationResponse_Result_default_instance_;
 class StartTelemetryRequest;
 struct StartTelemetryRequestDefaultTypeInternal;
 extern StartTelemetryRequestDefaultTypeInternal _StartTelemetryRequest_default_instance_;
@@ -472,6 +496,10 @@ template<> ::grpc_cli::ListDeviceRequest* Arena::CreateMaybeMessage<::grpc_cli::
 template<> ::grpc_cli::ListDeviceResponse* Arena::CreateMaybeMessage<::grpc_cli::ListDeviceResponse>(Arena*);
 template<> ::grpc_cli::ListDeviceResponse_Result* Arena::CreateMaybeMessage<::grpc_cli::ListDeviceResponse_Result>(Arena*);
 template<> ::grpc_cli::ListDeviceResponse_Result_DeviceList* Arena::CreateMaybeMessage<::grpc_cli::ListDeviceResponse_Result_DeviceList>(Arena*);
+template<> ::grpc_cli::ListHaReplicationRequest* Arena::CreateMaybeMessage<::grpc_cli::ListHaReplicationRequest>(Arena*);
+template<> ::grpc_cli::ListHaReplicationResponse* Arena::CreateMaybeMessage<::grpc_cli::ListHaReplicationResponse>(Arena*);
+template<> ::grpc_cli::ListHaReplicationResponse_Result* Arena::CreateMaybeMessage<::grpc_cli::ListHaReplicationResponse_Result>(Arena*);
+template<> ::grpc_cli::ListHaReplicationResponse_Result_Replication* Arena::CreateMaybeMessage<::grpc_cli::ListHaReplicationResponse_Result_Replication>(Arena*);
 template<> ::grpc_cli::ListHaVolumeRequest* Arena::CreateMaybeMessage<::grpc_cli::ListHaVolumeRequest>(Arena*);
 template<> ::grpc_cli::ListHaVolumeResponse* Arena::CreateMaybeMessage<::grpc_cli::ListHaVolumeResponse>(Arena*);
 template<> ::grpc_cli::ListHaVolumeResponse_Result* Arena::CreateMaybeMessage<::grpc_cli::ListHaVolumeResponse_Result>(Arena*);
@@ -516,6 +544,10 @@ template<> ::grpc_cli::SetSystemPropertyRequest_Param* Arena::CreateMaybeMessage
 template<> ::grpc_cli::SetSystemPropertyResponse* Arena::CreateMaybeMessage<::grpc_cli::SetSystemPropertyResponse>(Arena*);
 template<> ::grpc_cli::SetSystemPropertyResponse_Result* Arena::CreateMaybeMessage<::grpc_cli::SetSystemPropertyResponse_Result>(Arena*);
 template<> ::grpc_cli::SmartLog* Arena::CreateMaybeMessage<::grpc_cli::SmartLog>(Arena*);
+template<> ::grpc_cli::StartHaReplicationRequest* Arena::CreateMaybeMessage<::grpc_cli::StartHaReplicationRequest>(Arena*);
+template<> ::grpc_cli::StartHaReplicationRequest_Param* Arena::CreateMaybeMessage<::grpc_cli::StartHaReplicationRequest_Param>(Arena*);
+template<> ::grpc_cli::StartHaReplicationResponse* Arena::CreateMaybeMessage<::grpc_cli::StartHaReplicationResponse>(Arena*);
+template<> ::grpc_cli::StartHaReplicationResponse_Result* Arena::CreateMaybeMessage<::grpc_cli::StartHaReplicationResponse_Result>(Arena*);
 template<> ::grpc_cli::StartTelemetryRequest* Arena::CreateMaybeMessage<::grpc_cli::StartTelemetryRequest>(Arena*);
 template<> ::grpc_cli::StartTelemetryResponse* Arena::CreateMaybeMessage<::grpc_cli::StartTelemetryResponse>(Arena*);
 template<> ::grpc_cli::StartTelemetryResponse_Result* Arena::CreateMaybeMessage<::grpc_cli::StartTelemetryResponse_Result>(Arena*);
@@ -1215,6 +1247,7 @@ class SystemInfoResponse_Result_Data PROTOBUF_FINAL :
 
   enum : int {
     kVersionFieldNumber = 1,
+    kBiosVersionFieldNumber = 2,
   };
   // string version = 1;
   void clear_version();
@@ -1232,6 +1265,22 @@ class SystemInfoResponse_Result_Data PROTOBUF_FINAL :
   std::string* _internal_mutable_version();
   public:
 
+  // string biosVersion = 2;
+  void clear_biosversion();
+  const std::string& biosversion() const;
+  void set_biosversion(const std::string& value);
+  void set_biosversion(std::string&& value);
+  void set_biosversion(const char* value);
+  void set_biosversion(const char* value, size_t size);
+  std::string* mutable_biosversion();
+  std::string* release_biosversion();
+  void set_allocated_biosversion(std::string* biosversion);
+  private:
+  const std::string& _internal_biosversion() const;
+  void _internal_set_biosversion(const std::string& value);
+  std::string* _internal_mutable_biosversion();
+  public:
+
   // @@protoc_insertion_point(class_scope:grpc_cli.SystemInfoResponse.Result.Data)
  private:
   class _Internal;
@@ -1240,6 +1289,7 @@ class SystemInfoResponse_Result_Data PROTOBUF_FINAL :
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr version_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr biosversion_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_cli_2eproto;
 };
@@ -15861,6 +15911,1597 @@ class ListHaVolumeResponse PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class ListHaReplicationRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.ListHaReplicationRequest) */ {
+ public:
+  inline ListHaReplicationRequest() : ListHaReplicationRequest(nullptr) {}
+  virtual ~ListHaReplicationRequest();
+  explicit constexpr ListHaReplicationRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  ListHaReplicationRequest(const ListHaReplicationRequest& from);
+  ListHaReplicationRequest(ListHaReplicationRequest&& from) noexcept
+    : ListHaReplicationRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline ListHaReplicationRequest& operator=(const ListHaReplicationRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ListHaReplicationRequest& operator=(ListHaReplicationRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const ListHaReplicationRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ListHaReplicationRequest* internal_default_instance() {
+    return reinterpret_cast<const ListHaReplicationRequest*>(
+               &_ListHaReplicationRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    85;
+
+  friend void swap(ListHaReplicationRequest& a, ListHaReplicationRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ListHaReplicationRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ListHaReplicationRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ListHaReplicationRequest* New() const final {
+    return CreateMaybeMessage<ListHaReplicationRequest>(nullptr);
+  }
+
+  ListHaReplicationRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<ListHaReplicationRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const ListHaReplicationRequest& from);
+  void MergeFrom(const ListHaReplicationRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ListHaReplicationRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.ListHaReplicationRequest";
+  }
+  protected:
+  explicit ListHaReplicationRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kCommandFieldNumber = 1,
+    kRidFieldNumber = 2,
+    kRequestorFieldNumber = 3,
+  };
+  // string command = 1;
+  void clear_command();
+  const std::string& command() const;
+  void set_command(const std::string& value);
+  void set_command(std::string&& value);
+  void set_command(const char* value);
+  void set_command(const char* value, size_t size);
+  std::string* mutable_command();
+  std::string* release_command();
+  void set_allocated_command(std::string* command);
+  private:
+  const std::string& _internal_command() const;
+  void _internal_set_command(const std::string& value);
+  std::string* _internal_mutable_command();
+  public:
+
+  // string rid = 2;
+  void clear_rid();
+  const std::string& rid() const;
+  void set_rid(const std::string& value);
+  void set_rid(std::string&& value);
+  void set_rid(const char* value);
+  void set_rid(const char* value, size_t size);
+  std::string* mutable_rid();
+  std::string* release_rid();
+  void set_allocated_rid(std::string* rid);
+  private:
+  const std::string& _internal_rid() const;
+  void _internal_set_rid(const std::string& value);
+  std::string* _internal_mutable_rid();
+  public:
+
+  // string requestor = 3;
+  void clear_requestor();
+  const std::string& requestor() const;
+  void set_requestor(const std::string& value);
+  void set_requestor(std::string&& value);
+  void set_requestor(const char* value);
+  void set_requestor(const char* value, size_t size);
+  std::string* mutable_requestor();
+  std::string* release_requestor();
+  void set_allocated_requestor(std::string* requestor);
+  private:
+  const std::string& _internal_requestor() const;
+  void _internal_set_requestor(const std::string& value);
+  std::string* _internal_mutable_requestor();
+  public:
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.ListHaReplicationRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr command_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr rid_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr requestor_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ListHaReplicationResponse_Result_Replication PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.ListHaReplicationResponse.Result.Replication) */ {
+ public:
+  inline ListHaReplicationResponse_Result_Replication() : ListHaReplicationResponse_Result_Replication(nullptr) {}
+  virtual ~ListHaReplicationResponse_Result_Replication();
+  explicit constexpr ListHaReplicationResponse_Result_Replication(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  ListHaReplicationResponse_Result_Replication(const ListHaReplicationResponse_Result_Replication& from);
+  ListHaReplicationResponse_Result_Replication(ListHaReplicationResponse_Result_Replication&& from) noexcept
+    : ListHaReplicationResponse_Result_Replication() {
+    *this = ::std::move(from);
+  }
+
+  inline ListHaReplicationResponse_Result_Replication& operator=(const ListHaReplicationResponse_Result_Replication& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ListHaReplicationResponse_Result_Replication& operator=(ListHaReplicationResponse_Result_Replication&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const ListHaReplicationResponse_Result_Replication& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ListHaReplicationResponse_Result_Replication* internal_default_instance() {
+    return reinterpret_cast<const ListHaReplicationResponse_Result_Replication*>(
+               &_ListHaReplicationResponse_Result_Replication_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    86;
+
+  friend void swap(ListHaReplicationResponse_Result_Replication& a, ListHaReplicationResponse_Result_Replication& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ListHaReplicationResponse_Result_Replication* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ListHaReplicationResponse_Result_Replication* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ListHaReplicationResponse_Result_Replication* New() const final {
+    return CreateMaybeMessage<ListHaReplicationResponse_Result_Replication>(nullptr);
+  }
+
+  ListHaReplicationResponse_Result_Replication* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<ListHaReplicationResponse_Result_Replication>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const ListHaReplicationResponse_Result_Replication& from);
+  void MergeFrom(const ListHaReplicationResponse_Result_Replication& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ListHaReplicationResponse_Result_Replication* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.ListHaReplicationResponse.Result.Replication";
+  }
+  protected:
+  explicit ListHaReplicationResponse_Result_Replication(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kIdFieldNumber = 1,
+    kSourceVolumeIdFieldNumber = 2,
+    kSourceWalVolumeIdFieldNumber = 3,
+    kDestinationVolumeIdFieldNumber = 4,
+    kDestinationWalVolumeIdFieldNumber = 5,
+  };
+  // int32 id = 1;
+  void clear_id();
+  ::PROTOBUF_NAMESPACE_ID::int32 id() const;
+  void set_id(::PROTOBUF_NAMESPACE_ID::int32 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::int32 _internal_id() const;
+  void _internal_set_id(::PROTOBUF_NAMESPACE_ID::int32 value);
+  public:
+
+  // int32 sourceVolumeId = 2;
+  void clear_sourcevolumeid();
+  ::PROTOBUF_NAMESPACE_ID::int32 sourcevolumeid() const;
+  void set_sourcevolumeid(::PROTOBUF_NAMESPACE_ID::int32 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::int32 _internal_sourcevolumeid() const;
+  void _internal_set_sourcevolumeid(::PROTOBUF_NAMESPACE_ID::int32 value);
+  public:
+
+  // int32 sourceWalVolume_id = 3;
+  void clear_sourcewalvolume_id();
+  ::PROTOBUF_NAMESPACE_ID::int32 sourcewalvolume_id() const;
+  void set_sourcewalvolume_id(::PROTOBUF_NAMESPACE_ID::int32 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::int32 _internal_sourcewalvolume_id() const;
+  void _internal_set_sourcewalvolume_id(::PROTOBUF_NAMESPACE_ID::int32 value);
+  public:
+
+  // int32 destinationVolumeId = 4;
+  void clear_destinationvolumeid();
+  ::PROTOBUF_NAMESPACE_ID::int32 destinationvolumeid() const;
+  void set_destinationvolumeid(::PROTOBUF_NAMESPACE_ID::int32 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::int32 _internal_destinationvolumeid() const;
+  void _internal_set_destinationvolumeid(::PROTOBUF_NAMESPACE_ID::int32 value);
+  public:
+
+  // int32 destinationWalVolumeId = 5;
+  void clear_destinationwalvolumeid();
+  ::PROTOBUF_NAMESPACE_ID::int32 destinationwalvolumeid() const;
+  void set_destinationwalvolumeid(::PROTOBUF_NAMESPACE_ID::int32 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::int32 _internal_destinationwalvolumeid() const;
+  void _internal_set_destinationwalvolumeid(::PROTOBUF_NAMESPACE_ID::int32 value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.ListHaReplicationResponse.Result.Replication)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::int32 id_;
+  ::PROTOBUF_NAMESPACE_ID::int32 sourcevolumeid_;
+  ::PROTOBUF_NAMESPACE_ID::int32 sourcewalvolume_id_;
+  ::PROTOBUF_NAMESPACE_ID::int32 destinationvolumeid_;
+  ::PROTOBUF_NAMESPACE_ID::int32 destinationwalvolumeid_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ListHaReplicationResponse_Result PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.ListHaReplicationResponse.Result) */ {
+ public:
+  inline ListHaReplicationResponse_Result() : ListHaReplicationResponse_Result(nullptr) {}
+  virtual ~ListHaReplicationResponse_Result();
+  explicit constexpr ListHaReplicationResponse_Result(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  ListHaReplicationResponse_Result(const ListHaReplicationResponse_Result& from);
+  ListHaReplicationResponse_Result(ListHaReplicationResponse_Result&& from) noexcept
+    : ListHaReplicationResponse_Result() {
+    *this = ::std::move(from);
+  }
+
+  inline ListHaReplicationResponse_Result& operator=(const ListHaReplicationResponse_Result& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ListHaReplicationResponse_Result& operator=(ListHaReplicationResponse_Result&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const ListHaReplicationResponse_Result& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ListHaReplicationResponse_Result* internal_default_instance() {
+    return reinterpret_cast<const ListHaReplicationResponse_Result*>(
+               &_ListHaReplicationResponse_Result_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    87;
+
+  friend void swap(ListHaReplicationResponse_Result& a, ListHaReplicationResponse_Result& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ListHaReplicationResponse_Result* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ListHaReplicationResponse_Result* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ListHaReplicationResponse_Result* New() const final {
+    return CreateMaybeMessage<ListHaReplicationResponse_Result>(nullptr);
+  }
+
+  ListHaReplicationResponse_Result* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<ListHaReplicationResponse_Result>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const ListHaReplicationResponse_Result& from);
+  void MergeFrom(const ListHaReplicationResponse_Result& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ListHaReplicationResponse_Result* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.ListHaReplicationResponse.Result";
+  }
+  protected:
+  explicit ListHaReplicationResponse_Result(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  typedef ListHaReplicationResponse_Result_Replication Replication;
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kDataFieldNumber = 2,
+    kStatusFieldNumber = 1,
+  };
+  // repeated .grpc_cli.ListHaReplicationResponse.Result.Replication data = 2;
+  int data_size() const;
+  private:
+  int _internal_data_size() const;
+  public:
+  void clear_data();
+  ::grpc_cli::ListHaReplicationResponse_Result_Replication* mutable_data(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::grpc_cli::ListHaReplicationResponse_Result_Replication >*
+      mutable_data();
+  private:
+  const ::grpc_cli::ListHaReplicationResponse_Result_Replication& _internal_data(int index) const;
+  ::grpc_cli::ListHaReplicationResponse_Result_Replication* _internal_add_data();
+  public:
+  const ::grpc_cli::ListHaReplicationResponse_Result_Replication& data(int index) const;
+  ::grpc_cli::ListHaReplicationResponse_Result_Replication* add_data();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::grpc_cli::ListHaReplicationResponse_Result_Replication >&
+      data() const;
+
+  // .grpc_cli.Status status = 1;
+  bool has_status() const;
+  private:
+  bool _internal_has_status() const;
+  public:
+  void clear_status();
+  const ::grpc_cli::Status& status() const;
+  ::grpc_cli::Status* release_status();
+  ::grpc_cli::Status* mutable_status();
+  void set_allocated_status(::grpc_cli::Status* status);
+  private:
+  const ::grpc_cli::Status& _internal_status() const;
+  ::grpc_cli::Status* _internal_mutable_status();
+  public:
+  void unsafe_arena_set_allocated_status(
+      ::grpc_cli::Status* status);
+  ::grpc_cli::Status* unsafe_arena_release_status();
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.ListHaReplicationResponse.Result)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::grpc_cli::ListHaReplicationResponse_Result_Replication > data_;
+  ::grpc_cli::Status* status_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ListHaReplicationResponse PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.ListHaReplicationResponse) */ {
+ public:
+  inline ListHaReplicationResponse() : ListHaReplicationResponse(nullptr) {}
+  virtual ~ListHaReplicationResponse();
+  explicit constexpr ListHaReplicationResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  ListHaReplicationResponse(const ListHaReplicationResponse& from);
+  ListHaReplicationResponse(ListHaReplicationResponse&& from) noexcept
+    : ListHaReplicationResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline ListHaReplicationResponse& operator=(const ListHaReplicationResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ListHaReplicationResponse& operator=(ListHaReplicationResponse&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const ListHaReplicationResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ListHaReplicationResponse* internal_default_instance() {
+    return reinterpret_cast<const ListHaReplicationResponse*>(
+               &_ListHaReplicationResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    88;
+
+  friend void swap(ListHaReplicationResponse& a, ListHaReplicationResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(ListHaReplicationResponse* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ListHaReplicationResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ListHaReplicationResponse* New() const final {
+    return CreateMaybeMessage<ListHaReplicationResponse>(nullptr);
+  }
+
+  ListHaReplicationResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<ListHaReplicationResponse>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const ListHaReplicationResponse& from);
+  void MergeFrom(const ListHaReplicationResponse& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ListHaReplicationResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.ListHaReplicationResponse";
+  }
+  protected:
+  explicit ListHaReplicationResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  typedef ListHaReplicationResponse_Result Result;
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kCommandFieldNumber = 1,
+    kRidFieldNumber = 2,
+    kResultFieldNumber = 3,
+    kInfoFieldNumber = 4,
+  };
+  // string command = 1;
+  void clear_command();
+  const std::string& command() const;
+  void set_command(const std::string& value);
+  void set_command(std::string&& value);
+  void set_command(const char* value);
+  void set_command(const char* value, size_t size);
+  std::string* mutable_command();
+  std::string* release_command();
+  void set_allocated_command(std::string* command);
+  private:
+  const std::string& _internal_command() const;
+  void _internal_set_command(const std::string& value);
+  std::string* _internal_mutable_command();
+  public:
+
+  // string rid = 2;
+  void clear_rid();
+  const std::string& rid() const;
+  void set_rid(const std::string& value);
+  void set_rid(std::string&& value);
+  void set_rid(const char* value);
+  void set_rid(const char* value, size_t size);
+  std::string* mutable_rid();
+  std::string* release_rid();
+  void set_allocated_rid(std::string* rid);
+  private:
+  const std::string& _internal_rid() const;
+  void _internal_set_rid(const std::string& value);
+  std::string* _internal_mutable_rid();
+  public:
+
+  // .grpc_cli.ListHaReplicationResponse.Result result = 3;
+  bool has_result() const;
+  private:
+  bool _internal_has_result() const;
+  public:
+  void clear_result();
+  const ::grpc_cli::ListHaReplicationResponse_Result& result() const;
+  ::grpc_cli::ListHaReplicationResponse_Result* release_result();
+  ::grpc_cli::ListHaReplicationResponse_Result* mutable_result();
+  void set_allocated_result(::grpc_cli::ListHaReplicationResponse_Result* result);
+  private:
+  const ::grpc_cli::ListHaReplicationResponse_Result& _internal_result() const;
+  ::grpc_cli::ListHaReplicationResponse_Result* _internal_mutable_result();
+  public:
+  void unsafe_arena_set_allocated_result(
+      ::grpc_cli::ListHaReplicationResponse_Result* result);
+  ::grpc_cli::ListHaReplicationResponse_Result* unsafe_arena_release_result();
+
+  // .grpc_cli.PosInfo info = 4;
+  bool has_info() const;
+  private:
+  bool _internal_has_info() const;
+  public:
+  void clear_info();
+  const ::grpc_cli::PosInfo& info() const;
+  ::grpc_cli::PosInfo* release_info();
+  ::grpc_cli::PosInfo* mutable_info();
+  void set_allocated_info(::grpc_cli::PosInfo* info);
+  private:
+  const ::grpc_cli::PosInfo& _internal_info() const;
+  ::grpc_cli::PosInfo* _internal_mutable_info();
+  public:
+  void unsafe_arena_set_allocated_info(
+      ::grpc_cli::PosInfo* info);
+  ::grpc_cli::PosInfo* unsafe_arena_release_info();
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.ListHaReplicationResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr command_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr rid_;
+  ::grpc_cli::ListHaReplicationResponse_Result* result_;
+  ::grpc_cli::PosInfo* info_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class StartHaReplicationRequest_Param PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.StartHaReplicationRequest.Param) */ {
+ public:
+  inline StartHaReplicationRequest_Param() : StartHaReplicationRequest_Param(nullptr) {}
+  virtual ~StartHaReplicationRequest_Param();
+  explicit constexpr StartHaReplicationRequest_Param(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  StartHaReplicationRequest_Param(const StartHaReplicationRequest_Param& from);
+  StartHaReplicationRequest_Param(StartHaReplicationRequest_Param&& from) noexcept
+    : StartHaReplicationRequest_Param() {
+    *this = ::std::move(from);
+  }
+
+  inline StartHaReplicationRequest_Param& operator=(const StartHaReplicationRequest_Param& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline StartHaReplicationRequest_Param& operator=(StartHaReplicationRequest_Param&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const StartHaReplicationRequest_Param& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const StartHaReplicationRequest_Param* internal_default_instance() {
+    return reinterpret_cast<const StartHaReplicationRequest_Param*>(
+               &_StartHaReplicationRequest_Param_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    89;
+
+  friend void swap(StartHaReplicationRequest_Param& a, StartHaReplicationRequest_Param& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(StartHaReplicationRequest_Param* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(StartHaReplicationRequest_Param* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline StartHaReplicationRequest_Param* New() const final {
+    return CreateMaybeMessage<StartHaReplicationRequest_Param>(nullptr);
+  }
+
+  StartHaReplicationRequest_Param* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<StartHaReplicationRequest_Param>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const StartHaReplicationRequest_Param& from);
+  void MergeFrom(const StartHaReplicationRequest_Param& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(StartHaReplicationRequest_Param* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.StartHaReplicationRequest.Param";
+  }
+  protected:
+  explicit StartHaReplicationRequest_Param(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPrimaryNodeNameFieldNumber = 1,
+    kPrimaryArrayNameFieldNumber = 2,
+    kPrimaryVolumeNameFieldNumber = 3,
+    kPrimaryWalVolumeNameFieldNumber = 4,
+    kSecondaryNodeNameFieldNumber = 5,
+    kSecondaryArrayNameFieldNumber = 6,
+    kSecondaryVolumeNameFieldNumber = 7,
+    kSecondaryWalVolumeNameFieldNumber = 8,
+    kStuatsFieldNumber = 9,
+    kTimestampFieldNumber = 10,
+  };
+  // string primaryNodeName = 1;
+  void clear_primarynodename();
+  const std::string& primarynodename() const;
+  void set_primarynodename(const std::string& value);
+  void set_primarynodename(std::string&& value);
+  void set_primarynodename(const char* value);
+  void set_primarynodename(const char* value, size_t size);
+  std::string* mutable_primarynodename();
+  std::string* release_primarynodename();
+  void set_allocated_primarynodename(std::string* primarynodename);
+  private:
+  const std::string& _internal_primarynodename() const;
+  void _internal_set_primarynodename(const std::string& value);
+  std::string* _internal_mutable_primarynodename();
+  public:
+
+  // string primaryArrayName = 2;
+  void clear_primaryarrayname();
+  const std::string& primaryarrayname() const;
+  void set_primaryarrayname(const std::string& value);
+  void set_primaryarrayname(std::string&& value);
+  void set_primaryarrayname(const char* value);
+  void set_primaryarrayname(const char* value, size_t size);
+  std::string* mutable_primaryarrayname();
+  std::string* release_primaryarrayname();
+  void set_allocated_primaryarrayname(std::string* primaryarrayname);
+  private:
+  const std::string& _internal_primaryarrayname() const;
+  void _internal_set_primaryarrayname(const std::string& value);
+  std::string* _internal_mutable_primaryarrayname();
+  public:
+
+  // string primaryVolumeName = 3;
+  void clear_primaryvolumename();
+  const std::string& primaryvolumename() const;
+  void set_primaryvolumename(const std::string& value);
+  void set_primaryvolumename(std::string&& value);
+  void set_primaryvolumename(const char* value);
+  void set_primaryvolumename(const char* value, size_t size);
+  std::string* mutable_primaryvolumename();
+  std::string* release_primaryvolumename();
+  void set_allocated_primaryvolumename(std::string* primaryvolumename);
+  private:
+  const std::string& _internal_primaryvolumename() const;
+  void _internal_set_primaryvolumename(const std::string& value);
+  std::string* _internal_mutable_primaryvolumename();
+  public:
+
+  // string primaryWalVolumeName = 4;
+  void clear_primarywalvolumename();
+  const std::string& primarywalvolumename() const;
+  void set_primarywalvolumename(const std::string& value);
+  void set_primarywalvolumename(std::string&& value);
+  void set_primarywalvolumename(const char* value);
+  void set_primarywalvolumename(const char* value, size_t size);
+  std::string* mutable_primarywalvolumename();
+  std::string* release_primarywalvolumename();
+  void set_allocated_primarywalvolumename(std::string* primarywalvolumename);
+  private:
+  const std::string& _internal_primarywalvolumename() const;
+  void _internal_set_primarywalvolumename(const std::string& value);
+  std::string* _internal_mutable_primarywalvolumename();
+  public:
+
+  // string secondaryNodeName = 5;
+  void clear_secondarynodename();
+  const std::string& secondarynodename() const;
+  void set_secondarynodename(const std::string& value);
+  void set_secondarynodename(std::string&& value);
+  void set_secondarynodename(const char* value);
+  void set_secondarynodename(const char* value, size_t size);
+  std::string* mutable_secondarynodename();
+  std::string* release_secondarynodename();
+  void set_allocated_secondarynodename(std::string* secondarynodename);
+  private:
+  const std::string& _internal_secondarynodename() const;
+  void _internal_set_secondarynodename(const std::string& value);
+  std::string* _internal_mutable_secondarynodename();
+  public:
+
+  // string secondaryArrayName = 6;
+  void clear_secondaryarrayname();
+  const std::string& secondaryarrayname() const;
+  void set_secondaryarrayname(const std::string& value);
+  void set_secondaryarrayname(std::string&& value);
+  void set_secondaryarrayname(const char* value);
+  void set_secondaryarrayname(const char* value, size_t size);
+  std::string* mutable_secondaryarrayname();
+  std::string* release_secondaryarrayname();
+  void set_allocated_secondaryarrayname(std::string* secondaryarrayname);
+  private:
+  const std::string& _internal_secondaryarrayname() const;
+  void _internal_set_secondaryarrayname(const std::string& value);
+  std::string* _internal_mutable_secondaryarrayname();
+  public:
+
+  // string secondaryVolumeName = 7;
+  void clear_secondaryvolumename();
+  const std::string& secondaryvolumename() const;
+  void set_secondaryvolumename(const std::string& value);
+  void set_secondaryvolumename(std::string&& value);
+  void set_secondaryvolumename(const char* value);
+  void set_secondaryvolumename(const char* value, size_t size);
+  std::string* mutable_secondaryvolumename();
+  std::string* release_secondaryvolumename();
+  void set_allocated_secondaryvolumename(std::string* secondaryvolumename);
+  private:
+  const std::string& _internal_secondaryvolumename() const;
+  void _internal_set_secondaryvolumename(const std::string& value);
+  std::string* _internal_mutable_secondaryvolumename();
+  public:
+
+  // string secondaryWalVolumeName = 8;
+  void clear_secondarywalvolumename();
+  const std::string& secondarywalvolumename() const;
+  void set_secondarywalvolumename(const std::string& value);
+  void set_secondarywalvolumename(std::string&& value);
+  void set_secondarywalvolumename(const char* value);
+  void set_secondarywalvolumename(const char* value, size_t size);
+  std::string* mutable_secondarywalvolumename();
+  std::string* release_secondarywalvolumename();
+  void set_allocated_secondarywalvolumename(std::string* secondarywalvolumename);
+  private:
+  const std::string& _internal_secondarywalvolumename() const;
+  void _internal_set_secondarywalvolumename(const std::string& value);
+  std::string* _internal_mutable_secondarywalvolumename();
+  public:
+
+  // string stuats = 9;
+  void clear_stuats();
+  const std::string& stuats() const;
+  void set_stuats(const std::string& value);
+  void set_stuats(std::string&& value);
+  void set_stuats(const char* value);
+  void set_stuats(const char* value, size_t size);
+  std::string* mutable_stuats();
+  std::string* release_stuats();
+  void set_allocated_stuats(std::string* stuats);
+  private:
+  const std::string& _internal_stuats() const;
+  void _internal_set_stuats(const std::string& value);
+  std::string* _internal_mutable_stuats();
+  public:
+
+  // string timestamp = 10;
+  void clear_timestamp();
+  const std::string& timestamp() const;
+  void set_timestamp(const std::string& value);
+  void set_timestamp(std::string&& value);
+  void set_timestamp(const char* value);
+  void set_timestamp(const char* value, size_t size);
+  std::string* mutable_timestamp();
+  std::string* release_timestamp();
+  void set_allocated_timestamp(std::string* timestamp);
+  private:
+  const std::string& _internal_timestamp() const;
+  void _internal_set_timestamp(const std::string& value);
+  std::string* _internal_mutable_timestamp();
+  public:
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.StartHaReplicationRequest.Param)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr primarynodename_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr primaryarrayname_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr primaryvolumename_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr primarywalvolumename_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr secondarynodename_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr secondaryarrayname_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr secondaryvolumename_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr secondarywalvolumename_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr stuats_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr timestamp_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class StartHaReplicationRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.StartHaReplicationRequest) */ {
+ public:
+  inline StartHaReplicationRequest() : StartHaReplicationRequest(nullptr) {}
+  virtual ~StartHaReplicationRequest();
+  explicit constexpr StartHaReplicationRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  StartHaReplicationRequest(const StartHaReplicationRequest& from);
+  StartHaReplicationRequest(StartHaReplicationRequest&& from) noexcept
+    : StartHaReplicationRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline StartHaReplicationRequest& operator=(const StartHaReplicationRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline StartHaReplicationRequest& operator=(StartHaReplicationRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const StartHaReplicationRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const StartHaReplicationRequest* internal_default_instance() {
+    return reinterpret_cast<const StartHaReplicationRequest*>(
+               &_StartHaReplicationRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    90;
+
+  friend void swap(StartHaReplicationRequest& a, StartHaReplicationRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(StartHaReplicationRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(StartHaReplicationRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline StartHaReplicationRequest* New() const final {
+    return CreateMaybeMessage<StartHaReplicationRequest>(nullptr);
+  }
+
+  StartHaReplicationRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<StartHaReplicationRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const StartHaReplicationRequest& from);
+  void MergeFrom(const StartHaReplicationRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(StartHaReplicationRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.StartHaReplicationRequest";
+  }
+  protected:
+  explicit StartHaReplicationRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  typedef StartHaReplicationRequest_Param Param;
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kCommandFieldNumber = 1,
+    kRidFieldNumber = 2,
+    kRequestorFieldNumber = 3,
+    kParamFieldNumber = 4,
+  };
+  // string command = 1;
+  void clear_command();
+  const std::string& command() const;
+  void set_command(const std::string& value);
+  void set_command(std::string&& value);
+  void set_command(const char* value);
+  void set_command(const char* value, size_t size);
+  std::string* mutable_command();
+  std::string* release_command();
+  void set_allocated_command(std::string* command);
+  private:
+  const std::string& _internal_command() const;
+  void _internal_set_command(const std::string& value);
+  std::string* _internal_mutable_command();
+  public:
+
+  // string rid = 2;
+  void clear_rid();
+  const std::string& rid() const;
+  void set_rid(const std::string& value);
+  void set_rid(std::string&& value);
+  void set_rid(const char* value);
+  void set_rid(const char* value, size_t size);
+  std::string* mutable_rid();
+  std::string* release_rid();
+  void set_allocated_rid(std::string* rid);
+  private:
+  const std::string& _internal_rid() const;
+  void _internal_set_rid(const std::string& value);
+  std::string* _internal_mutable_rid();
+  public:
+
+  // string requestor = 3;
+  void clear_requestor();
+  const std::string& requestor() const;
+  void set_requestor(const std::string& value);
+  void set_requestor(std::string&& value);
+  void set_requestor(const char* value);
+  void set_requestor(const char* value, size_t size);
+  std::string* mutable_requestor();
+  std::string* release_requestor();
+  void set_allocated_requestor(std::string* requestor);
+  private:
+  const std::string& _internal_requestor() const;
+  void _internal_set_requestor(const std::string& value);
+  std::string* _internal_mutable_requestor();
+  public:
+
+  // .grpc_cli.StartHaReplicationRequest.Param param = 4;
+  bool has_param() const;
+  private:
+  bool _internal_has_param() const;
+  public:
+  void clear_param();
+  const ::grpc_cli::StartHaReplicationRequest_Param& param() const;
+  ::grpc_cli::StartHaReplicationRequest_Param* release_param();
+  ::grpc_cli::StartHaReplicationRequest_Param* mutable_param();
+  void set_allocated_param(::grpc_cli::StartHaReplicationRequest_Param* param);
+  private:
+  const ::grpc_cli::StartHaReplicationRequest_Param& _internal_param() const;
+  ::grpc_cli::StartHaReplicationRequest_Param* _internal_mutable_param();
+  public:
+  void unsafe_arena_set_allocated_param(
+      ::grpc_cli::StartHaReplicationRequest_Param* param);
+  ::grpc_cli::StartHaReplicationRequest_Param* unsafe_arena_release_param();
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.StartHaReplicationRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr command_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr rid_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr requestor_;
+  ::grpc_cli::StartHaReplicationRequest_Param* param_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class StartHaReplicationResponse_Result PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.StartHaReplicationResponse.Result) */ {
+ public:
+  inline StartHaReplicationResponse_Result() : StartHaReplicationResponse_Result(nullptr) {}
+  virtual ~StartHaReplicationResponse_Result();
+  explicit constexpr StartHaReplicationResponse_Result(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  StartHaReplicationResponse_Result(const StartHaReplicationResponse_Result& from);
+  StartHaReplicationResponse_Result(StartHaReplicationResponse_Result&& from) noexcept
+    : StartHaReplicationResponse_Result() {
+    *this = ::std::move(from);
+  }
+
+  inline StartHaReplicationResponse_Result& operator=(const StartHaReplicationResponse_Result& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline StartHaReplicationResponse_Result& operator=(StartHaReplicationResponse_Result&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const StartHaReplicationResponse_Result& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const StartHaReplicationResponse_Result* internal_default_instance() {
+    return reinterpret_cast<const StartHaReplicationResponse_Result*>(
+               &_StartHaReplicationResponse_Result_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    91;
+
+  friend void swap(StartHaReplicationResponse_Result& a, StartHaReplicationResponse_Result& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(StartHaReplicationResponse_Result* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(StartHaReplicationResponse_Result* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline StartHaReplicationResponse_Result* New() const final {
+    return CreateMaybeMessage<StartHaReplicationResponse_Result>(nullptr);
+  }
+
+  StartHaReplicationResponse_Result* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<StartHaReplicationResponse_Result>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const StartHaReplicationResponse_Result& from);
+  void MergeFrom(const StartHaReplicationResponse_Result& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(StartHaReplicationResponse_Result* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.StartHaReplicationResponse.Result";
+  }
+  protected:
+  explicit StartHaReplicationResponse_Result(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kStatusFieldNumber = 1,
+  };
+  // .grpc_cli.Status status = 1;
+  bool has_status() const;
+  private:
+  bool _internal_has_status() const;
+  public:
+  void clear_status();
+  const ::grpc_cli::Status& status() const;
+  ::grpc_cli::Status* release_status();
+  ::grpc_cli::Status* mutable_status();
+  void set_allocated_status(::grpc_cli::Status* status);
+  private:
+  const ::grpc_cli::Status& _internal_status() const;
+  ::grpc_cli::Status* _internal_mutable_status();
+  public:
+  void unsafe_arena_set_allocated_status(
+      ::grpc_cli::Status* status);
+  ::grpc_cli::Status* unsafe_arena_release_status();
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.StartHaReplicationResponse.Result)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::grpc_cli::Status* status_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class StartHaReplicationResponse PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.StartHaReplicationResponse) */ {
+ public:
+  inline StartHaReplicationResponse() : StartHaReplicationResponse(nullptr) {}
+  virtual ~StartHaReplicationResponse();
+  explicit constexpr StartHaReplicationResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  StartHaReplicationResponse(const StartHaReplicationResponse& from);
+  StartHaReplicationResponse(StartHaReplicationResponse&& from) noexcept
+    : StartHaReplicationResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline StartHaReplicationResponse& operator=(const StartHaReplicationResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline StartHaReplicationResponse& operator=(StartHaReplicationResponse&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const StartHaReplicationResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const StartHaReplicationResponse* internal_default_instance() {
+    return reinterpret_cast<const StartHaReplicationResponse*>(
+               &_StartHaReplicationResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    92;
+
+  friend void swap(StartHaReplicationResponse& a, StartHaReplicationResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(StartHaReplicationResponse* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(StartHaReplicationResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline StartHaReplicationResponse* New() const final {
+    return CreateMaybeMessage<StartHaReplicationResponse>(nullptr);
+  }
+
+  StartHaReplicationResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<StartHaReplicationResponse>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const StartHaReplicationResponse& from);
+  void MergeFrom(const StartHaReplicationResponse& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(StartHaReplicationResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.StartHaReplicationResponse";
+  }
+  protected:
+  explicit StartHaReplicationResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  typedef StartHaReplicationResponse_Result Result;
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kCommandFieldNumber = 1,
+    kRidFieldNumber = 2,
+    kResultFieldNumber = 3,
+    kInfoFieldNumber = 4,
+  };
+  // string command = 1;
+  void clear_command();
+  const std::string& command() const;
+  void set_command(const std::string& value);
+  void set_command(std::string&& value);
+  void set_command(const char* value);
+  void set_command(const char* value, size_t size);
+  std::string* mutable_command();
+  std::string* release_command();
+  void set_allocated_command(std::string* command);
+  private:
+  const std::string& _internal_command() const;
+  void _internal_set_command(const std::string& value);
+  std::string* _internal_mutable_command();
+  public:
+
+  // string rid = 2;
+  void clear_rid();
+  const std::string& rid() const;
+  void set_rid(const std::string& value);
+  void set_rid(std::string&& value);
+  void set_rid(const char* value);
+  void set_rid(const char* value, size_t size);
+  std::string* mutable_rid();
+  std::string* release_rid();
+  void set_allocated_rid(std::string* rid);
+  private:
+  const std::string& _internal_rid() const;
+  void _internal_set_rid(const std::string& value);
+  std::string* _internal_mutable_rid();
+  public:
+
+  // .grpc_cli.StartHaReplicationResponse.Result result = 3;
+  bool has_result() const;
+  private:
+  bool _internal_has_result() const;
+  public:
+  void clear_result();
+  const ::grpc_cli::StartHaReplicationResponse_Result& result() const;
+  ::grpc_cli::StartHaReplicationResponse_Result* release_result();
+  ::grpc_cli::StartHaReplicationResponse_Result* mutable_result();
+  void set_allocated_result(::grpc_cli::StartHaReplicationResponse_Result* result);
+  private:
+  const ::grpc_cli::StartHaReplicationResponse_Result& _internal_result() const;
+  ::grpc_cli::StartHaReplicationResponse_Result* _internal_mutable_result();
+  public:
+  void unsafe_arena_set_allocated_result(
+      ::grpc_cli::StartHaReplicationResponse_Result* result);
+  ::grpc_cli::StartHaReplicationResponse_Result* unsafe_arena_release_result();
+
+  // .grpc_cli.PosInfo info = 4;
+  bool has_info() const;
+  private:
+  bool _internal_has_info() const;
+  public:
+  void clear_info();
+  const ::grpc_cli::PosInfo& info() const;
+  ::grpc_cli::PosInfo* release_info();
+  ::grpc_cli::PosInfo* mutable_info();
+  void set_allocated_info(::grpc_cli::PosInfo* info);
+  private:
+  const ::grpc_cli::PosInfo& _internal_info() const;
+  ::grpc_cli::PosInfo* _internal_mutable_info();
+  public:
+  void unsafe_arena_set_allocated_info(
+      ::grpc_cli::PosInfo* info);
+  ::grpc_cli::PosInfo* unsafe_arena_release_info();
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.StartHaReplicationResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr command_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr rid_;
+  ::grpc_cli::StartHaReplicationResponse_Result* result_;
+  ::grpc_cli::PosInfo* info_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
 class SetLogLevelRequest_Param PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.SetLogLevelRequest.Param) */ {
  public:
@@ -15904,7 +17545,7 @@ class SetLogLevelRequest_Param PROTOBUF_FINAL :
                &_SetLogLevelRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    85;
+    93;
 
   friend void swap(SetLogLevelRequest_Param& a, SetLogLevelRequest_Param& b) {
     a.Swap(&b);
@@ -16048,7 +17689,7 @@ class SetLogLevelRequest PROTOBUF_FINAL :
                &_SetLogLevelRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    86;
+    94;
 
   friend void swap(SetLogLevelRequest& a, SetLogLevelRequest& b) {
     a.Swap(&b);
@@ -16250,7 +17891,7 @@ class SetLogLevelResponse_Result PROTOBUF_FINAL :
                &_SetLogLevelResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    87;
+    95;
 
   friend void swap(SetLogLevelResponse_Result& a, SetLogLevelResponse_Result& b) {
     a.Swap(&b);
@@ -16396,7 +18037,7 @@ class SetLogLevelResponse PROTOBUF_FINAL :
                &_SetLogLevelResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    88;
+    96;
 
   friend void swap(SetLogLevelResponse& a, SetLogLevelResponse& b) {
     a.Swap(&b);
@@ -16600,7 +18241,7 @@ class SetLogPreferenceRequest_Param PROTOBUF_FINAL :
                &_SetLogPreferenceRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    89;
+    97;
 
   friend void swap(SetLogPreferenceRequest_Param& a, SetLogPreferenceRequest_Param& b) {
     a.Swap(&b);
@@ -16744,7 +18385,7 @@ class SetLogPreferenceRequest PROTOBUF_FINAL :
                &_SetLogPreferenceRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    90;
+    98;
 
   friend void swap(SetLogPreferenceRequest& a, SetLogPreferenceRequest& b) {
     a.Swap(&b);
@@ -16946,7 +18587,7 @@ class SetLogPreferenceResponse_Result PROTOBUF_FINAL :
                &_SetLogPreferenceResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    91;
+    99;
 
   friend void swap(SetLogPreferenceResponse_Result& a, SetLogPreferenceResponse_Result& b) {
     a.Swap(&b);
@@ -17092,7 +18733,7 @@ class SetLogPreferenceResponse PROTOBUF_FINAL :
                &_SetLogPreferenceResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    92;
+    100;
 
   friend void swap(SetLogPreferenceResponse& a, SetLogPreferenceResponse& b) {
     a.Swap(&b);
@@ -17296,7 +18937,7 @@ class LoggerInfoRequest PROTOBUF_FINAL :
                &_LoggerInfoRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    93;
+    101;
 
   friend void swap(LoggerInfoRequest& a, LoggerInfoRequest& b) {
     a.Swap(&b);
@@ -17476,7 +19117,7 @@ class LoggerInfoResponse_Result_LoggerInfo PROTOBUF_FINAL :
                &_LoggerInfoResponse_Result_LoggerInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    94;
+    102;
 
   friend void swap(LoggerInfoResponse_Result_LoggerInfo& a, LoggerInfoResponse_Result_LoggerInfo& b) {
     a.Swap(&b);
@@ -17743,7 +19384,7 @@ class LoggerInfoResponse_Result PROTOBUF_FINAL :
                &_LoggerInfoResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    95;
+    103;
 
   friend void swap(LoggerInfoResponse_Result& a, LoggerInfoResponse_Result& b) {
     a.Swap(&b);
@@ -17911,7 +19552,7 @@ class LoggerInfoResponse PROTOBUF_FINAL :
                &_LoggerInfoResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    96;
+    104;
 
   friend void swap(LoggerInfoResponse& a, LoggerInfoResponse& b) {
     a.Swap(&b);
@@ -18115,7 +19756,7 @@ class GetLogLevelRequest PROTOBUF_FINAL :
                &_GetLogLevelRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    97;
+    105;
 
   friend void swap(GetLogLevelRequest& a, GetLogLevelRequest& b) {
     a.Swap(&b);
@@ -18295,7 +19936,7 @@ class GetLogLevelResponse_Result_LogLevel PROTOBUF_FINAL :
                &_GetLogLevelResponse_Result_LogLevel_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    98;
+    106;
 
   friend void swap(GetLogLevelResponse_Result_LogLevel& a, GetLogLevelResponse_Result_LogLevel& b) {
     a.Swap(&b);
@@ -18439,7 +20080,7 @@ class GetLogLevelResponse_Result PROTOBUF_FINAL :
                &_GetLogLevelResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    99;
+    107;
 
   friend void swap(GetLogLevelResponse_Result& a, GetLogLevelResponse_Result& b) {
     a.Swap(&b);
@@ -18607,7 +20248,7 @@ class GetLogLevelResponse PROTOBUF_FINAL :
                &_GetLogLevelResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    100;
+    108;
 
   friend void swap(GetLogLevelResponse& a, GetLogLevelResponse& b) {
     a.Swap(&b);
@@ -18811,7 +20452,7 @@ class ApplyLogFilterRequest PROTOBUF_FINAL :
                &_ApplyLogFilterRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    101;
+    109;
 
   friend void swap(ApplyLogFilterRequest& a, ApplyLogFilterRequest& b) {
     a.Swap(&b);
@@ -18991,7 +20632,7 @@ class ApplyLogFilterResponse_Result PROTOBUF_FINAL :
                &_ApplyLogFilterResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    102;
+    110;
 
   friend void swap(ApplyLogFilterResponse_Result& a, ApplyLogFilterResponse_Result& b) {
     a.Swap(&b);
@@ -19137,7 +20778,7 @@ class ApplyLogFilterResponse PROTOBUF_FINAL :
                &_ApplyLogFilterResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    103;
+    111;
 
   friend void swap(ApplyLogFilterResponse& a, ApplyLogFilterResponse& b) {
     a.Swap(&b);
@@ -19341,7 +20982,7 @@ class CreateDeviceRequest_Param PROTOBUF_FINAL :
                &_CreateDeviceRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    104;
+    112;
 
   friend void swap(CreateDeviceRequest_Param& a, CreateDeviceRequest_Param& b) {
     a.Swap(&b);
@@ -19536,7 +21177,7 @@ class CreateDeviceRequest PROTOBUF_FINAL :
                &_CreateDeviceRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    105;
+    113;
 
   friend void swap(CreateDeviceRequest& a, CreateDeviceRequest& b) {
     a.Swap(&b);
@@ -19738,7 +21379,7 @@ class CreateDeviceResponse_Result PROTOBUF_FINAL :
                &_CreateDeviceResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    106;
+    114;
 
   friend void swap(CreateDeviceResponse_Result& a, CreateDeviceResponse_Result& b) {
     a.Swap(&b);
@@ -19884,7 +21525,7 @@ class CreateDeviceResponse PROTOBUF_FINAL :
                &_CreateDeviceResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    107;
+    115;
 
   friend void swap(CreateDeviceResponse& a, CreateDeviceResponse& b) {
     a.Swap(&b);
@@ -20088,7 +21729,7 @@ class ScanDeviceRequest PROTOBUF_FINAL :
                &_ScanDeviceRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    108;
+    116;
 
   friend void swap(ScanDeviceRequest& a, ScanDeviceRequest& b) {
     a.Swap(&b);
@@ -20268,7 +21909,7 @@ class ScanDeviceResponse_Result PROTOBUF_FINAL :
                &_ScanDeviceResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    109;
+    117;
 
   friend void swap(ScanDeviceResponse_Result& a, ScanDeviceResponse_Result& b) {
     a.Swap(&b);
@@ -20414,7 +22055,7 @@ class ScanDeviceResponse PROTOBUF_FINAL :
                &_ScanDeviceResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    110;
+    118;
 
   friend void swap(ScanDeviceResponse& a, ScanDeviceResponse& b) {
     a.Swap(&b);
@@ -20618,7 +22259,7 @@ class Device PROTOBUF_FINAL :
                &_Device_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    111;
+    119;
 
   friend void swap(Device& a, Device& b) {
     a.Swap(&b);
@@ -20881,7 +22522,7 @@ class ListDeviceRequest PROTOBUF_FINAL :
                &_ListDeviceRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    112;
+    120;
 
   friend void swap(ListDeviceRequest& a, ListDeviceRequest& b) {
     a.Swap(&b);
@@ -21061,7 +22702,7 @@ class ListDeviceResponse_Result_DeviceList PROTOBUF_FINAL :
                &_ListDeviceResponse_Result_DeviceList_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    113;
+    121;
 
   friend void swap(ListDeviceResponse_Result_DeviceList& a, ListDeviceResponse_Result_DeviceList& b) {
     a.Swap(&b);
@@ -21207,7 +22848,7 @@ class ListDeviceResponse_Result PROTOBUF_FINAL :
                &_ListDeviceResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    114;
+    122;
 
   friend void swap(ListDeviceResponse_Result& a, ListDeviceResponse_Result& b) {
     a.Swap(&b);
@@ -21375,7 +23016,7 @@ class ListDeviceResponse PROTOBUF_FINAL :
                &_ListDeviceResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    115;
+    123;
 
   friend void swap(ListDeviceResponse& a, ListDeviceResponse& b) {
     a.Swap(&b);
@@ -21579,7 +23220,7 @@ class SmartLog PROTOBUF_FINAL :
                &_SmartLog_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    116;
+    124;
 
   friend void swap(SmartLog& a, SmartLog& b) {
     a.Swap(&b);
@@ -22109,7 +23750,7 @@ class GetSmartLogRequest_Param PROTOBUF_FINAL :
                &_GetSmartLogRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    117;
+    125;
 
   friend void swap(GetSmartLogRequest_Param& a, GetSmartLogRequest_Param& b) {
     a.Swap(&b);
@@ -22253,7 +23894,7 @@ class GetSmartLogRequest PROTOBUF_FINAL :
                &_GetSmartLogRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    118;
+    126;
 
   friend void swap(GetSmartLogRequest& a, GetSmartLogRequest& b) {
     a.Swap(&b);
@@ -22455,7 +24096,7 @@ class GetSmartLogResponse_Result PROTOBUF_FINAL :
                &_GetSmartLogResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    119;
+    127;
 
   friend void swap(GetSmartLogResponse_Result& a, GetSmartLogResponse_Result& b) {
     a.Swap(&b);
@@ -22621,7 +24262,7 @@ class GetSmartLogResponse PROTOBUF_FINAL :
                &_GetSmartLogResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    120;
+    128;
 
   friend void swap(GetSmartLogResponse& a, GetSmartLogResponse& b) {
     a.Swap(&b);
@@ -23426,6 +25067,67 @@ inline void SystemInfoResponse_Result_Data::set_allocated_version(std::string* v
   version_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), version,
       GetArena());
   // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.version)
+}
+
+// string biosVersion = 2;
+inline void SystemInfoResponse_Result_Data::clear_biosversion() {
+  biosversion_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::biosversion() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.biosVersion)
+  return _internal_biosversion();
+}
+inline void SystemInfoResponse_Result_Data::set_biosversion(const std::string& value) {
+  _internal_set_biosversion(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.biosVersion)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_biosversion() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.biosVersion)
+  return _internal_mutable_biosversion();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_biosversion() const {
+  return biosversion_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_biosversion(const std::string& value) {
+  
+  biosversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_biosversion(std::string&& value) {
+  
+  biosversion_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.biosVersion)
+}
+inline void SystemInfoResponse_Result_Data::set_biosversion(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  biosversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.biosVersion)
+}
+inline void SystemInfoResponse_Result_Data::set_biosversion(const char* value,
+    size_t size) {
+  
+  biosversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.biosVersion)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_biosversion() {
+  
+  return biosversion_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_biosversion() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.biosVersion)
+  return biosversion_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_biosversion(std::string* biosversion) {
+  if (biosversion != nullptr) {
+    
+  } else {
+    
+  }
+  biosversion_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), biosversion,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.biosVersion)
 }
 
 // -------------------------------------------------------------------
@@ -39142,6 +40844,1978 @@ inline void ListHaVolumeResponse::set_allocated_info(::grpc_cli::PosInfo* info) 
 
 // -------------------------------------------------------------------
 
+// ListHaReplicationRequest
+
+// string command = 1;
+inline void ListHaReplicationRequest::clear_command() {
+  command_.ClearToEmpty();
+}
+inline const std::string& ListHaReplicationRequest::command() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationRequest.command)
+  return _internal_command();
+}
+inline void ListHaReplicationRequest::set_command(const std::string& value) {
+  _internal_set_command(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaReplicationRequest.command)
+}
+inline std::string* ListHaReplicationRequest::mutable_command() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaReplicationRequest.command)
+  return _internal_mutable_command();
+}
+inline const std::string& ListHaReplicationRequest::_internal_command() const {
+  return command_.Get();
+}
+inline void ListHaReplicationRequest::_internal_set_command(const std::string& value) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaReplicationRequest::set_command(std::string&& value) {
+  
+  command_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaReplicationRequest.command)
+}
+inline void ListHaReplicationRequest::set_command(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaReplicationRequest.command)
+}
+inline void ListHaReplicationRequest::set_command(const char* value,
+    size_t size) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaReplicationRequest.command)
+}
+inline std::string* ListHaReplicationRequest::_internal_mutable_command() {
+  
+  return command_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaReplicationRequest::release_command() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaReplicationRequest.command)
+  return command_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaReplicationRequest::set_allocated_command(std::string* command) {
+  if (command != nullptr) {
+    
+  } else {
+    
+  }
+  command_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), command,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaReplicationRequest.command)
+}
+
+// string rid = 2;
+inline void ListHaReplicationRequest::clear_rid() {
+  rid_.ClearToEmpty();
+}
+inline const std::string& ListHaReplicationRequest::rid() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationRequest.rid)
+  return _internal_rid();
+}
+inline void ListHaReplicationRequest::set_rid(const std::string& value) {
+  _internal_set_rid(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaReplicationRequest.rid)
+}
+inline std::string* ListHaReplicationRequest::mutable_rid() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaReplicationRequest.rid)
+  return _internal_mutable_rid();
+}
+inline const std::string& ListHaReplicationRequest::_internal_rid() const {
+  return rid_.Get();
+}
+inline void ListHaReplicationRequest::_internal_set_rid(const std::string& value) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaReplicationRequest::set_rid(std::string&& value) {
+  
+  rid_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaReplicationRequest.rid)
+}
+inline void ListHaReplicationRequest::set_rid(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaReplicationRequest.rid)
+}
+inline void ListHaReplicationRequest::set_rid(const char* value,
+    size_t size) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaReplicationRequest.rid)
+}
+inline std::string* ListHaReplicationRequest::_internal_mutable_rid() {
+  
+  return rid_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaReplicationRequest::release_rid() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaReplicationRequest.rid)
+  return rid_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaReplicationRequest::set_allocated_rid(std::string* rid) {
+  if (rid != nullptr) {
+    
+  } else {
+    
+  }
+  rid_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), rid,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaReplicationRequest.rid)
+}
+
+// string requestor = 3;
+inline void ListHaReplicationRequest::clear_requestor() {
+  requestor_.ClearToEmpty();
+}
+inline const std::string& ListHaReplicationRequest::requestor() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationRequest.requestor)
+  return _internal_requestor();
+}
+inline void ListHaReplicationRequest::set_requestor(const std::string& value) {
+  _internal_set_requestor(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaReplicationRequest.requestor)
+}
+inline std::string* ListHaReplicationRequest::mutable_requestor() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaReplicationRequest.requestor)
+  return _internal_mutable_requestor();
+}
+inline const std::string& ListHaReplicationRequest::_internal_requestor() const {
+  return requestor_.Get();
+}
+inline void ListHaReplicationRequest::_internal_set_requestor(const std::string& value) {
+  
+  requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaReplicationRequest::set_requestor(std::string&& value) {
+  
+  requestor_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaReplicationRequest.requestor)
+}
+inline void ListHaReplicationRequest::set_requestor(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaReplicationRequest.requestor)
+}
+inline void ListHaReplicationRequest::set_requestor(const char* value,
+    size_t size) {
+  
+  requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaReplicationRequest.requestor)
+}
+inline std::string* ListHaReplicationRequest::_internal_mutable_requestor() {
+  
+  return requestor_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaReplicationRequest::release_requestor() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaReplicationRequest.requestor)
+  return requestor_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaReplicationRequest::set_allocated_requestor(std::string* requestor) {
+  if (requestor != nullptr) {
+    
+  } else {
+    
+  }
+  requestor_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), requestor,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaReplicationRequest.requestor)
+}
+
+// -------------------------------------------------------------------
+
+// ListHaReplicationResponse_Result_Replication
+
+// int32 id = 1;
+inline void ListHaReplicationResponse_Result_Replication::clear_id() {
+  id_ = 0;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 ListHaReplicationResponse_Result_Replication::_internal_id() const {
+  return id_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 ListHaReplicationResponse_Result_Replication::id() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationResponse.Result.Replication.id)
+  return _internal_id();
+}
+inline void ListHaReplicationResponse_Result_Replication::_internal_set_id(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  
+  id_ = value;
+}
+inline void ListHaReplicationResponse_Result_Replication::set_id(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  _internal_set_id(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaReplicationResponse.Result.Replication.id)
+}
+
+// int32 sourceVolumeId = 2;
+inline void ListHaReplicationResponse_Result_Replication::clear_sourcevolumeid() {
+  sourcevolumeid_ = 0;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 ListHaReplicationResponse_Result_Replication::_internal_sourcevolumeid() const {
+  return sourcevolumeid_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 ListHaReplicationResponse_Result_Replication::sourcevolumeid() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationResponse.Result.Replication.sourceVolumeId)
+  return _internal_sourcevolumeid();
+}
+inline void ListHaReplicationResponse_Result_Replication::_internal_set_sourcevolumeid(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  
+  sourcevolumeid_ = value;
+}
+inline void ListHaReplicationResponse_Result_Replication::set_sourcevolumeid(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  _internal_set_sourcevolumeid(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaReplicationResponse.Result.Replication.sourceVolumeId)
+}
+
+// int32 sourceWalVolume_id = 3;
+inline void ListHaReplicationResponse_Result_Replication::clear_sourcewalvolume_id() {
+  sourcewalvolume_id_ = 0;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 ListHaReplicationResponse_Result_Replication::_internal_sourcewalvolume_id() const {
+  return sourcewalvolume_id_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 ListHaReplicationResponse_Result_Replication::sourcewalvolume_id() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationResponse.Result.Replication.sourceWalVolume_id)
+  return _internal_sourcewalvolume_id();
+}
+inline void ListHaReplicationResponse_Result_Replication::_internal_set_sourcewalvolume_id(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  
+  sourcewalvolume_id_ = value;
+}
+inline void ListHaReplicationResponse_Result_Replication::set_sourcewalvolume_id(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  _internal_set_sourcewalvolume_id(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaReplicationResponse.Result.Replication.sourceWalVolume_id)
+}
+
+// int32 destinationVolumeId = 4;
+inline void ListHaReplicationResponse_Result_Replication::clear_destinationvolumeid() {
+  destinationvolumeid_ = 0;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 ListHaReplicationResponse_Result_Replication::_internal_destinationvolumeid() const {
+  return destinationvolumeid_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 ListHaReplicationResponse_Result_Replication::destinationvolumeid() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationResponse.Result.Replication.destinationVolumeId)
+  return _internal_destinationvolumeid();
+}
+inline void ListHaReplicationResponse_Result_Replication::_internal_set_destinationvolumeid(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  
+  destinationvolumeid_ = value;
+}
+inline void ListHaReplicationResponse_Result_Replication::set_destinationvolumeid(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  _internal_set_destinationvolumeid(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaReplicationResponse.Result.Replication.destinationVolumeId)
+}
+
+// int32 destinationWalVolumeId = 5;
+inline void ListHaReplicationResponse_Result_Replication::clear_destinationwalvolumeid() {
+  destinationwalvolumeid_ = 0;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 ListHaReplicationResponse_Result_Replication::_internal_destinationwalvolumeid() const {
+  return destinationwalvolumeid_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 ListHaReplicationResponse_Result_Replication::destinationwalvolumeid() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationResponse.Result.Replication.destinationWalVolumeId)
+  return _internal_destinationwalvolumeid();
+}
+inline void ListHaReplicationResponse_Result_Replication::_internal_set_destinationwalvolumeid(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  
+  destinationwalvolumeid_ = value;
+}
+inline void ListHaReplicationResponse_Result_Replication::set_destinationwalvolumeid(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  _internal_set_destinationwalvolumeid(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaReplicationResponse.Result.Replication.destinationWalVolumeId)
+}
+
+// -------------------------------------------------------------------
+
+// ListHaReplicationResponse_Result
+
+// .grpc_cli.Status status = 1;
+inline bool ListHaReplicationResponse_Result::_internal_has_status() const {
+  return this != internal_default_instance() && status_ != nullptr;
+}
+inline bool ListHaReplicationResponse_Result::has_status() const {
+  return _internal_has_status();
+}
+inline void ListHaReplicationResponse_Result::clear_status() {
+  if (GetArena() == nullptr && status_ != nullptr) {
+    delete status_;
+  }
+  status_ = nullptr;
+}
+inline const ::grpc_cli::Status& ListHaReplicationResponse_Result::_internal_status() const {
+  const ::grpc_cli::Status* p = status_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::Status&>(
+      ::grpc_cli::_Status_default_instance_);
+}
+inline const ::grpc_cli::Status& ListHaReplicationResponse_Result::status() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationResponse.Result.status)
+  return _internal_status();
+}
+inline void ListHaReplicationResponse_Result::unsafe_arena_set_allocated_status(
+    ::grpc_cli::Status* status) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(status_);
+  }
+  status_ = status;
+  if (status) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.ListHaReplicationResponse.Result.status)
+}
+inline ::grpc_cli::Status* ListHaReplicationResponse_Result::release_status() {
+  
+  ::grpc_cli::Status* temp = status_;
+  status_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::Status* ListHaReplicationResponse_Result::unsafe_arena_release_status() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaReplicationResponse.Result.status)
+  
+  ::grpc_cli::Status* temp = status_;
+  status_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::Status* ListHaReplicationResponse_Result::_internal_mutable_status() {
+  
+  if (status_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::Status>(GetArena());
+    status_ = p;
+  }
+  return status_;
+}
+inline ::grpc_cli::Status* ListHaReplicationResponse_Result::mutable_status() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaReplicationResponse.Result.status)
+  return _internal_mutable_status();
+}
+inline void ListHaReplicationResponse_Result::set_allocated_status(::grpc_cli::Status* status) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete status_;
+  }
+  if (status) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(status);
+    if (message_arena != submessage_arena) {
+      status = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, status, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  status_ = status;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaReplicationResponse.Result.status)
+}
+
+// repeated .grpc_cli.ListHaReplicationResponse.Result.Replication data = 2;
+inline int ListHaReplicationResponse_Result::_internal_data_size() const {
+  return data_.size();
+}
+inline int ListHaReplicationResponse_Result::data_size() const {
+  return _internal_data_size();
+}
+inline void ListHaReplicationResponse_Result::clear_data() {
+  data_.Clear();
+}
+inline ::grpc_cli::ListHaReplicationResponse_Result_Replication* ListHaReplicationResponse_Result::mutable_data(int index) {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaReplicationResponse.Result.data)
+  return data_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::grpc_cli::ListHaReplicationResponse_Result_Replication >*
+ListHaReplicationResponse_Result::mutable_data() {
+  // @@protoc_insertion_point(field_mutable_list:grpc_cli.ListHaReplicationResponse.Result.data)
+  return &data_;
+}
+inline const ::grpc_cli::ListHaReplicationResponse_Result_Replication& ListHaReplicationResponse_Result::_internal_data(int index) const {
+  return data_.Get(index);
+}
+inline const ::grpc_cli::ListHaReplicationResponse_Result_Replication& ListHaReplicationResponse_Result::data(int index) const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationResponse.Result.data)
+  return _internal_data(index);
+}
+inline ::grpc_cli::ListHaReplicationResponse_Result_Replication* ListHaReplicationResponse_Result::_internal_add_data() {
+  return data_.Add();
+}
+inline ::grpc_cli::ListHaReplicationResponse_Result_Replication* ListHaReplicationResponse_Result::add_data() {
+  // @@protoc_insertion_point(field_add:grpc_cli.ListHaReplicationResponse.Result.data)
+  return _internal_add_data();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::grpc_cli::ListHaReplicationResponse_Result_Replication >&
+ListHaReplicationResponse_Result::data() const {
+  // @@protoc_insertion_point(field_list:grpc_cli.ListHaReplicationResponse.Result.data)
+  return data_;
+}
+
+// -------------------------------------------------------------------
+
+// ListHaReplicationResponse
+
+// string command = 1;
+inline void ListHaReplicationResponse::clear_command() {
+  command_.ClearToEmpty();
+}
+inline const std::string& ListHaReplicationResponse::command() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationResponse.command)
+  return _internal_command();
+}
+inline void ListHaReplicationResponse::set_command(const std::string& value) {
+  _internal_set_command(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaReplicationResponse.command)
+}
+inline std::string* ListHaReplicationResponse::mutable_command() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaReplicationResponse.command)
+  return _internal_mutable_command();
+}
+inline const std::string& ListHaReplicationResponse::_internal_command() const {
+  return command_.Get();
+}
+inline void ListHaReplicationResponse::_internal_set_command(const std::string& value) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaReplicationResponse::set_command(std::string&& value) {
+  
+  command_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaReplicationResponse.command)
+}
+inline void ListHaReplicationResponse::set_command(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaReplicationResponse.command)
+}
+inline void ListHaReplicationResponse::set_command(const char* value,
+    size_t size) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaReplicationResponse.command)
+}
+inline std::string* ListHaReplicationResponse::_internal_mutable_command() {
+  
+  return command_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaReplicationResponse::release_command() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaReplicationResponse.command)
+  return command_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaReplicationResponse::set_allocated_command(std::string* command) {
+  if (command != nullptr) {
+    
+  } else {
+    
+  }
+  command_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), command,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaReplicationResponse.command)
+}
+
+// string rid = 2;
+inline void ListHaReplicationResponse::clear_rid() {
+  rid_.ClearToEmpty();
+}
+inline const std::string& ListHaReplicationResponse::rid() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationResponse.rid)
+  return _internal_rid();
+}
+inline void ListHaReplicationResponse::set_rid(const std::string& value) {
+  _internal_set_rid(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.ListHaReplicationResponse.rid)
+}
+inline std::string* ListHaReplicationResponse::mutable_rid() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaReplicationResponse.rid)
+  return _internal_mutable_rid();
+}
+inline const std::string& ListHaReplicationResponse::_internal_rid() const {
+  return rid_.Get();
+}
+inline void ListHaReplicationResponse::_internal_set_rid(const std::string& value) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void ListHaReplicationResponse::set_rid(std::string&& value) {
+  
+  rid_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.ListHaReplicationResponse.rid)
+}
+inline void ListHaReplicationResponse::set_rid(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.ListHaReplicationResponse.rid)
+}
+inline void ListHaReplicationResponse::set_rid(const char* value,
+    size_t size) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.ListHaReplicationResponse.rid)
+}
+inline std::string* ListHaReplicationResponse::_internal_mutable_rid() {
+  
+  return rid_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* ListHaReplicationResponse::release_rid() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaReplicationResponse.rid)
+  return rid_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void ListHaReplicationResponse::set_allocated_rid(std::string* rid) {
+  if (rid != nullptr) {
+    
+  } else {
+    
+  }
+  rid_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), rid,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaReplicationResponse.rid)
+}
+
+// .grpc_cli.ListHaReplicationResponse.Result result = 3;
+inline bool ListHaReplicationResponse::_internal_has_result() const {
+  return this != internal_default_instance() && result_ != nullptr;
+}
+inline bool ListHaReplicationResponse::has_result() const {
+  return _internal_has_result();
+}
+inline void ListHaReplicationResponse::clear_result() {
+  if (GetArena() == nullptr && result_ != nullptr) {
+    delete result_;
+  }
+  result_ = nullptr;
+}
+inline const ::grpc_cli::ListHaReplicationResponse_Result& ListHaReplicationResponse::_internal_result() const {
+  const ::grpc_cli::ListHaReplicationResponse_Result* p = result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::ListHaReplicationResponse_Result&>(
+      ::grpc_cli::_ListHaReplicationResponse_Result_default_instance_);
+}
+inline const ::grpc_cli::ListHaReplicationResponse_Result& ListHaReplicationResponse::result() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationResponse.result)
+  return _internal_result();
+}
+inline void ListHaReplicationResponse::unsafe_arena_set_allocated_result(
+    ::grpc_cli::ListHaReplicationResponse_Result* result) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(result_);
+  }
+  result_ = result;
+  if (result) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.ListHaReplicationResponse.result)
+}
+inline ::grpc_cli::ListHaReplicationResponse_Result* ListHaReplicationResponse::release_result() {
+  
+  ::grpc_cli::ListHaReplicationResponse_Result* temp = result_;
+  result_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::ListHaReplicationResponse_Result* ListHaReplicationResponse::unsafe_arena_release_result() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaReplicationResponse.result)
+  
+  ::grpc_cli::ListHaReplicationResponse_Result* temp = result_;
+  result_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::ListHaReplicationResponse_Result* ListHaReplicationResponse::_internal_mutable_result() {
+  
+  if (result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::ListHaReplicationResponse_Result>(GetArena());
+    result_ = p;
+  }
+  return result_;
+}
+inline ::grpc_cli::ListHaReplicationResponse_Result* ListHaReplicationResponse::mutable_result() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaReplicationResponse.result)
+  return _internal_mutable_result();
+}
+inline void ListHaReplicationResponse::set_allocated_result(::grpc_cli::ListHaReplicationResponse_Result* result) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete result_;
+  }
+  if (result) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(result);
+    if (message_arena != submessage_arena) {
+      result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, result, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  result_ = result;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaReplicationResponse.result)
+}
+
+// .grpc_cli.PosInfo info = 4;
+inline bool ListHaReplicationResponse::_internal_has_info() const {
+  return this != internal_default_instance() && info_ != nullptr;
+}
+inline bool ListHaReplicationResponse::has_info() const {
+  return _internal_has_info();
+}
+inline void ListHaReplicationResponse::clear_info() {
+  if (GetArena() == nullptr && info_ != nullptr) {
+    delete info_;
+  }
+  info_ = nullptr;
+}
+inline const ::grpc_cli::PosInfo& ListHaReplicationResponse::_internal_info() const {
+  const ::grpc_cli::PosInfo* p = info_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::PosInfo&>(
+      ::grpc_cli::_PosInfo_default_instance_);
+}
+inline const ::grpc_cli::PosInfo& ListHaReplicationResponse::info() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.ListHaReplicationResponse.info)
+  return _internal_info();
+}
+inline void ListHaReplicationResponse::unsafe_arena_set_allocated_info(
+    ::grpc_cli::PosInfo* info) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(info_);
+  }
+  info_ = info;
+  if (info) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.ListHaReplicationResponse.info)
+}
+inline ::grpc_cli::PosInfo* ListHaReplicationResponse::release_info() {
+  
+  ::grpc_cli::PosInfo* temp = info_;
+  info_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::PosInfo* ListHaReplicationResponse::unsafe_arena_release_info() {
+  // @@protoc_insertion_point(field_release:grpc_cli.ListHaReplicationResponse.info)
+  
+  ::grpc_cli::PosInfo* temp = info_;
+  info_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::PosInfo* ListHaReplicationResponse::_internal_mutable_info() {
+  
+  if (info_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::PosInfo>(GetArena());
+    info_ = p;
+  }
+  return info_;
+}
+inline ::grpc_cli::PosInfo* ListHaReplicationResponse::mutable_info() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.ListHaReplicationResponse.info)
+  return _internal_mutable_info();
+}
+inline void ListHaReplicationResponse::set_allocated_info(::grpc_cli::PosInfo* info) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete info_;
+  }
+  if (info) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(info);
+    if (message_arena != submessage_arena) {
+      info = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, info, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  info_ = info;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.ListHaReplicationResponse.info)
+}
+
+// -------------------------------------------------------------------
+
+// StartHaReplicationRequest_Param
+
+// string primaryNodeName = 1;
+inline void StartHaReplicationRequest_Param::clear_primarynodename() {
+  primarynodename_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationRequest_Param::primarynodename() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.Param.primaryNodeName)
+  return _internal_primarynodename();
+}
+inline void StartHaReplicationRequest_Param::set_primarynodename(const std::string& value) {
+  _internal_set_primarynodename(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationRequest.Param.primaryNodeName)
+}
+inline std::string* StartHaReplicationRequest_Param::mutable_primarynodename() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.Param.primaryNodeName)
+  return _internal_mutable_primarynodename();
+}
+inline const std::string& StartHaReplicationRequest_Param::_internal_primarynodename() const {
+  return primarynodename_.Get();
+}
+inline void StartHaReplicationRequest_Param::_internal_set_primarynodename(const std::string& value) {
+  
+  primarynodename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_primarynodename(std::string&& value) {
+  
+  primarynodename_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationRequest.Param.primaryNodeName)
+}
+inline void StartHaReplicationRequest_Param::set_primarynodename(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  primarynodename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationRequest.Param.primaryNodeName)
+}
+inline void StartHaReplicationRequest_Param::set_primarynodename(const char* value,
+    size_t size) {
+  
+  primarynodename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationRequest.Param.primaryNodeName)
+}
+inline std::string* StartHaReplicationRequest_Param::_internal_mutable_primarynodename() {
+  
+  return primarynodename_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationRequest_Param::release_primarynodename() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.Param.primaryNodeName)
+  return primarynodename_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_allocated_primarynodename(std::string* primarynodename) {
+  if (primarynodename != nullptr) {
+    
+  } else {
+    
+  }
+  primarynodename_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), primarynodename,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.Param.primaryNodeName)
+}
+
+// string primaryArrayName = 2;
+inline void StartHaReplicationRequest_Param::clear_primaryarrayname() {
+  primaryarrayname_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationRequest_Param::primaryarrayname() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.Param.primaryArrayName)
+  return _internal_primaryarrayname();
+}
+inline void StartHaReplicationRequest_Param::set_primaryarrayname(const std::string& value) {
+  _internal_set_primaryarrayname(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationRequest.Param.primaryArrayName)
+}
+inline std::string* StartHaReplicationRequest_Param::mutable_primaryarrayname() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.Param.primaryArrayName)
+  return _internal_mutable_primaryarrayname();
+}
+inline const std::string& StartHaReplicationRequest_Param::_internal_primaryarrayname() const {
+  return primaryarrayname_.Get();
+}
+inline void StartHaReplicationRequest_Param::_internal_set_primaryarrayname(const std::string& value) {
+  
+  primaryarrayname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_primaryarrayname(std::string&& value) {
+  
+  primaryarrayname_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationRequest.Param.primaryArrayName)
+}
+inline void StartHaReplicationRequest_Param::set_primaryarrayname(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  primaryarrayname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationRequest.Param.primaryArrayName)
+}
+inline void StartHaReplicationRequest_Param::set_primaryarrayname(const char* value,
+    size_t size) {
+  
+  primaryarrayname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationRequest.Param.primaryArrayName)
+}
+inline std::string* StartHaReplicationRequest_Param::_internal_mutable_primaryarrayname() {
+  
+  return primaryarrayname_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationRequest_Param::release_primaryarrayname() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.Param.primaryArrayName)
+  return primaryarrayname_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_allocated_primaryarrayname(std::string* primaryarrayname) {
+  if (primaryarrayname != nullptr) {
+    
+  } else {
+    
+  }
+  primaryarrayname_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), primaryarrayname,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.Param.primaryArrayName)
+}
+
+// string primaryVolumeName = 3;
+inline void StartHaReplicationRequest_Param::clear_primaryvolumename() {
+  primaryvolumename_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationRequest_Param::primaryvolumename() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.Param.primaryVolumeName)
+  return _internal_primaryvolumename();
+}
+inline void StartHaReplicationRequest_Param::set_primaryvolumename(const std::string& value) {
+  _internal_set_primaryvolumename(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationRequest.Param.primaryVolumeName)
+}
+inline std::string* StartHaReplicationRequest_Param::mutable_primaryvolumename() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.Param.primaryVolumeName)
+  return _internal_mutable_primaryvolumename();
+}
+inline const std::string& StartHaReplicationRequest_Param::_internal_primaryvolumename() const {
+  return primaryvolumename_.Get();
+}
+inline void StartHaReplicationRequest_Param::_internal_set_primaryvolumename(const std::string& value) {
+  
+  primaryvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_primaryvolumename(std::string&& value) {
+  
+  primaryvolumename_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationRequest.Param.primaryVolumeName)
+}
+inline void StartHaReplicationRequest_Param::set_primaryvolumename(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  primaryvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationRequest.Param.primaryVolumeName)
+}
+inline void StartHaReplicationRequest_Param::set_primaryvolumename(const char* value,
+    size_t size) {
+  
+  primaryvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationRequest.Param.primaryVolumeName)
+}
+inline std::string* StartHaReplicationRequest_Param::_internal_mutable_primaryvolumename() {
+  
+  return primaryvolumename_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationRequest_Param::release_primaryvolumename() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.Param.primaryVolumeName)
+  return primaryvolumename_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_allocated_primaryvolumename(std::string* primaryvolumename) {
+  if (primaryvolumename != nullptr) {
+    
+  } else {
+    
+  }
+  primaryvolumename_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), primaryvolumename,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.Param.primaryVolumeName)
+}
+
+// string primaryWalVolumeName = 4;
+inline void StartHaReplicationRequest_Param::clear_primarywalvolumename() {
+  primarywalvolumename_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationRequest_Param::primarywalvolumename() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.Param.primaryWalVolumeName)
+  return _internal_primarywalvolumename();
+}
+inline void StartHaReplicationRequest_Param::set_primarywalvolumename(const std::string& value) {
+  _internal_set_primarywalvolumename(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationRequest.Param.primaryWalVolumeName)
+}
+inline std::string* StartHaReplicationRequest_Param::mutable_primarywalvolumename() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.Param.primaryWalVolumeName)
+  return _internal_mutable_primarywalvolumename();
+}
+inline const std::string& StartHaReplicationRequest_Param::_internal_primarywalvolumename() const {
+  return primarywalvolumename_.Get();
+}
+inline void StartHaReplicationRequest_Param::_internal_set_primarywalvolumename(const std::string& value) {
+  
+  primarywalvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_primarywalvolumename(std::string&& value) {
+  
+  primarywalvolumename_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationRequest.Param.primaryWalVolumeName)
+}
+inline void StartHaReplicationRequest_Param::set_primarywalvolumename(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  primarywalvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationRequest.Param.primaryWalVolumeName)
+}
+inline void StartHaReplicationRequest_Param::set_primarywalvolumename(const char* value,
+    size_t size) {
+  
+  primarywalvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationRequest.Param.primaryWalVolumeName)
+}
+inline std::string* StartHaReplicationRequest_Param::_internal_mutable_primarywalvolumename() {
+  
+  return primarywalvolumename_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationRequest_Param::release_primarywalvolumename() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.Param.primaryWalVolumeName)
+  return primarywalvolumename_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_allocated_primarywalvolumename(std::string* primarywalvolumename) {
+  if (primarywalvolumename != nullptr) {
+    
+  } else {
+    
+  }
+  primarywalvolumename_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), primarywalvolumename,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.Param.primaryWalVolumeName)
+}
+
+// string secondaryNodeName = 5;
+inline void StartHaReplicationRequest_Param::clear_secondarynodename() {
+  secondarynodename_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationRequest_Param::secondarynodename() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.Param.secondaryNodeName)
+  return _internal_secondarynodename();
+}
+inline void StartHaReplicationRequest_Param::set_secondarynodename(const std::string& value) {
+  _internal_set_secondarynodename(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationRequest.Param.secondaryNodeName)
+}
+inline std::string* StartHaReplicationRequest_Param::mutable_secondarynodename() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.Param.secondaryNodeName)
+  return _internal_mutable_secondarynodename();
+}
+inline const std::string& StartHaReplicationRequest_Param::_internal_secondarynodename() const {
+  return secondarynodename_.Get();
+}
+inline void StartHaReplicationRequest_Param::_internal_set_secondarynodename(const std::string& value) {
+  
+  secondarynodename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_secondarynodename(std::string&& value) {
+  
+  secondarynodename_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationRequest.Param.secondaryNodeName)
+}
+inline void StartHaReplicationRequest_Param::set_secondarynodename(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  secondarynodename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationRequest.Param.secondaryNodeName)
+}
+inline void StartHaReplicationRequest_Param::set_secondarynodename(const char* value,
+    size_t size) {
+  
+  secondarynodename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationRequest.Param.secondaryNodeName)
+}
+inline std::string* StartHaReplicationRequest_Param::_internal_mutable_secondarynodename() {
+  
+  return secondarynodename_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationRequest_Param::release_secondarynodename() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.Param.secondaryNodeName)
+  return secondarynodename_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_allocated_secondarynodename(std::string* secondarynodename) {
+  if (secondarynodename != nullptr) {
+    
+  } else {
+    
+  }
+  secondarynodename_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), secondarynodename,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.Param.secondaryNodeName)
+}
+
+// string secondaryArrayName = 6;
+inline void StartHaReplicationRequest_Param::clear_secondaryarrayname() {
+  secondaryarrayname_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationRequest_Param::secondaryarrayname() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.Param.secondaryArrayName)
+  return _internal_secondaryarrayname();
+}
+inline void StartHaReplicationRequest_Param::set_secondaryarrayname(const std::string& value) {
+  _internal_set_secondaryarrayname(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationRequest.Param.secondaryArrayName)
+}
+inline std::string* StartHaReplicationRequest_Param::mutable_secondaryarrayname() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.Param.secondaryArrayName)
+  return _internal_mutable_secondaryarrayname();
+}
+inline const std::string& StartHaReplicationRequest_Param::_internal_secondaryarrayname() const {
+  return secondaryarrayname_.Get();
+}
+inline void StartHaReplicationRequest_Param::_internal_set_secondaryarrayname(const std::string& value) {
+  
+  secondaryarrayname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_secondaryarrayname(std::string&& value) {
+  
+  secondaryarrayname_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationRequest.Param.secondaryArrayName)
+}
+inline void StartHaReplicationRequest_Param::set_secondaryarrayname(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  secondaryarrayname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationRequest.Param.secondaryArrayName)
+}
+inline void StartHaReplicationRequest_Param::set_secondaryarrayname(const char* value,
+    size_t size) {
+  
+  secondaryarrayname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationRequest.Param.secondaryArrayName)
+}
+inline std::string* StartHaReplicationRequest_Param::_internal_mutable_secondaryarrayname() {
+  
+  return secondaryarrayname_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationRequest_Param::release_secondaryarrayname() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.Param.secondaryArrayName)
+  return secondaryarrayname_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_allocated_secondaryarrayname(std::string* secondaryarrayname) {
+  if (secondaryarrayname != nullptr) {
+    
+  } else {
+    
+  }
+  secondaryarrayname_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), secondaryarrayname,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.Param.secondaryArrayName)
+}
+
+// string secondaryVolumeName = 7;
+inline void StartHaReplicationRequest_Param::clear_secondaryvolumename() {
+  secondaryvolumename_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationRequest_Param::secondaryvolumename() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.Param.secondaryVolumeName)
+  return _internal_secondaryvolumename();
+}
+inline void StartHaReplicationRequest_Param::set_secondaryvolumename(const std::string& value) {
+  _internal_set_secondaryvolumename(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationRequest.Param.secondaryVolumeName)
+}
+inline std::string* StartHaReplicationRequest_Param::mutable_secondaryvolumename() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.Param.secondaryVolumeName)
+  return _internal_mutable_secondaryvolumename();
+}
+inline const std::string& StartHaReplicationRequest_Param::_internal_secondaryvolumename() const {
+  return secondaryvolumename_.Get();
+}
+inline void StartHaReplicationRequest_Param::_internal_set_secondaryvolumename(const std::string& value) {
+  
+  secondaryvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_secondaryvolumename(std::string&& value) {
+  
+  secondaryvolumename_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationRequest.Param.secondaryVolumeName)
+}
+inline void StartHaReplicationRequest_Param::set_secondaryvolumename(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  secondaryvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationRequest.Param.secondaryVolumeName)
+}
+inline void StartHaReplicationRequest_Param::set_secondaryvolumename(const char* value,
+    size_t size) {
+  
+  secondaryvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationRequest.Param.secondaryVolumeName)
+}
+inline std::string* StartHaReplicationRequest_Param::_internal_mutable_secondaryvolumename() {
+  
+  return secondaryvolumename_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationRequest_Param::release_secondaryvolumename() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.Param.secondaryVolumeName)
+  return secondaryvolumename_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_allocated_secondaryvolumename(std::string* secondaryvolumename) {
+  if (secondaryvolumename != nullptr) {
+    
+  } else {
+    
+  }
+  secondaryvolumename_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), secondaryvolumename,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.Param.secondaryVolumeName)
+}
+
+// string secondaryWalVolumeName = 8;
+inline void StartHaReplicationRequest_Param::clear_secondarywalvolumename() {
+  secondarywalvolumename_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationRequest_Param::secondarywalvolumename() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.Param.secondaryWalVolumeName)
+  return _internal_secondarywalvolumename();
+}
+inline void StartHaReplicationRequest_Param::set_secondarywalvolumename(const std::string& value) {
+  _internal_set_secondarywalvolumename(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationRequest.Param.secondaryWalVolumeName)
+}
+inline std::string* StartHaReplicationRequest_Param::mutable_secondarywalvolumename() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.Param.secondaryWalVolumeName)
+  return _internal_mutable_secondarywalvolumename();
+}
+inline const std::string& StartHaReplicationRequest_Param::_internal_secondarywalvolumename() const {
+  return secondarywalvolumename_.Get();
+}
+inline void StartHaReplicationRequest_Param::_internal_set_secondarywalvolumename(const std::string& value) {
+  
+  secondarywalvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_secondarywalvolumename(std::string&& value) {
+  
+  secondarywalvolumename_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationRequest.Param.secondaryWalVolumeName)
+}
+inline void StartHaReplicationRequest_Param::set_secondarywalvolumename(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  secondarywalvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationRequest.Param.secondaryWalVolumeName)
+}
+inline void StartHaReplicationRequest_Param::set_secondarywalvolumename(const char* value,
+    size_t size) {
+  
+  secondarywalvolumename_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationRequest.Param.secondaryWalVolumeName)
+}
+inline std::string* StartHaReplicationRequest_Param::_internal_mutable_secondarywalvolumename() {
+  
+  return secondarywalvolumename_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationRequest_Param::release_secondarywalvolumename() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.Param.secondaryWalVolumeName)
+  return secondarywalvolumename_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_allocated_secondarywalvolumename(std::string* secondarywalvolumename) {
+  if (secondarywalvolumename != nullptr) {
+    
+  } else {
+    
+  }
+  secondarywalvolumename_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), secondarywalvolumename,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.Param.secondaryWalVolumeName)
+}
+
+// string stuats = 9;
+inline void StartHaReplicationRequest_Param::clear_stuats() {
+  stuats_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationRequest_Param::stuats() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.Param.stuats)
+  return _internal_stuats();
+}
+inline void StartHaReplicationRequest_Param::set_stuats(const std::string& value) {
+  _internal_set_stuats(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationRequest.Param.stuats)
+}
+inline std::string* StartHaReplicationRequest_Param::mutable_stuats() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.Param.stuats)
+  return _internal_mutable_stuats();
+}
+inline const std::string& StartHaReplicationRequest_Param::_internal_stuats() const {
+  return stuats_.Get();
+}
+inline void StartHaReplicationRequest_Param::_internal_set_stuats(const std::string& value) {
+  
+  stuats_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_stuats(std::string&& value) {
+  
+  stuats_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationRequest.Param.stuats)
+}
+inline void StartHaReplicationRequest_Param::set_stuats(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  stuats_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationRequest.Param.stuats)
+}
+inline void StartHaReplicationRequest_Param::set_stuats(const char* value,
+    size_t size) {
+  
+  stuats_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationRequest.Param.stuats)
+}
+inline std::string* StartHaReplicationRequest_Param::_internal_mutable_stuats() {
+  
+  return stuats_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationRequest_Param::release_stuats() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.Param.stuats)
+  return stuats_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_allocated_stuats(std::string* stuats) {
+  if (stuats != nullptr) {
+    
+  } else {
+    
+  }
+  stuats_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), stuats,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.Param.stuats)
+}
+
+// string timestamp = 10;
+inline void StartHaReplicationRequest_Param::clear_timestamp() {
+  timestamp_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationRequest_Param::timestamp() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.Param.timestamp)
+  return _internal_timestamp();
+}
+inline void StartHaReplicationRequest_Param::set_timestamp(const std::string& value) {
+  _internal_set_timestamp(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationRequest.Param.timestamp)
+}
+inline std::string* StartHaReplicationRequest_Param::mutable_timestamp() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.Param.timestamp)
+  return _internal_mutable_timestamp();
+}
+inline const std::string& StartHaReplicationRequest_Param::_internal_timestamp() const {
+  return timestamp_.Get();
+}
+inline void StartHaReplicationRequest_Param::_internal_set_timestamp(const std::string& value) {
+  
+  timestamp_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_timestamp(std::string&& value) {
+  
+  timestamp_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationRequest.Param.timestamp)
+}
+inline void StartHaReplicationRequest_Param::set_timestamp(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  timestamp_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationRequest.Param.timestamp)
+}
+inline void StartHaReplicationRequest_Param::set_timestamp(const char* value,
+    size_t size) {
+  
+  timestamp_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationRequest.Param.timestamp)
+}
+inline std::string* StartHaReplicationRequest_Param::_internal_mutable_timestamp() {
+  
+  return timestamp_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationRequest_Param::release_timestamp() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.Param.timestamp)
+  return timestamp_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationRequest_Param::set_allocated_timestamp(std::string* timestamp) {
+  if (timestamp != nullptr) {
+    
+  } else {
+    
+  }
+  timestamp_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), timestamp,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.Param.timestamp)
+}
+
+// -------------------------------------------------------------------
+
+// StartHaReplicationRequest
+
+// string command = 1;
+inline void StartHaReplicationRequest::clear_command() {
+  command_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationRequest::command() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.command)
+  return _internal_command();
+}
+inline void StartHaReplicationRequest::set_command(const std::string& value) {
+  _internal_set_command(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationRequest.command)
+}
+inline std::string* StartHaReplicationRequest::mutable_command() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.command)
+  return _internal_mutable_command();
+}
+inline const std::string& StartHaReplicationRequest::_internal_command() const {
+  return command_.Get();
+}
+inline void StartHaReplicationRequest::_internal_set_command(const std::string& value) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationRequest::set_command(std::string&& value) {
+  
+  command_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationRequest.command)
+}
+inline void StartHaReplicationRequest::set_command(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationRequest.command)
+}
+inline void StartHaReplicationRequest::set_command(const char* value,
+    size_t size) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationRequest.command)
+}
+inline std::string* StartHaReplicationRequest::_internal_mutable_command() {
+  
+  return command_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationRequest::release_command() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.command)
+  return command_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationRequest::set_allocated_command(std::string* command) {
+  if (command != nullptr) {
+    
+  } else {
+    
+  }
+  command_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), command,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.command)
+}
+
+// string rid = 2;
+inline void StartHaReplicationRequest::clear_rid() {
+  rid_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationRequest::rid() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.rid)
+  return _internal_rid();
+}
+inline void StartHaReplicationRequest::set_rid(const std::string& value) {
+  _internal_set_rid(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationRequest.rid)
+}
+inline std::string* StartHaReplicationRequest::mutable_rid() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.rid)
+  return _internal_mutable_rid();
+}
+inline const std::string& StartHaReplicationRequest::_internal_rid() const {
+  return rid_.Get();
+}
+inline void StartHaReplicationRequest::_internal_set_rid(const std::string& value) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationRequest::set_rid(std::string&& value) {
+  
+  rid_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationRequest.rid)
+}
+inline void StartHaReplicationRequest::set_rid(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationRequest.rid)
+}
+inline void StartHaReplicationRequest::set_rid(const char* value,
+    size_t size) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationRequest.rid)
+}
+inline std::string* StartHaReplicationRequest::_internal_mutable_rid() {
+  
+  return rid_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationRequest::release_rid() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.rid)
+  return rid_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationRequest::set_allocated_rid(std::string* rid) {
+  if (rid != nullptr) {
+    
+  } else {
+    
+  }
+  rid_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), rid,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.rid)
+}
+
+// string requestor = 3;
+inline void StartHaReplicationRequest::clear_requestor() {
+  requestor_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationRequest::requestor() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.requestor)
+  return _internal_requestor();
+}
+inline void StartHaReplicationRequest::set_requestor(const std::string& value) {
+  _internal_set_requestor(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationRequest.requestor)
+}
+inline std::string* StartHaReplicationRequest::mutable_requestor() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.requestor)
+  return _internal_mutable_requestor();
+}
+inline const std::string& StartHaReplicationRequest::_internal_requestor() const {
+  return requestor_.Get();
+}
+inline void StartHaReplicationRequest::_internal_set_requestor(const std::string& value) {
+  
+  requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationRequest::set_requestor(std::string&& value) {
+  
+  requestor_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationRequest.requestor)
+}
+inline void StartHaReplicationRequest::set_requestor(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationRequest.requestor)
+}
+inline void StartHaReplicationRequest::set_requestor(const char* value,
+    size_t size) {
+  
+  requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationRequest.requestor)
+}
+inline std::string* StartHaReplicationRequest::_internal_mutable_requestor() {
+  
+  return requestor_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationRequest::release_requestor() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.requestor)
+  return requestor_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationRequest::set_allocated_requestor(std::string* requestor) {
+  if (requestor != nullptr) {
+    
+  } else {
+    
+  }
+  requestor_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), requestor,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.requestor)
+}
+
+// .grpc_cli.StartHaReplicationRequest.Param param = 4;
+inline bool StartHaReplicationRequest::_internal_has_param() const {
+  return this != internal_default_instance() && param_ != nullptr;
+}
+inline bool StartHaReplicationRequest::has_param() const {
+  return _internal_has_param();
+}
+inline void StartHaReplicationRequest::clear_param() {
+  if (GetArena() == nullptr && param_ != nullptr) {
+    delete param_;
+  }
+  param_ = nullptr;
+}
+inline const ::grpc_cli::StartHaReplicationRequest_Param& StartHaReplicationRequest::_internal_param() const {
+  const ::grpc_cli::StartHaReplicationRequest_Param* p = param_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::StartHaReplicationRequest_Param&>(
+      ::grpc_cli::_StartHaReplicationRequest_Param_default_instance_);
+}
+inline const ::grpc_cli::StartHaReplicationRequest_Param& StartHaReplicationRequest::param() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationRequest.param)
+  return _internal_param();
+}
+inline void StartHaReplicationRequest::unsafe_arena_set_allocated_param(
+    ::grpc_cli::StartHaReplicationRequest_Param* param) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(param_);
+  }
+  param_ = param;
+  if (param) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.StartHaReplicationRequest.param)
+}
+inline ::grpc_cli::StartHaReplicationRequest_Param* StartHaReplicationRequest::release_param() {
+  
+  ::grpc_cli::StartHaReplicationRequest_Param* temp = param_;
+  param_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::StartHaReplicationRequest_Param* StartHaReplicationRequest::unsafe_arena_release_param() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationRequest.param)
+  
+  ::grpc_cli::StartHaReplicationRequest_Param* temp = param_;
+  param_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::StartHaReplicationRequest_Param* StartHaReplicationRequest::_internal_mutable_param() {
+  
+  if (param_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::StartHaReplicationRequest_Param>(GetArena());
+    param_ = p;
+  }
+  return param_;
+}
+inline ::grpc_cli::StartHaReplicationRequest_Param* StartHaReplicationRequest::mutable_param() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationRequest.param)
+  return _internal_mutable_param();
+}
+inline void StartHaReplicationRequest::set_allocated_param(::grpc_cli::StartHaReplicationRequest_Param* param) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete param_;
+  }
+  if (param) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(param);
+    if (message_arena != submessage_arena) {
+      param = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, param, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  param_ = param;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationRequest.param)
+}
+
+// -------------------------------------------------------------------
+
+// StartHaReplicationResponse_Result
+
+// .grpc_cli.Status status = 1;
+inline bool StartHaReplicationResponse_Result::_internal_has_status() const {
+  return this != internal_default_instance() && status_ != nullptr;
+}
+inline bool StartHaReplicationResponse_Result::has_status() const {
+  return _internal_has_status();
+}
+inline void StartHaReplicationResponse_Result::clear_status() {
+  if (GetArena() == nullptr && status_ != nullptr) {
+    delete status_;
+  }
+  status_ = nullptr;
+}
+inline const ::grpc_cli::Status& StartHaReplicationResponse_Result::_internal_status() const {
+  const ::grpc_cli::Status* p = status_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::Status&>(
+      ::grpc_cli::_Status_default_instance_);
+}
+inline const ::grpc_cli::Status& StartHaReplicationResponse_Result::status() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationResponse.Result.status)
+  return _internal_status();
+}
+inline void StartHaReplicationResponse_Result::unsafe_arena_set_allocated_status(
+    ::grpc_cli::Status* status) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(status_);
+  }
+  status_ = status;
+  if (status) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.StartHaReplicationResponse.Result.status)
+}
+inline ::grpc_cli::Status* StartHaReplicationResponse_Result::release_status() {
+  
+  ::grpc_cli::Status* temp = status_;
+  status_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::Status* StartHaReplicationResponse_Result::unsafe_arena_release_status() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationResponse.Result.status)
+  
+  ::grpc_cli::Status* temp = status_;
+  status_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::Status* StartHaReplicationResponse_Result::_internal_mutable_status() {
+  
+  if (status_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::Status>(GetArena());
+    status_ = p;
+  }
+  return status_;
+}
+inline ::grpc_cli::Status* StartHaReplicationResponse_Result::mutable_status() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationResponse.Result.status)
+  return _internal_mutable_status();
+}
+inline void StartHaReplicationResponse_Result::set_allocated_status(::grpc_cli::Status* status) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete status_;
+  }
+  if (status) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(status);
+    if (message_arena != submessage_arena) {
+      status = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, status, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  status_ = status;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationResponse.Result.status)
+}
+
+// -------------------------------------------------------------------
+
+// StartHaReplicationResponse
+
+// string command = 1;
+inline void StartHaReplicationResponse::clear_command() {
+  command_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationResponse::command() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationResponse.command)
+  return _internal_command();
+}
+inline void StartHaReplicationResponse::set_command(const std::string& value) {
+  _internal_set_command(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationResponse.command)
+}
+inline std::string* StartHaReplicationResponse::mutable_command() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationResponse.command)
+  return _internal_mutable_command();
+}
+inline const std::string& StartHaReplicationResponse::_internal_command() const {
+  return command_.Get();
+}
+inline void StartHaReplicationResponse::_internal_set_command(const std::string& value) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationResponse::set_command(std::string&& value) {
+  
+  command_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationResponse.command)
+}
+inline void StartHaReplicationResponse::set_command(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationResponse.command)
+}
+inline void StartHaReplicationResponse::set_command(const char* value,
+    size_t size) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationResponse.command)
+}
+inline std::string* StartHaReplicationResponse::_internal_mutable_command() {
+  
+  return command_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationResponse::release_command() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationResponse.command)
+  return command_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationResponse::set_allocated_command(std::string* command) {
+  if (command != nullptr) {
+    
+  } else {
+    
+  }
+  command_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), command,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationResponse.command)
+}
+
+// string rid = 2;
+inline void StartHaReplicationResponse::clear_rid() {
+  rid_.ClearToEmpty();
+}
+inline const std::string& StartHaReplicationResponse::rid() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationResponse.rid)
+  return _internal_rid();
+}
+inline void StartHaReplicationResponse::set_rid(const std::string& value) {
+  _internal_set_rid(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.StartHaReplicationResponse.rid)
+}
+inline std::string* StartHaReplicationResponse::mutable_rid() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationResponse.rid)
+  return _internal_mutable_rid();
+}
+inline const std::string& StartHaReplicationResponse::_internal_rid() const {
+  return rid_.Get();
+}
+inline void StartHaReplicationResponse::_internal_set_rid(const std::string& value) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void StartHaReplicationResponse::set_rid(std::string&& value) {
+  
+  rid_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.StartHaReplicationResponse.rid)
+}
+inline void StartHaReplicationResponse::set_rid(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.StartHaReplicationResponse.rid)
+}
+inline void StartHaReplicationResponse::set_rid(const char* value,
+    size_t size) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.StartHaReplicationResponse.rid)
+}
+inline std::string* StartHaReplicationResponse::_internal_mutable_rid() {
+  
+  return rid_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* StartHaReplicationResponse::release_rid() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationResponse.rid)
+  return rid_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void StartHaReplicationResponse::set_allocated_rid(std::string* rid) {
+  if (rid != nullptr) {
+    
+  } else {
+    
+  }
+  rid_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), rid,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationResponse.rid)
+}
+
+// .grpc_cli.StartHaReplicationResponse.Result result = 3;
+inline bool StartHaReplicationResponse::_internal_has_result() const {
+  return this != internal_default_instance() && result_ != nullptr;
+}
+inline bool StartHaReplicationResponse::has_result() const {
+  return _internal_has_result();
+}
+inline void StartHaReplicationResponse::clear_result() {
+  if (GetArena() == nullptr && result_ != nullptr) {
+    delete result_;
+  }
+  result_ = nullptr;
+}
+inline const ::grpc_cli::StartHaReplicationResponse_Result& StartHaReplicationResponse::_internal_result() const {
+  const ::grpc_cli::StartHaReplicationResponse_Result* p = result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::StartHaReplicationResponse_Result&>(
+      ::grpc_cli::_StartHaReplicationResponse_Result_default_instance_);
+}
+inline const ::grpc_cli::StartHaReplicationResponse_Result& StartHaReplicationResponse::result() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationResponse.result)
+  return _internal_result();
+}
+inline void StartHaReplicationResponse::unsafe_arena_set_allocated_result(
+    ::grpc_cli::StartHaReplicationResponse_Result* result) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(result_);
+  }
+  result_ = result;
+  if (result) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.StartHaReplicationResponse.result)
+}
+inline ::grpc_cli::StartHaReplicationResponse_Result* StartHaReplicationResponse::release_result() {
+  
+  ::grpc_cli::StartHaReplicationResponse_Result* temp = result_;
+  result_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::StartHaReplicationResponse_Result* StartHaReplicationResponse::unsafe_arena_release_result() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationResponse.result)
+  
+  ::grpc_cli::StartHaReplicationResponse_Result* temp = result_;
+  result_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::StartHaReplicationResponse_Result* StartHaReplicationResponse::_internal_mutable_result() {
+  
+  if (result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::StartHaReplicationResponse_Result>(GetArena());
+    result_ = p;
+  }
+  return result_;
+}
+inline ::grpc_cli::StartHaReplicationResponse_Result* StartHaReplicationResponse::mutable_result() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationResponse.result)
+  return _internal_mutable_result();
+}
+inline void StartHaReplicationResponse::set_allocated_result(::grpc_cli::StartHaReplicationResponse_Result* result) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete result_;
+  }
+  if (result) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(result);
+    if (message_arena != submessage_arena) {
+      result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, result, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  result_ = result;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationResponse.result)
+}
+
+// .grpc_cli.PosInfo info = 4;
+inline bool StartHaReplicationResponse::_internal_has_info() const {
+  return this != internal_default_instance() && info_ != nullptr;
+}
+inline bool StartHaReplicationResponse::has_info() const {
+  return _internal_has_info();
+}
+inline void StartHaReplicationResponse::clear_info() {
+  if (GetArena() == nullptr && info_ != nullptr) {
+    delete info_;
+  }
+  info_ = nullptr;
+}
+inline const ::grpc_cli::PosInfo& StartHaReplicationResponse::_internal_info() const {
+  const ::grpc_cli::PosInfo* p = info_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::PosInfo&>(
+      ::grpc_cli::_PosInfo_default_instance_);
+}
+inline const ::grpc_cli::PosInfo& StartHaReplicationResponse::info() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.StartHaReplicationResponse.info)
+  return _internal_info();
+}
+inline void StartHaReplicationResponse::unsafe_arena_set_allocated_info(
+    ::grpc_cli::PosInfo* info) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(info_);
+  }
+  info_ = info;
+  if (info) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.StartHaReplicationResponse.info)
+}
+inline ::grpc_cli::PosInfo* StartHaReplicationResponse::release_info() {
+  
+  ::grpc_cli::PosInfo* temp = info_;
+  info_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::PosInfo* StartHaReplicationResponse::unsafe_arena_release_info() {
+  // @@protoc_insertion_point(field_release:grpc_cli.StartHaReplicationResponse.info)
+  
+  ::grpc_cli::PosInfo* temp = info_;
+  info_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::PosInfo* StartHaReplicationResponse::_internal_mutable_info() {
+  
+  if (info_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::PosInfo>(GetArena());
+    info_ = p;
+  }
+  return info_;
+}
+inline ::grpc_cli::PosInfo* StartHaReplicationResponse::mutable_info() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.StartHaReplicationResponse.info)
+  return _internal_mutable_info();
+}
+inline void StartHaReplicationResponse::set_allocated_info(::grpc_cli::PosInfo* info) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete info_;
+  }
+  if (info) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(info);
+    if (message_arena != submessage_arena) {
+      info = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, info, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  info_ = info;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.StartHaReplicationResponse.info)
+}
+
+// -------------------------------------------------------------------
+
 // SetLogLevelRequest_Param
 
 // string level = 1;
@@ -47630,6 +51304,22 @@ inline void GetSmartLogResponse::set_allocated_info(::grpc_cli::PosInfo* info) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/proto/generated/cpp/cli.pb.h
+++ b/proto/generated/cpp/cli.pb.h
@@ -1248,6 +1248,12 @@ class SystemInfoResponse_Result_Data PROTOBUF_FINAL :
   enum : int {
     kVersionFieldNumber = 1,
     kBiosVersionFieldNumber = 2,
+    kBiosVendorFieldNumber = 3,
+    kBiosReleaseDateFieldNumber = 4,
+    kSystemManufacturerFieldNumber = 5,
+    kSystemProductNameFieldNumber = 6,
+    kSystemSerialNumberFieldNumber = 7,
+    kSystemUuidFieldNumber = 8,
   };
   // string version = 1;
   void clear_version();
@@ -1281,6 +1287,102 @@ class SystemInfoResponse_Result_Data PROTOBUF_FINAL :
   std::string* _internal_mutable_biosversion();
   public:
 
+  // string biosVendor = 3;
+  void clear_biosvendor();
+  const std::string& biosvendor() const;
+  void set_biosvendor(const std::string& value);
+  void set_biosvendor(std::string&& value);
+  void set_biosvendor(const char* value);
+  void set_biosvendor(const char* value, size_t size);
+  std::string* mutable_biosvendor();
+  std::string* release_biosvendor();
+  void set_allocated_biosvendor(std::string* biosvendor);
+  private:
+  const std::string& _internal_biosvendor() const;
+  void _internal_set_biosvendor(const std::string& value);
+  std::string* _internal_mutable_biosvendor();
+  public:
+
+  // string biosReleaseDate = 4;
+  void clear_biosreleasedate();
+  const std::string& biosreleasedate() const;
+  void set_biosreleasedate(const std::string& value);
+  void set_biosreleasedate(std::string&& value);
+  void set_biosreleasedate(const char* value);
+  void set_biosreleasedate(const char* value, size_t size);
+  std::string* mutable_biosreleasedate();
+  std::string* release_biosreleasedate();
+  void set_allocated_biosreleasedate(std::string* biosreleasedate);
+  private:
+  const std::string& _internal_biosreleasedate() const;
+  void _internal_set_biosreleasedate(const std::string& value);
+  std::string* _internal_mutable_biosreleasedate();
+  public:
+
+  // string systemManufacturer = 5;
+  void clear_systemmanufacturer();
+  const std::string& systemmanufacturer() const;
+  void set_systemmanufacturer(const std::string& value);
+  void set_systemmanufacturer(std::string&& value);
+  void set_systemmanufacturer(const char* value);
+  void set_systemmanufacturer(const char* value, size_t size);
+  std::string* mutable_systemmanufacturer();
+  std::string* release_systemmanufacturer();
+  void set_allocated_systemmanufacturer(std::string* systemmanufacturer);
+  private:
+  const std::string& _internal_systemmanufacturer() const;
+  void _internal_set_systemmanufacturer(const std::string& value);
+  std::string* _internal_mutable_systemmanufacturer();
+  public:
+
+  // string systemProductName = 6;
+  void clear_systemproductname();
+  const std::string& systemproductname() const;
+  void set_systemproductname(const std::string& value);
+  void set_systemproductname(std::string&& value);
+  void set_systemproductname(const char* value);
+  void set_systemproductname(const char* value, size_t size);
+  std::string* mutable_systemproductname();
+  std::string* release_systemproductname();
+  void set_allocated_systemproductname(std::string* systemproductname);
+  private:
+  const std::string& _internal_systemproductname() const;
+  void _internal_set_systemproductname(const std::string& value);
+  std::string* _internal_mutable_systemproductname();
+  public:
+
+  // string systemSerialNumber = 7;
+  void clear_systemserialnumber();
+  const std::string& systemserialnumber() const;
+  void set_systemserialnumber(const std::string& value);
+  void set_systemserialnumber(std::string&& value);
+  void set_systemserialnumber(const char* value);
+  void set_systemserialnumber(const char* value, size_t size);
+  std::string* mutable_systemserialnumber();
+  std::string* release_systemserialnumber();
+  void set_allocated_systemserialnumber(std::string* systemserialnumber);
+  private:
+  const std::string& _internal_systemserialnumber() const;
+  void _internal_set_systemserialnumber(const std::string& value);
+  std::string* _internal_mutable_systemserialnumber();
+  public:
+
+  // string systemUuid = 8;
+  void clear_systemuuid();
+  const std::string& systemuuid() const;
+  void set_systemuuid(const std::string& value);
+  void set_systemuuid(std::string&& value);
+  void set_systemuuid(const char* value);
+  void set_systemuuid(const char* value, size_t size);
+  std::string* mutable_systemuuid();
+  std::string* release_systemuuid();
+  void set_allocated_systemuuid(std::string* systemuuid);
+  private:
+  const std::string& _internal_systemuuid() const;
+  void _internal_set_systemuuid(const std::string& value);
+  std::string* _internal_mutable_systemuuid();
+  public:
+
   // @@protoc_insertion_point(class_scope:grpc_cli.SystemInfoResponse.Result.Data)
  private:
   class _Internal;
@@ -1290,6 +1392,12 @@ class SystemInfoResponse_Result_Data PROTOBUF_FINAL :
   typedef void DestructorSkippable_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr version_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr biosversion_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr biosvendor_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr biosreleasedate_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr systemmanufacturer_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr systemproductname_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr systemserialnumber_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr systemuuid_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_cli_2eproto;
 };
@@ -25128,6 +25236,372 @@ inline void SystemInfoResponse_Result_Data::set_allocated_biosversion(std::strin
   biosversion_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), biosversion,
       GetArena());
   // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.biosVersion)
+}
+
+// string biosVendor = 3;
+inline void SystemInfoResponse_Result_Data::clear_biosvendor() {
+  biosvendor_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::biosvendor() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.biosVendor)
+  return _internal_biosvendor();
+}
+inline void SystemInfoResponse_Result_Data::set_biosvendor(const std::string& value) {
+  _internal_set_biosvendor(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.biosVendor)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_biosvendor() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.biosVendor)
+  return _internal_mutable_biosvendor();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_biosvendor() const {
+  return biosvendor_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_biosvendor(const std::string& value) {
+  
+  biosvendor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_biosvendor(std::string&& value) {
+  
+  biosvendor_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.biosVendor)
+}
+inline void SystemInfoResponse_Result_Data::set_biosvendor(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  biosvendor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.biosVendor)
+}
+inline void SystemInfoResponse_Result_Data::set_biosvendor(const char* value,
+    size_t size) {
+  
+  biosvendor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.biosVendor)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_biosvendor() {
+  
+  return biosvendor_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_biosvendor() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.biosVendor)
+  return biosvendor_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_biosvendor(std::string* biosvendor) {
+  if (biosvendor != nullptr) {
+    
+  } else {
+    
+  }
+  biosvendor_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), biosvendor,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.biosVendor)
+}
+
+// string biosReleaseDate = 4;
+inline void SystemInfoResponse_Result_Data::clear_biosreleasedate() {
+  biosreleasedate_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::biosreleasedate() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.biosReleaseDate)
+  return _internal_biosreleasedate();
+}
+inline void SystemInfoResponse_Result_Data::set_biosreleasedate(const std::string& value) {
+  _internal_set_biosreleasedate(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.biosReleaseDate)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_biosreleasedate() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.biosReleaseDate)
+  return _internal_mutable_biosreleasedate();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_biosreleasedate() const {
+  return biosreleasedate_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_biosreleasedate(const std::string& value) {
+  
+  biosreleasedate_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_biosreleasedate(std::string&& value) {
+  
+  biosreleasedate_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.biosReleaseDate)
+}
+inline void SystemInfoResponse_Result_Data::set_biosreleasedate(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  biosreleasedate_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.biosReleaseDate)
+}
+inline void SystemInfoResponse_Result_Data::set_biosreleasedate(const char* value,
+    size_t size) {
+  
+  biosreleasedate_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.biosReleaseDate)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_biosreleasedate() {
+  
+  return biosreleasedate_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_biosreleasedate() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.biosReleaseDate)
+  return biosreleasedate_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_biosreleasedate(std::string* biosreleasedate) {
+  if (biosreleasedate != nullptr) {
+    
+  } else {
+    
+  }
+  biosreleasedate_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), biosreleasedate,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.biosReleaseDate)
+}
+
+// string systemManufacturer = 5;
+inline void SystemInfoResponse_Result_Data::clear_systemmanufacturer() {
+  systemmanufacturer_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::systemmanufacturer() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.systemManufacturer)
+  return _internal_systemmanufacturer();
+}
+inline void SystemInfoResponse_Result_Data::set_systemmanufacturer(const std::string& value) {
+  _internal_set_systemmanufacturer(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.systemManufacturer)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_systemmanufacturer() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.systemManufacturer)
+  return _internal_mutable_systemmanufacturer();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_systemmanufacturer() const {
+  return systemmanufacturer_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_systemmanufacturer(const std::string& value) {
+  
+  systemmanufacturer_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_systemmanufacturer(std::string&& value) {
+  
+  systemmanufacturer_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.systemManufacturer)
+}
+inline void SystemInfoResponse_Result_Data::set_systemmanufacturer(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  systemmanufacturer_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.systemManufacturer)
+}
+inline void SystemInfoResponse_Result_Data::set_systemmanufacturer(const char* value,
+    size_t size) {
+  
+  systemmanufacturer_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.systemManufacturer)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_systemmanufacturer() {
+  
+  return systemmanufacturer_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_systemmanufacturer() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.systemManufacturer)
+  return systemmanufacturer_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_systemmanufacturer(std::string* systemmanufacturer) {
+  if (systemmanufacturer != nullptr) {
+    
+  } else {
+    
+  }
+  systemmanufacturer_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), systemmanufacturer,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.systemManufacturer)
+}
+
+// string systemProductName = 6;
+inline void SystemInfoResponse_Result_Data::clear_systemproductname() {
+  systemproductname_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::systemproductname() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.systemProductName)
+  return _internal_systemproductname();
+}
+inline void SystemInfoResponse_Result_Data::set_systemproductname(const std::string& value) {
+  _internal_set_systemproductname(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.systemProductName)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_systemproductname() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.systemProductName)
+  return _internal_mutable_systemproductname();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_systemproductname() const {
+  return systemproductname_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_systemproductname(const std::string& value) {
+  
+  systemproductname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_systemproductname(std::string&& value) {
+  
+  systemproductname_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.systemProductName)
+}
+inline void SystemInfoResponse_Result_Data::set_systemproductname(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  systemproductname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.systemProductName)
+}
+inline void SystemInfoResponse_Result_Data::set_systemproductname(const char* value,
+    size_t size) {
+  
+  systemproductname_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.systemProductName)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_systemproductname() {
+  
+  return systemproductname_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_systemproductname() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.systemProductName)
+  return systemproductname_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_systemproductname(std::string* systemproductname) {
+  if (systemproductname != nullptr) {
+    
+  } else {
+    
+  }
+  systemproductname_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), systemproductname,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.systemProductName)
+}
+
+// string systemSerialNumber = 7;
+inline void SystemInfoResponse_Result_Data::clear_systemserialnumber() {
+  systemserialnumber_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::systemserialnumber() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.systemSerialNumber)
+  return _internal_systemserialnumber();
+}
+inline void SystemInfoResponse_Result_Data::set_systemserialnumber(const std::string& value) {
+  _internal_set_systemserialnumber(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.systemSerialNumber)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_systemserialnumber() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.systemSerialNumber)
+  return _internal_mutable_systemserialnumber();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_systemserialnumber() const {
+  return systemserialnumber_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_systemserialnumber(const std::string& value) {
+  
+  systemserialnumber_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_systemserialnumber(std::string&& value) {
+  
+  systemserialnumber_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.systemSerialNumber)
+}
+inline void SystemInfoResponse_Result_Data::set_systemserialnumber(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  systemserialnumber_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.systemSerialNumber)
+}
+inline void SystemInfoResponse_Result_Data::set_systemserialnumber(const char* value,
+    size_t size) {
+  
+  systemserialnumber_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.systemSerialNumber)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_systemserialnumber() {
+  
+  return systemserialnumber_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_systemserialnumber() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.systemSerialNumber)
+  return systemserialnumber_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_systemserialnumber(std::string* systemserialnumber) {
+  if (systemserialnumber != nullptr) {
+    
+  } else {
+    
+  }
+  systemserialnumber_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), systemserialnumber,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.systemSerialNumber)
+}
+
+// string systemUuid = 8;
+inline void SystemInfoResponse_Result_Data::clear_systemuuid() {
+  systemuuid_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::systemuuid() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.systemUuid)
+  return _internal_systemuuid();
+}
+inline void SystemInfoResponse_Result_Data::set_systemuuid(const std::string& value) {
+  _internal_set_systemuuid(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.systemUuid)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_systemuuid() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.systemUuid)
+  return _internal_mutable_systemuuid();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_systemuuid() const {
+  return systemuuid_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_systemuuid(const std::string& value) {
+  
+  systemuuid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_systemuuid(std::string&& value) {
+  
+  systemuuid_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.systemUuid)
+}
+inline void SystemInfoResponse_Result_Data::set_systemuuid(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  systemuuid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.systemUuid)
+}
+inline void SystemInfoResponse_Result_Data::set_systemuuid(const char* value,
+    size_t size) {
+  
+  systemuuid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.systemUuid)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_systemuuid() {
+  
+  return systemuuid_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_systemuuid() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.systemUuid)
+  return systemuuid_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_systemuuid(std::string* systemuuid) {
+  if (systemuuid != nullptr) {
+    
+  } else {
+    
+  }
+  systemuuid_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), systemuuid,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.systemUuid)
 }
 
 // -------------------------------------------------------------------

--- a/proto/generated/cpp/cli.pb.h
+++ b/proto/generated/cpp/cli.pb.h
@@ -1258,6 +1258,9 @@ class SystemInfoResponse_Result_Data PROTOBUF_FINAL :
     kBaseboardProductNameFieldNumber = 10,
     kBaseboardSerialNumberFieldNumber = 11,
     kBaseboardVersionFieldNumber = 12,
+    kProcessorManufacturerFieldNumber = 13,
+    kProcessorVersionFieldNumber = 14,
+    kProcessorFrequencyFieldNumber = 15,
   };
   // string version = 1;
   void clear_version();
@@ -1451,6 +1454,54 @@ class SystemInfoResponse_Result_Data PROTOBUF_FINAL :
   std::string* _internal_mutable_baseboardversion();
   public:
 
+  // string processorManufacturer = 13;
+  void clear_processormanufacturer();
+  const std::string& processormanufacturer() const;
+  void set_processormanufacturer(const std::string& value);
+  void set_processormanufacturer(std::string&& value);
+  void set_processormanufacturer(const char* value);
+  void set_processormanufacturer(const char* value, size_t size);
+  std::string* mutable_processormanufacturer();
+  std::string* release_processormanufacturer();
+  void set_allocated_processormanufacturer(std::string* processormanufacturer);
+  private:
+  const std::string& _internal_processormanufacturer() const;
+  void _internal_set_processormanufacturer(const std::string& value);
+  std::string* _internal_mutable_processormanufacturer();
+  public:
+
+  // string processorVersion = 14;
+  void clear_processorversion();
+  const std::string& processorversion() const;
+  void set_processorversion(const std::string& value);
+  void set_processorversion(std::string&& value);
+  void set_processorversion(const char* value);
+  void set_processorversion(const char* value, size_t size);
+  std::string* mutable_processorversion();
+  std::string* release_processorversion();
+  void set_allocated_processorversion(std::string* processorversion);
+  private:
+  const std::string& _internal_processorversion() const;
+  void _internal_set_processorversion(const std::string& value);
+  std::string* _internal_mutable_processorversion();
+  public:
+
+  // string processorFrequency = 15;
+  void clear_processorfrequency();
+  const std::string& processorfrequency() const;
+  void set_processorfrequency(const std::string& value);
+  void set_processorfrequency(std::string&& value);
+  void set_processorfrequency(const char* value);
+  void set_processorfrequency(const char* value, size_t size);
+  std::string* mutable_processorfrequency();
+  std::string* release_processorfrequency();
+  void set_allocated_processorfrequency(std::string* processorfrequency);
+  private:
+  const std::string& _internal_processorfrequency() const;
+  void _internal_set_processorfrequency(const std::string& value);
+  std::string* _internal_mutable_processorfrequency();
+  public:
+
   // @@protoc_insertion_point(class_scope:grpc_cli.SystemInfoResponse.Result.Data)
  private:
   class _Internal;
@@ -1470,6 +1521,9 @@ class SystemInfoResponse_Result_Data PROTOBUF_FINAL :
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr baseboardproductname_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr baseboardserialnumber_;
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr baseboardversion_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr processormanufacturer_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr processorversion_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr processorfrequency_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_cli_2eproto;
 };
@@ -25918,6 +25972,189 @@ inline void SystemInfoResponse_Result_Data::set_allocated_baseboardversion(std::
   baseboardversion_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), baseboardversion,
       GetArena());
   // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.baseboardVersion)
+}
+
+// string processorManufacturer = 13;
+inline void SystemInfoResponse_Result_Data::clear_processormanufacturer() {
+  processormanufacturer_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::processormanufacturer() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.processorManufacturer)
+  return _internal_processormanufacturer();
+}
+inline void SystemInfoResponse_Result_Data::set_processormanufacturer(const std::string& value) {
+  _internal_set_processormanufacturer(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.processorManufacturer)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_processormanufacturer() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.processorManufacturer)
+  return _internal_mutable_processormanufacturer();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_processormanufacturer() const {
+  return processormanufacturer_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_processormanufacturer(const std::string& value) {
+  
+  processormanufacturer_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_processormanufacturer(std::string&& value) {
+  
+  processormanufacturer_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.processorManufacturer)
+}
+inline void SystemInfoResponse_Result_Data::set_processormanufacturer(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  processormanufacturer_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.processorManufacturer)
+}
+inline void SystemInfoResponse_Result_Data::set_processormanufacturer(const char* value,
+    size_t size) {
+  
+  processormanufacturer_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.processorManufacturer)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_processormanufacturer() {
+  
+  return processormanufacturer_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_processormanufacturer() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.processorManufacturer)
+  return processormanufacturer_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_processormanufacturer(std::string* processormanufacturer) {
+  if (processormanufacturer != nullptr) {
+    
+  } else {
+    
+  }
+  processormanufacturer_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), processormanufacturer,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.processorManufacturer)
+}
+
+// string processorVersion = 14;
+inline void SystemInfoResponse_Result_Data::clear_processorversion() {
+  processorversion_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::processorversion() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.processorVersion)
+  return _internal_processorversion();
+}
+inline void SystemInfoResponse_Result_Data::set_processorversion(const std::string& value) {
+  _internal_set_processorversion(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.processorVersion)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_processorversion() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.processorVersion)
+  return _internal_mutable_processorversion();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_processorversion() const {
+  return processorversion_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_processorversion(const std::string& value) {
+  
+  processorversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_processorversion(std::string&& value) {
+  
+  processorversion_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.processorVersion)
+}
+inline void SystemInfoResponse_Result_Data::set_processorversion(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  processorversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.processorVersion)
+}
+inline void SystemInfoResponse_Result_Data::set_processorversion(const char* value,
+    size_t size) {
+  
+  processorversion_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.processorVersion)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_processorversion() {
+  
+  return processorversion_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_processorversion() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.processorVersion)
+  return processorversion_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_processorversion(std::string* processorversion) {
+  if (processorversion != nullptr) {
+    
+  } else {
+    
+  }
+  processorversion_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), processorversion,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.processorVersion)
+}
+
+// string processorFrequency = 15;
+inline void SystemInfoResponse_Result_Data::clear_processorfrequency() {
+  processorfrequency_.ClearToEmpty();
+}
+inline const std::string& SystemInfoResponse_Result_Data::processorfrequency() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SystemInfoResponse.Result.Data.processorFrequency)
+  return _internal_processorfrequency();
+}
+inline void SystemInfoResponse_Result_Data::set_processorfrequency(const std::string& value) {
+  _internal_set_processorfrequency(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SystemInfoResponse.Result.Data.processorFrequency)
+}
+inline std::string* SystemInfoResponse_Result_Data::mutable_processorfrequency() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SystemInfoResponse.Result.Data.processorFrequency)
+  return _internal_mutable_processorfrequency();
+}
+inline const std::string& SystemInfoResponse_Result_Data::_internal_processorfrequency() const {
+  return processorfrequency_.Get();
+}
+inline void SystemInfoResponse_Result_Data::_internal_set_processorfrequency(const std::string& value) {
+  
+  processorfrequency_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_processorfrequency(std::string&& value) {
+  
+  processorfrequency_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SystemInfoResponse.Result.Data.processorFrequency)
+}
+inline void SystemInfoResponse_Result_Data::set_processorfrequency(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  processorfrequency_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SystemInfoResponse.Result.Data.processorFrequency)
+}
+inline void SystemInfoResponse_Result_Data::set_processorfrequency(const char* value,
+    size_t size) {
+  
+  processorfrequency_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SystemInfoResponse.Result.Data.processorFrequency)
+}
+inline std::string* SystemInfoResponse_Result_Data::_internal_mutable_processorfrequency() {
+  
+  return processorfrequency_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SystemInfoResponse_Result_Data::release_processorfrequency() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SystemInfoResponse.Result.Data.processorFrequency)
+  return processorfrequency_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SystemInfoResponse_Result_Data::set_allocated_processorfrequency(std::string* processorfrequency) {
+  if (processorfrequency != nullptr) {
+    
+  } else {
+    
+  }
+  processorfrequency_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), processorfrequency,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SystemInfoResponse.Result.Data.processorFrequency)
 }
 
 // -------------------------------------------------------------------

--- a/src/cli/command_processor.cpp
+++ b/src/cli/command_processor.cpp
@@ -60,6 +60,11 @@ CommandProcessor::ExecuteSystemInfoCommand(const SystemInfoRequest* request, Sys
     reply->mutable_result()->mutable_data()->set_baseboardserialnumber(baseboardInfo.serialNumber);
     reply->mutable_result()->mutable_data()->set_baseboardversion(baseboardInfo.version);
 
+    ProcessorInfo proccessorInfo = _GetProcessorInfo();
+    reply->mutable_result()->mutable_data()->set_processormanufacturer(proccessorInfo.manufacturer);
+    reply->mutable_result()->mutable_data()->set_processorversion(proccessorInfo.version);
+    reply->mutable_result()->mutable_data()->set_processorfrequency(proccessorInfo.frequency);
+
     _SetEventStatus(EID(SUCCESS), reply->mutable_result()->mutable_status());
     _SetPosInfo(reply->mutable_info());
     
@@ -1383,6 +1388,21 @@ CommandProcessor::_GetBaseboardInfo()
     baseboard.version = _ExecuteLinuxCmd(getBaseboardVersionCmd);
 
     return baseboard;
+}
+
+CommandProcessor::ProcessorInfo
+CommandProcessor::_GetProcessorInfo()
+{
+    const std::string getProcessorManufacturerCmd = "dmidecode -s processor-manufacturer";
+    const std::string getProcessorVersioneCmd = "dmidecode -s processor-version";
+    const std::string getProcessorFrequencyCmd = "dmidecode -s processor-frequency";
+    
+    ProcessorInfo processor;
+    processor.manufacturer = _ExecuteLinuxCmd(getProcessorManufacturerCmd);
+    processor.version = _ExecuteLinuxCmd(getProcessorVersioneCmd);
+    processor.frequency = _ExecuteLinuxCmd(getProcessorFrequencyCmd);
+
+    return processor;
 }
 
 std::string

--- a/src/cli/command_processor.cpp
+++ b/src/cli/command_processor.cpp
@@ -54,6 +54,12 @@ CommandProcessor::ExecuteSystemInfoCommand(const SystemInfoRequest* request, Sys
     reply->mutable_result()->mutable_data()->set_systemserialnumber(systemInfo.serialNumber);
     reply->mutable_result()->mutable_data()->set_systemuuid(systemInfo.uuid);
 
+    BaseboardInfo baseboardInfo = _GetBaseboardInfo();
+    reply->mutable_result()->mutable_data()->set_baseboardmanufacturer(baseboardInfo.manufacturer);
+    reply->mutable_result()->mutable_data()->set_baseboardproductname(baseboardInfo.productName);
+    reply->mutable_result()->mutable_data()->set_baseboardserialnumber(baseboardInfo.serialNumber);
+    reply->mutable_result()->mutable_data()->set_baseboardversion(baseboardInfo.version);
+
     _SetEventStatus(EID(SUCCESS), reply->mutable_result()->mutable_status());
     _SetPosInfo(reply->mutable_info());
     
@@ -1351,7 +1357,7 @@ CommandProcessor::_GetSystemInfo()
     const std::string getSystemManufacturerCmd = "dmidecode -s system-manufacturer";
     const std::string getSystemProductNameCmd = "dmidecode -s system-product-name";
     const std::string getSystemSerialNumberCmd = "dmidecode -s system-serial-number";
-    const std::string getSystemUuidCmd = "dmidecode -s system-serial-uuid";
+    const std::string getSystemUuidCmd = "dmidecode -s system-uuid";
     
     SystemInfo system;
     system.manufacturer = _ExecuteLinuxCmd(getSystemManufacturerCmd);
@@ -1360,6 +1366,23 @@ CommandProcessor::_GetSystemInfo()
     system.uuid = _ExecuteLinuxCmd(getSystemUuidCmd);
 
     return system;
+}
+
+CommandProcessor::BaseboardInfo
+CommandProcessor::_GetBaseboardInfo()
+{
+    const std::string getBaseboardManufacturerCmd = "dmidecode -s baseboard-manufacturer";
+    const std::string getBaseboardProductNameCmd = "dmidecode -s baseboard-product-name";
+    const std::string getBaseboardSerialNumberCmd = "dmidecode -s baseboard-serial-number";
+    const std::string getBaseboardVersionCmd = "dmidecode -s baseboard-version";
+    
+    BaseboardInfo baseboard;
+    baseboard.manufacturer = _ExecuteLinuxCmd(getBaseboardManufacturerCmd);
+    baseboard.productName = _ExecuteLinuxCmd(getBaseboardProductNameCmd);
+    baseboard.serialNumber = _ExecuteLinuxCmd(getBaseboardSerialNumberCmd);
+    baseboard.version = _ExecuteLinuxCmd(getBaseboardVersionCmd);
+
+    return baseboard;
 }
 
 std::string

--- a/src/cli/command_processor.cpp
+++ b/src/cli/command_processor.cpp
@@ -44,9 +44,9 @@ CommandProcessor::ExecuteSystemInfoCommand(const SystemInfoRequest* request, Sys
     reply->mutable_result()->mutable_data()->set_version(version);
 
     BiosInfo biosInfo = _GetBiosInfo();
-    reply->mutable_result()->mutable_data()->set_biosversion(biosInfo.vendor);
+    reply->mutable_result()->mutable_data()->set_biosvendor(biosInfo.vendor);
     reply->mutable_result()->mutable_data()->set_biosversion(biosInfo.version);
-    reply->mutable_result()->mutable_data()->set_biosversion(biosInfo.releaseDate);
+    reply->mutable_result()->mutable_data()->set_biosreleasedate(biosInfo.releaseDate);
 
     SystemInfo systemInfo = _GetSystemInfo();
     reply->mutable_result()->mutable_data()->set_systemmanufacturer(systemInfo.manufacturer);

--- a/src/cli/command_processor.cpp
+++ b/src/cli/command_processor.cpp
@@ -44,7 +44,6 @@ CommandProcessor::ExecuteSystemInfoCommand(const SystemInfoRequest* request, Sys
     reply->mutable_result()->mutable_data()->set_version(version);
 
     BiosInfo biosInfo = _GetBiosInfo();
-    cout << biosInfo.version;
     reply->mutable_result()->mutable_data()->set_biosversion(biosInfo.version);
 
     _SetEventStatus(EID(SUCCESS), reply->mutable_result()->mutable_status());
@@ -1327,9 +1326,11 @@ CommandProcessor::BiosInfo
 CommandProcessor::_GetBiosInfo()
 {
     const std::string getBiosVersionCmd = "dmidecode -s bios-version";
-
+    const std::string getBiosVendorCmd = "dmidecode -s bios-vendor";
+    
     BiosInfo bios;
-    bios.version = _ExecuteLinuxCmd(getBiosVersionCmd);   
+    bios.version = _ExecuteLinuxCmd(getBiosVersionCmd);
+    bios.vendor = _ExecuteLinuxCmd(getBiosVendorCmd);
 
     return bios;
 }

--- a/src/cli/command_processor.cpp
+++ b/src/cli/command_processor.cpp
@@ -1421,7 +1421,9 @@ CommandProcessor::_ExecuteLinuxCmd(std::string command)
           result += buffer;
     }   
     
-    buffer[strcspn(buffer, "\n")] = '\0';    
+    result.erase(std::remove(result.begin(), result.end(), '\n'),
+            result.end());
     pclose(pipe);
+
     return result;
 }

--- a/src/cli/command_processor.cpp
+++ b/src/cli/command_processor.cpp
@@ -1327,10 +1327,12 @@ CommandProcessor::_GetBiosInfo()
 {
     const std::string getBiosVersionCmd = "dmidecode -s bios-version";
     const std::string getBiosVendorCmd = "dmidecode -s bios-vendor";
+    const std::string getBiosReleaseDateCmd = "dmidecode -s bios-release-date";
     
     BiosInfo bios;
     bios.version = _ExecuteLinuxCmd(getBiosVersionCmd);
     bios.vendor = _ExecuteLinuxCmd(getBiosVendorCmd);
+    bios.releaseDate = _ExecuteLinuxCmd(getBiosReleaseDateCmd);
 
     return bios;
 }

--- a/src/cli/command_processor.cpp
+++ b/src/cli/command_processor.cpp
@@ -44,7 +44,15 @@ CommandProcessor::ExecuteSystemInfoCommand(const SystemInfoRequest* request, Sys
     reply->mutable_result()->mutable_data()->set_version(version);
 
     BiosInfo biosInfo = _GetBiosInfo();
+    reply->mutable_result()->mutable_data()->set_biosversion(biosInfo.vendor);
     reply->mutable_result()->mutable_data()->set_biosversion(biosInfo.version);
+    reply->mutable_result()->mutable_data()->set_biosversion(biosInfo.releaseDate);
+
+    SystemInfo systemInfo = _GetSystemInfo();
+    reply->mutable_result()->mutable_data()->set_systemmanufacturer(systemInfo.manufacturer);
+    reply->mutable_result()->mutable_data()->set_systemproductname(systemInfo.productName);
+    reply->mutable_result()->mutable_data()->set_systemserialnumber(systemInfo.serialNumber);
+    reply->mutable_result()->mutable_data()->set_systemuuid(systemInfo.uuid);
 
     _SetEventStatus(EID(SUCCESS), reply->mutable_result()->mutable_status());
     _SetPosInfo(reply->mutable_info());
@@ -1335,6 +1343,23 @@ CommandProcessor::_GetBiosInfo()
     bios.releaseDate = _ExecuteLinuxCmd(getBiosReleaseDateCmd);
 
     return bios;
+}
+
+CommandProcessor::SystemInfo
+CommandProcessor::_GetSystemInfo()
+{
+    const std::string getSystemManufacturerCmd = "dmidecode -s system-manufacturer";
+    const std::string getSystemProductNameCmd = "dmidecode -s system-product-name";
+    const std::string getSystemSerialNumberCmd = "dmidecode -s system-serial-number";
+    const std::string getSystemUuidCmd = "dmidecode -s system-serial-uuid";
+    
+    SystemInfo system;
+    system.manufacturer = _ExecuteLinuxCmd(getSystemManufacturerCmd);
+    system.productName = _ExecuteLinuxCmd(getSystemProductNameCmd);
+    system.serialNumber = _ExecuteLinuxCmd(getSystemSerialNumberCmd);
+    system.uuid = _ExecuteLinuxCmd(getSystemUuidCmd);
+
+    return system;
 }
 
 std::string

--- a/src/cli/command_processor.h
+++ b/src/cli/command_processor.h
@@ -40,6 +40,7 @@
 #define RESET_EVENT_WRR_DEFAULT_WEIGHT 20
 #define DEFAULT_ARRAY_STATUS "Unmounted"
 #define ARRAY_ERROR_INDEX -1
+#define MAX_LINUX_CMD_LENGTH 128
 
 namespace pos
 {
@@ -165,4 +166,15 @@ private:
     void _FillSmartData(struct spdk_nvme_health_information_page payload, grpc_cli::SmartLog* data);
     void _PrintUint128Hex(uint64_t* v, char* s, size_t n);
     void _PrintUint128Dec(uint64_t* v, char* s, size_t n);
+    
+    typedef struct BiosInfo {
+        std::string vendor;
+        std::string version;
+        std::string releaseDate;
+        std::string address;
+        std::string romSize;
+    } BiosInfo;
+    
+    BiosInfo _GetBiosInfo();
+    std::string _ExecuteLinuxCmd(std::string command);
 };

--- a/src/cli/command_processor.h
+++ b/src/cli/command_processor.h
@@ -172,7 +172,15 @@ private:
         std::string version;
         std::string releaseDate;
     } BiosInfo;
+
+    typedef struct SystemInfo {
+        std::string manufacturer;
+        std::string productName;
+        std::string serialNumber;
+        std::string uuid;
+    } SystemInfo;
     
     BiosInfo _GetBiosInfo();
-    std::string _ExecuteLinuxCmd(std::string command);
+    SystemInfo _GetSystemInfo();
+    std::string _ExecuteLinuxCmd(std::string command);    
 };

--- a/src/cli/command_processor.h
+++ b/src/cli/command_processor.h
@@ -186,9 +186,16 @@ private:
         std::string serialNumber;
         std::string version;
     } BaseboardInfo;
+
+    typedef struct ProcessorInfo {
+        std::string manufacturer;
+        std::string version;
+        std::string frequency;
+    } ProcessorInfo;
     
     BiosInfo _GetBiosInfo();
     SystemInfo _GetSystemInfo();
     BaseboardInfo _GetBaseboardInfo();
+    ProcessorInfo _GetProcessorInfo();
     std::string _ExecuteLinuxCmd(std::string command);    
 };

--- a/src/cli/command_processor.h
+++ b/src/cli/command_processor.h
@@ -171,8 +171,6 @@ private:
         std::string vendor;
         std::string version;
         std::string releaseDate;
-        std::string address;
-        std::string romSize;
     } BiosInfo;
     
     BiosInfo _GetBiosInfo();

--- a/src/cli/command_processor.h
+++ b/src/cli/command_processor.h
@@ -179,8 +179,16 @@ private:
         std::string serialNumber;
         std::string uuid;
     } SystemInfo;
+
+    typedef struct BaseboardInfo {
+        std::string manufacturer;
+        std::string productName;
+        std::string serialNumber;
+        std::string version;
+    } BaseboardInfo;
     
     BiosInfo _GetBiosInfo();
     SystemInfo _GetSystemInfo();
+    BaseboardInfo _GetBaseboardInfo();
     std::string _ExecuteLinuxCmd(std::string command);    
 };

--- a/tool/cli/cmd/displaymgr/display_response.go
+++ b/tool/cli/cmd/displaymgr/display_response.go
@@ -652,16 +652,37 @@ func printResToHumanReadable(command string, resJSON string, displayUnit bool) {
 		w.Flush()
 
 	case "SYSTEMINFO":
-		res := messages.POSInfoResponse{}
-		json.Unmarshal([]byte(resJSON), &res)
+		res := &pb.SystemInfoResponse{}
+		protojson.Unmarshal([]byte(resJSON), res)
 
-		if res.RESULT.STATUS.CODE != globals.CliServerSuccessCode {
-			printEventInfo(res.RESULT.STATUS.CODE, res.RESULT.STATUS.EVENTNAME,
-				res.RESULT.STATUS.DESCRIPTION, res.RESULT.STATUS.CAUSE, res.RESULT.STATUS.SOLUTION)
+		status := res.GetResult().GetStatus()
+		if isFailed(*status) {
+			printEvent(*status)
 			return
 		}
 
-		fmt.Println(res.RESULT.DATA.VERSION)
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+
+		fmt.Fprintln(w, "PosVersion\t: "+res.GetResult().GetData().Version)
+		fmt.Fprintln(w, "BiosVersion\t: "+res.GetResult().GetData().BiosVersion)
+		fmt.Fprintln(w, "BiosVendor\t: "+res.GetResult().GetData().BiosVendor)
+		fmt.Fprintln(w, "BiosReleaseDate\t: "+res.GetResult().GetData().BiosReleaseDate)
+
+		fmt.Fprintln(w, "SystemManufacturer\t: "+res.GetResult().GetData().SystemManufacturer)
+		fmt.Fprintln(w, "SystemProductName\t: "+res.GetResult().GetData().SystemProductName)
+		fmt.Fprintln(w, "SystemSerialNumber\t: "+res.GetResult().GetData().SystemSerialNumber)
+		fmt.Fprintln(w, "SystemUuid\t: "+res.GetResult().GetData().SystemUuid)
+
+		fmt.Fprintln(w, "BaseboardManufacturer\t: "+res.GetResult().GetData().BaseboardManufacturer)
+		fmt.Fprintln(w, "BaseboardProductName\t: "+res.GetResult().GetData().BaseboardProductName)
+		fmt.Fprintln(w, "BaseboardSerialNumber\t: "+res.GetResult().GetData().BaseboardSerialNumber)
+		fmt.Fprintln(w, "BaseboardVersion\t: "+res.GetResult().GetData().BaseboardVersion)
+
+		fmt.Fprintln(w, "ProcessorManufacturer\t: "+res.GetResult().GetData().ProcessorManufacturer)
+		fmt.Fprintln(w, "ProcessorVersion\t: "+res.GetResult().GetData().ProcessorVersion)
+		fmt.Fprintln(w, "ProcessorFrequency\t: "+res.GetResult().GetData().ProcessorFrequency)
+
+		w.Flush()
 
 	case "GETSYSTEMPROPERTY":
 		res := messages.POSPropertyResponse{}


### PR DESCRIPTION
Add BIOS, mainboard, baseboard, and processor information to SYSTEMINFO command.

Now the SYSTEMINFO command displays a wide range of information, which might be 
useful to the system administrator. 

The command will result as follows:

lee@lee-Z390-DESIGNARE:~/Workspace/pos/pos-main/poseidonos/bin$ ./poseidonos-cli system info
PosVersion            : v0.11.0-rc6
BiosVersion           : F8
BiosVendor            : American Megatrends Inc.
BiosReleaseDate       : 10/15/2019
SystemManufacturer    : Gigabyte Technology Co., Ltd.
SystemProductName     : Z390 DESIGNARE
SystemSerialNumber    : Default string
SystemUuid            : 032E02B4-0499-05FF-9806-9B0700080009
BaseboardManufacturer : Gigabyte Technology Co., Ltd.
BaseboardProductName  : Z390 DESIGNARE-CF
BaseboardSerialNumber : Default string
BaseboardVersion      : x.x
ProcessorManufacturer : Intel(R) Corporation
ProcessorVersion      : Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
ProcessorFrequency    : 4653 MHz
