### PR TITLE
[AWIBOF-6481] Change the resume timing of the monitoring daemon stopp…

### DIFF
--- a/src/debug/debug_info.cpp
+++ b/src/debug/debug_info.cpp
@@ -125,8 +125,8 @@ DebugInfo::Update(void)
     mapperService = MapperServiceSingleton::Instance();
     arrayManager = ArrayManagerSingleton::Instance();
     allocatorService = AllocatorServiceSingleton::Instance();
-    uramDrv = UramDrvSingleton::Instance();
-    unvmeDrv = UnvmeDrvSingleton::Instance();
+    uramDrv = static_cast<UramDrv*>(DeviceManagerSingleton::Instance()->GetUramDriver());
+    unvmeDrv = static_cast<UnvmeDrv*>(DeviceManagerSingleton::Instance()->GetUnvmeDriver());
     configManager = ConfigManagerSingleton::Instance();
     spdk = SpdkSingleton::Instance();
     rbaStateService = RBAStateServiceSingleton::Instance();

--- a/src/device/base/device_driver.h
+++ b/src/device/base/device_driver.h
@@ -41,6 +41,7 @@ namespace pos
 {
 class DeviceContext;
 class UBlockDevice;
+class DeviceMonitor;
 
 class DeviceDriver
 {
@@ -51,16 +52,14 @@ public:
     DeviceDriver(void);
     virtual ~DeviceDriver(void);
     virtual int ScanDevs(std::vector<UblockSharedPtr>* devs) = 0;
-
     virtual bool Open(DeviceContext* deviceContext) = 0;
     virtual bool Close(DeviceContext* deviceContext) = 0;
-
     virtual int SubmitAsyncIO(DeviceContext* deviceContext, UbioSmartPtr bio) = 0;
     virtual int CompleteIOs(DeviceContext* deviceContext) = 0;
     virtual int CompleteErrors(DeviceContext* deviceContext);
+    virtual DeviceMonitor* GetDaemon(void) { return nullptr; }
     std::string GetName(void);
-    void SetDeviceEventCallback(DeviceAttachEvent attach,
-        DeviceDetachEvent detach);
+    void SetDeviceEventCallback(DeviceAttachEvent attach, DeviceDetachEvent detach);
 
 protected:
     std::string name = "";

--- a/src/device/device_manager.h
+++ b/src/device/device_manager.h
@@ -82,20 +82,21 @@ public:
     virtual int DetachDevice(DevUid sn);
     virtual int RemoveDevice(UblockSharedPtr dev);
     virtual struct spdk_nvme_ctrlr* GetNvmeCtrlr(std::string& deviceName);
-
-
     virtual void HandleCompletedCommand(void);
-
     virtual int IterateDevicesAndDoFunc(DeviceIterFunc func, void* ctx);
     virtual void SetDeviceEventCallback(IDeviceEvent* event);
+    DeviceDriver* GetUnvmeDriver(void) { return unvmeDriver; }
+    DeviceDriver* GetUramDriver(void) { return uramDriver; }
+    void HandleSsdDestructionNotification(void);
 
 private:
-    void _InitDriver();
-    void _InitMonitor();
-    void _InitScan();
-    void _Rescan();
-    void _ClearDevices();
-    void _ClearMonitors();
+    void _InitDriver(void);
+    void _InitMonitor(void);
+    void _InitScan(void);
+    void _Rescan(void);
+    void _ClearDevices(void);
+    void _ClearMonitors(void);
+    void _ClearDrivers(void);
     int _DetachDeviceImpl(UblockSharedPtr dev);
     void _DetachDone(string devName);
     void _PrepareIOWorker(void);
@@ -116,6 +117,9 @@ private:
     SpdkNvmeCaller* spdkNvmeCaller;
     IDeviceEvent* deviceEvent = nullptr;
     IIODispatcher* ioDispatcher = nullptr;
+    DeviceDriver* uramDriver = nullptr;
+    DeviceDriver* unvmeDriver = nullptr;
+    bool waitSsdDestruction = false;
 };
 
 void DeviceDetachEventHandler(string sn);

--- a/src/device/unvme/unvme_drv.h
+++ b/src/device/unvme/unvme_drv.h
@@ -40,7 +40,6 @@
 #include "src/device/base/device_driver.h"
 #include "src/device/unvme/unvme_cmd.h"
 #include "src/device/unvme/unvme_mgmt.h"
-#include "src/lib/singleton.h"
 
 struct spdk_nvme_qpair;
 namespace pos
@@ -61,36 +60,20 @@ public:
         SpdkNvmeCaller* spdkNvmeCaller = nullptr);
     ~UnvmeDrv(void) override;
     int ScanDevs(std::vector<UblockSharedPtr>* devs) override;
-
     bool Open(DeviceContext* deviceContext) override;
     bool Close(DeviceContext* deviceContext) override;
-
     int CompleteIOs(DeviceContext* deviceContext) override;
     int CompleteErrors(DeviceContext* deviceContext) override;
-
     int SubmitAsyncIO(DeviceContext* deviceContext, UbioSmartPtr bio) override;
-
-    DeviceMonitor* GetDaemon(void);
-    int DeviceAttached(struct spdk_nvme_ns* ns, int num_devs,
-        const spdk_nvme_transport_id* trid);
-    int DeviceDetached(std::string sn);
+    DeviceMonitor* GetDaemon(void) override;
+    void DeviceAttached(struct spdk_nvme_ns* ns, int num_devs, const spdk_nvme_transport_id* trid);
+    void DeviceDetached(std::string sn);
 
 private:
-    int _RequestIO(UnvmeDeviceContext* deviceContext,
-        spdk_nvme_cmd_cb callbackFunc,
-        UnvmeIOContext* ioContext);
-
-    int _SubmitAsyncIOInternal(UnvmeDeviceContext* deviceContext,
-        UnvmeIOContext* ioCtx);
-
-    int _RequestWriteUncorrectable(UnvmeDeviceContext* deviceContext,
-        spdk_nvme_cmd_cb callbackFunc,
-        UnvmeIOContext* ioContext);
-
-    int _RequestDeallocate(UnvmeDeviceContext* deviceContext,
-        spdk_nvme_cmd_cb callbackFunc,
-        UnvmeIOContext* ioCtx);
-
+    int _RequestIO(UnvmeDeviceContext* deviceContext, spdk_nvme_cmd_cb callbackFunc, UnvmeIOContext* ioContext);
+    int _SubmitAsyncIOInternal(UnvmeDeviceContext* deviceContext, UnvmeIOContext* ioCtx);
+    int _RequestWriteUncorrectable(UnvmeDeviceContext* deviceContext, spdk_nvme_cmd_cb callbackFunc, UnvmeIOContext* ioContext);
+    int _RequestDeallocate(UnvmeDeviceContext* deviceContext, spdk_nvme_cmd_cb callbackFunc, UnvmeIOContext* ioCtx);
     int _CompleteIOs(DeviceContext* deviceContext, UnvmeIOContext* ioCtxToSkip);
 
     Nvme* nvmeSsd;
@@ -100,6 +83,4 @@ private:
 };
 
 const uint32_t UNVME_DRV_OUT_OF_MEMORY_RETRY_LIMIT = 10000000;
-
-using UnvmeDrvSingleton = Singleton<UnvmeDrv>;
 } // namespace pos

--- a/src/device/unvme/unvme_ssd.cpp
+++ b/src/device/unvme/unvme_ssd.cpp
@@ -75,6 +75,10 @@ UnvmeSsd::~UnvmeSsd(void)
     {
         delete spdkEnvCaller;
     }
+    if (destuctionCallback != nullptr)
+    {
+        destuctionCallback();
+    }
 }
 // LCOV_EXCL_STOP
 

--- a/src/device/unvme/unvme_ssd.h
+++ b/src/device/unvme/unvme_ssd.h
@@ -35,6 +35,7 @@
 
 #include <cstdint>
 #include <string>
+#include <functional>
 
 #include "spdk/nvme.h"
 #include "src/device/base/ublock_device.h"
@@ -45,6 +46,7 @@ namespace pos
 {
 class DeviceContext;
 class UnvmeDrv;
+using SsdDestructionNotification = std::function<void(void)>;
 
 class UnvmeSsd : public UBlockDevice
 {
@@ -59,8 +61,8 @@ public:
     virtual ~UnvmeSsd() override;
 
     struct spdk_nvme_ns* GetNs(void);
-
     void DecreaseOutstandingAdminCount(void);
+    void SetDestructionCallback(SsdDestructionNotification cb) { destuctionCallback = cb; }
 
 private:
     DeviceContext* _AllocateDeviceContext(void) override;
@@ -70,6 +72,7 @@ private:
     std::string _GetMN();
     int _GetNuma();
 
+    SsdDestructionNotification destuctionCallback = nullptr;
     spdk_nvme_ns* ns;
     SpdkNvmeCaller* spdkNvmeCaller;
     SpdkEnvCaller* spdkEnvCaller;

--- a/src/device/uram/uram_drv.cpp
+++ b/src/device/uram/uram_drv.cpp
@@ -268,13 +268,15 @@ UramDrv::SubmitIO(UramIOContext* ioCtx)
     }
     UramDeviceContext* devCtx = ioCtx->GetDeviceContext();
     spdk_bdev_io_completion_cb callbackFunc;
-
     callbackFunc = &AsyncIOComplete;
-
+    ioCtx->SetDriver(this);
     retValue = _RequestIO(devCtx, callbackFunc, ioCtx);
     spdk_bdev_io_wait_cb retryFunc = [](void* arg) -> void {
         UramIOContext* ioCtx = static_cast<UramIOContext*>(arg);
-        UramDrvSingleton::Instance()->SubmitIO(ioCtx);
+        if (ioCtx != nullptr)
+        {
+            ioCtx->GetDriver()->SubmitIO(ioCtx);
+        }
     };
 
     if (unlikely(-ENOMEM == retValue))

--- a/src/device/uram/uram_drv.h
+++ b/src/device/uram/uram_drv.h
@@ -33,12 +33,12 @@
 #pragma once
 
 #include <vector>
+#include <functional>
 
 #include "spdk/bdev.h"
 #include "src/device/base/device_driver.h"
 #include "src/spdk_wrapper/caller/spdk_bdev_caller.h"
 #include "src/spdk_wrapper/caller/spdk_thread_caller.h"
-#include "src/lib/singleton.h"
 #include "src/spdk_wrapper/event_framework_api.h"
 
 namespace pos
@@ -77,6 +77,4 @@ private:
     SpdkThreadCaller* spdkThreadCaller;
     EventFrameworkApi* eventFrameworkApi;
 };
-
-using UramDrvSingleton = Singleton<UramDrv>;
 } // namespace pos

--- a/src/device/uram/uram_io_context.h
+++ b/src/device/uram/uram_io_context.h
@@ -35,6 +35,7 @@
 #include "spdk/bdev.h"
 #include "src/device/base/io_context.h"
 #include "src/spdk_wrapper/caller/spdk_bdev_caller.h"
+#include "src/device/uram/uram_drv.h"
 
 namespace pos
 {
@@ -57,6 +58,8 @@ public:
     virtual void AddRetryCount(void);
     virtual bool RequestRetry(spdk_bdev_io_wait_cb callbackFunc);
     virtual SpdkBdevCaller* GetBdevCaller(void);
+    virtual UramDrv* GetDriver(void) { return driver; }
+    virtual void SetDriver(UramDrv* drv) { driver = drv; }
 
 private:
     void _PrepareRetryContext(spdk_bdev_io_wait_cb callbackFunc);
@@ -65,5 +68,6 @@ private:
     uint32_t retryCnt;
     spdk_bdev_io_wait_entry retryCtx;
     SpdkBdevCaller* spdkBdevCaller;
+    UramDrv* driver = nullptr;
 };
 } // namespace pos

--- a/src/spdk_wrapper/nvme.cpp
+++ b/src/spdk_wrapper/nvme.cpp
@@ -63,8 +63,8 @@ std::list<NsEntry*> Nvme::namespaces;
 
 uint32_t ioSizeBytes = 4096;
 
-Nvme::SpdkAttachEvent Nvme::attachCb = nullptr;
-Nvme::SpdkDetachEvent Nvme::detachCb = nullptr;
+SpdkAttachEvent Nvme::attachCb = nullptr;
+SpdkDetachEvent Nvme::detachCb = nullptr;
 std::atomic<bool> Nvme::paused;
 std::atomic<bool> Nvme::triggerSpdkDetach;
 std::mutex Nvme::nvmeMutex;

--- a/src/spdk_wrapper/nvme.hpp
+++ b/src/spdk_wrapper/nvme.hpp
@@ -110,23 +110,19 @@ enum class RetryType
     RETRY_TYPE_COUNT,
 };
 
+using SpdkAttachEvent = function<void(struct spdk_nvme_ns* ns, int num_devs, const spdk_nvme_transport_id* trid)>;
+using SpdkDetachEvent = function<void(string sn)>;
+
 class Nvme : public DeviceMonitor
 {
 public:
-    typedef void (*SpdkAttachEvent)(struct spdk_nvme_ns* ns, int num_devs,
-        const spdk_nvme_transport_id* trid);
-    typedef void (*SpdkDetachEvent)(string sn);
-
     virtual std::list<NsEntry*>* InitController(void);
-
     void Start(void) override;
     void Stop(void) override;
     void Pause(void) override;
     void Resume(void) override;
     bool IsPaused(void) override;
-
-    void
-    SetCallback(SpdkAttachEvent attach, SpdkDetachEvent detach)
+    void SetCallback(SpdkAttachEvent attach, SpdkDetachEvent detach)
     {
         attachCb = attach;
         detachCb = detach;

--- a/src/spdk_wrapper/nvme_spdk_test/nvme_spdk_test.cpp
+++ b/src/spdk_wrapper/nvme_spdk_test/nvme_spdk_test.cpp
@@ -154,8 +154,7 @@ test2_ctrl_reset(void)
 
     Nvme* nvmeSsd = new Nvme("Test");
     nvmeSsd->Pause();
-
-    UnvmeDrvSingleton::Instance()->DeviceDetached(targetDevice->GetSN());
+    DeviceManagerSingleton::Instance()->GetUnvmeDriver()->DeviceDetached(targetDevice->GetSN());
 
     while (nvmeSsd->IsPaused())
     {

--- a/test/unit-tests/device/unvme/unvme_drv_test.cpp
+++ b/test/unit-tests/device/unvme/unvme_drv_test.cpp
@@ -102,10 +102,9 @@ TEST(UnvmeDrv, DeviceAttached_testIfAttachEventIsNull)
     UnvmeDrv unvmeDrv;
 
     // When
-    int ret = unvmeDrv.DeviceAttached(nullptr, 0, nullptr);
+    unvmeDrv.DeviceAttached(nullptr, 0, nullptr);
 
     // Then
-    EXPECT_EQ(ret, expectedEventId);
 }
 
 TEST(UnvmeDrv, DeviceDetached_testIfDetachEventIsNull)
@@ -115,10 +114,9 @@ TEST(UnvmeDrv, DeviceDetached_testIfDetachEventIsNull)
     UnvmeDrv unvmeDrv;
 
     // When
-    int ret = unvmeDrv.DeviceDetached("");
+    unvmeDrv.DeviceDetached("");
 
     // Then
-    EXPECT_EQ(ret, expectedEventId);
 }
 
 TEST(UnvmeDrv, CompleteErrors_testIfRetryCountIsNotZero)

--- a/test/unit-tests/device/uram/uram_io_context_mock.h
+++ b/test/unit-tests/device/uram/uram_io_context_mock.h
@@ -39,6 +39,7 @@ public:
     MOCK_METHOD(void, IncOutOfMemoryRetryCount, (), (override));
     MOCK_METHOD(void, ClearOutOfMemoryRetryCount, (), (override));
     MOCK_METHOD(uint32_t, GetOutOfMemoryRetryCount, (), (override));
+    MOCK_METHOD(UramDrv*, GetDriver, (), (override));
 };
 
 } // namespace pos


### PR DESCRIPTION
…ed due to device detachment to the timing when the pending I/O are cleared

Signed-off-by: minjoon.ahn <minjoon.ahn@samsung.com>
현상: device 탈착과정에서 spdk의 tr 구조체 nullptr로 인한 assert 발생
원인: pending i/o 가 남아있는채로 pos에서 spdk_detach수행시, spdk 사이드의 tr 구조체가 미리 정리되어 발생
개선: pending i/o가 정리되어 ssd 객체가 소멸되는 시점에 spdk_detach가 수행되도록 monitoring daemon의 resume시점을 미룸
추가로 불필요한 singleton 객체 제거 및 코딩 스탠다드 개선