### PR TITLE
[AWIBOF-6481] Change the resume timing of the monitoring daemon stopp…

### DIFF
--- a/src/array/service/io_device_checker/io_device_checker.cpp
+++ b/src/array/service/io_device_checker/io_device_checker.cpp
@@ -101,8 +101,6 @@ IODeviceChecker::IsRecoverable(unsigned int arrayIndex, IArrayDevice* target, UB
     }
 
     bool ret = devCheckers[arrayIndex]->IsRecoverable(target, uBlock);
-    POS_TRACE_INFO(EID(ARRAY_DEV_DEBUG_MSG),
-        "IsRecoverableDevice, {}", ret);
     return ret;
 }
 

--- a/src/debug/debug_info.cpp
+++ b/src/debug/debug_info.cpp
@@ -125,8 +125,8 @@ DebugInfo::Update(void)
     mapperService = MapperServiceSingleton::Instance();
     arrayManager = ArrayManagerSingleton::Instance();
     allocatorService = AllocatorServiceSingleton::Instance();
-    uramDrv = UramDrvSingleton::Instance();
-    unvmeDrv = UnvmeDrvSingleton::Instance();
+    uramDrv = static_cast<UramDrv*>(DeviceManagerSingleton::Instance()->GetUramDriver());
+    unvmeDrv = static_cast<UnvmeDrv*>(DeviceManagerSingleton::Instance()->GetUnvmeDriver());
     configManager = ConfigManagerSingleton::Instance();
     spdk = SpdkSingleton::Instance();
     rbaStateService = RBAStateServiceSingleton::Instance();

--- a/src/device/base/device_driver.h
+++ b/src/device/base/device_driver.h
@@ -41,6 +41,7 @@ namespace pos
 {
 class DeviceContext;
 class UBlockDevice;
+class DeviceMonitor;
 
 class DeviceDriver
 {
@@ -51,16 +52,14 @@ public:
     DeviceDriver(void);
     virtual ~DeviceDriver(void);
     virtual int ScanDevs(std::vector<UblockSharedPtr>* devs) = 0;
-
     virtual bool Open(DeviceContext* deviceContext) = 0;
     virtual bool Close(DeviceContext* deviceContext) = 0;
-
     virtual int SubmitAsyncIO(DeviceContext* deviceContext, UbioSmartPtr bio) = 0;
     virtual int CompleteIOs(DeviceContext* deviceContext) = 0;
     virtual int CompleteErrors(DeviceContext* deviceContext);
+    virtual DeviceMonitor* GetDaemon(void) { return nullptr; }
     std::string GetName(void);
-    void SetDeviceEventCallback(DeviceAttachEvent attach,
-        DeviceDetachEvent detach);
+    void SetDeviceEventCallback(DeviceAttachEvent attach, DeviceDetachEvent detach);
 
 protected:
     std::string name = "";

--- a/src/device/device_manager.cpp
+++ b/src/device/device_manager.cpp
@@ -36,6 +36,7 @@
 #include <future>
 #include <string>
 #include <vector>
+#include <functional>
 
 #include "i_io_dispatcher.h"
 #include "src/bio/ubio.h"
@@ -95,21 +96,23 @@ DeviceManager::~DeviceManager()
     {
         delete spdkNvmeCaller;
     }
+    _ClearDrivers();
 }
 
 void
-DeviceManager::_InitDriver()
+DeviceManager::_InitDriver(void)
 {
-    drivers.push_back(UnvmeDrvSingleton::Instance());
-    drivers.push_back(UramDrvSingleton::Instance());
+    unvmeDriver = new UnvmeDrv();
+    uramDriver = UramDrvSingleton::Instance();
+    drivers.push_back(unvmeDriver);
+    drivers.push_back(uramDriver);
 }
 
 void
-DeviceManager::_InitMonitor()
+DeviceManager::_InitMonitor(void)
 {
-    UnvmeDrvSingleton::Instance()->SetDeviceEventCallback(DeviceAttachEventHandler, DeviceDetachEventHandler);
-
-    monitors.push_back(UnvmeDrvSingleton::Instance()->GetDaemon());
+    unvmeDriver->SetDeviceEventCallback(DeviceAttachEventHandler, DeviceDetachEventHandler);
+    monitors.push_back(unvmeDriver->GetDaemon());
 }
 
 void
@@ -157,7 +160,7 @@ DeviceManager::SetDeviceEventCallback(IDeviceEvent* event)
 
 // _ClearDevices() - DO NOT CALL EXCEPT DESTRUCTOR
 void
-DeviceManager::_ClearDevices()
+DeviceManager::_ClearDevices(void)
 {
     std::lock_guard<std::recursive_mutex> guard(deviceManagerMutex);
     for (UblockSharedPtr dev : devices)
@@ -170,7 +173,7 @@ DeviceManager::_ClearDevices()
 }
 
 void
-DeviceManager::_ClearMonitors()
+DeviceManager::_ClearMonitors(void)
 {
     for (auto it = monitors.begin(); it != monitors.end(); it++)
     {
@@ -183,7 +186,16 @@ DeviceManager::_ClearMonitors()
 }
 
 void
-DeviceManager::_StartMonitoring()
+DeviceManager::_ClearDrivers(void)
+{
+    delete unvmeDriver;
+    unvmeDriver = nullptr;
+    uramDriver = nullptr;
+    drivers.clear();
+}
+
+void
+DeviceManager::_StartMonitoring(void)
 {
     POS_TRACE_INFO(POS_EVENT_ID::DEVICEMGR_START_MONITOR,
         "Start Monitoring");
@@ -242,7 +254,7 @@ DeviceManager::ScanDevs(void)
 }
 
 void
-DeviceManager::_InitScan()
+DeviceManager::_InitScan(void)
 {
     POS_TRACE_INFO(POS_EVENT_ID::DEVICEMGR_INIT_SCAN, "InitScan begin");
     for (size_t i = 0; i < drivers.size(); i++)
@@ -290,7 +302,11 @@ DeviceManager::RemoveDevice(UblockSharedPtr dev)
     devices.erase(iter);
     if (type == DeviceType::SSD && ssd != nullptr)
     {
-        UnvmeDrvSingleton::Instance()->GetDaemon()->Resume();
+        waitSsdDestruction = true;
+        SsdDestructionNotification cb = bind(&DeviceManager::HandleSsdDestructionNotification, this);
+        ssd->SetDestructionCallback(cb);
+        POS_TRACE_INFO(POS_EVENT_ID::DEVICEMGR_DETACH,
+                "Pending I/O removal operation of ssd is in progress and monitoring resume is suspended yet.");
     }
 
     POS_TRACE_WARN(POS_EVENT_ID::DEVICEMGR_REMOVE_DEV,
@@ -301,7 +317,7 @@ DeviceManager::RemoveDevice(UblockSharedPtr dev)
 }
 
 void
-DeviceManager::_Rescan()
+DeviceManager::_Rescan(void)
 {
     // URAM RESCAN
     POS_TRACE_INFO(POS_EVENT_ID::DEVICEMGR_RESCAN, "ReScan begin");
@@ -384,13 +400,13 @@ DeviceManager::GetDev(DeviceIdentifier& devID)
 }
 
 vector<UblockSharedPtr>
-DeviceManager::GetDevs()
+DeviceManager::GetDevs(void)
 {
     return devices;
 }
 
 vector<DeviceProperty>
-DeviceManager::ListDevs()
+DeviceManager::ListDevs(void)
 {
     std::lock_guard<std::recursive_mutex> guard(deviceManagerMutex);
     vector<DeviceProperty> devs;
@@ -452,7 +468,7 @@ DeviceManager::DetachDevice(DevUid uid)
             {
                 // Device Manager can call DetachDevice for already removed Ublock Device.
                 // So, just resume the Daemon.
-                UnvmeDrvSingleton::Instance()->GetDaemon()->Resume();
+                unvmeDriver->GetDaemon()->Resume();
                 POS_TRACE_WARN(POS_EVENT_ID::DEVICEMGR_DETACH,
                     "DetachDevice - unknown device or already detached: {}", uid.val);
                 return static_cast<int>(POS_EVENT_ID::DEVICEMGR_DETACH);
@@ -533,4 +549,15 @@ DeviceManager::HandleCompletedCommand(void)
     }
 }
 
+void
+DeviceManager::HandleSsdDestructionNotification(void)
+{
+    if (waitSsdDestruction == true)
+    {
+        waitSsdDestruction = false;
+         POS_TRACE_INFO(POS_EVENT_ID::DEVICEMGR_DETACH,
+                "SSD removal operation has been cleared and monitoring resumes");
+        unvmeDriver->GetDaemon()->Resume();
+    }
+}
 } // namespace pos

--- a/src/device/device_manager.h
+++ b/src/device/device_manager.h
@@ -82,20 +82,21 @@ public:
     virtual int DetachDevice(DevUid sn);
     virtual int RemoveDevice(UblockSharedPtr dev);
     virtual struct spdk_nvme_ctrlr* GetNvmeCtrlr(std::string& deviceName);
-
-
     virtual void HandleCompletedCommand(void);
-
     virtual int IterateDevicesAndDoFunc(DeviceIterFunc func, void* ctx);
     virtual void SetDeviceEventCallback(IDeviceEvent* event);
+    DeviceDriver* GetUnvmeDriver(void) { return unvmeDriver; }
+    DeviceDriver* GetUramDriver(void) { return uramDriver; }
+    void HandleSsdDestructionNotification(void);
 
 private:
-    void _InitDriver();
-    void _InitMonitor();
-    void _InitScan();
-    void _Rescan();
-    void _ClearDevices();
-    void _ClearMonitors();
+    void _InitDriver(void);
+    void _InitMonitor(void);
+    void _InitScan(void);
+    void _Rescan(void);
+    void _ClearDevices(void);
+    void _ClearMonitors(void);
+    void _ClearDrivers(void);
     int _DetachDeviceImpl(UblockSharedPtr dev);
     void _DetachDone(string devName);
     void _PrepareIOWorker(void);
@@ -116,6 +117,9 @@ private:
     SpdkNvmeCaller* spdkNvmeCaller;
     IDeviceEvent* deviceEvent = nullptr;
     IIODispatcher* ioDispatcher = nullptr;
+    DeviceDriver* uramDriver = nullptr;
+    DeviceDriver* unvmeDriver = nullptr;
+    bool waitSsdDestruction = false;
 };
 
 void DeviceDetachEventHandler(string sn);

--- a/src/device/device_manager.h
+++ b/src/device/device_manager.h
@@ -119,7 +119,7 @@ private:
     IIODispatcher* ioDispatcher = nullptr;
     DeviceDriver* uramDriver = nullptr;
     DeviceDriver* unvmeDriver = nullptr;
-    bool waitSsdDestruction = false;
+    atomic<bool> waitSsdDestruction;
 };
 
 void DeviceDetachEventHandler(string sn);

--- a/src/device/unvme/unvme_drv.h
+++ b/src/device/unvme/unvme_drv.h
@@ -40,7 +40,6 @@
 #include "src/device/base/device_driver.h"
 #include "src/device/unvme/unvme_cmd.h"
 #include "src/device/unvme/unvme_mgmt.h"
-#include "src/lib/singleton.h"
 
 struct spdk_nvme_qpair;
 namespace pos
@@ -61,36 +60,20 @@ public:
         SpdkNvmeCaller* spdkNvmeCaller = nullptr);
     ~UnvmeDrv(void) override;
     int ScanDevs(std::vector<UblockSharedPtr>* devs) override;
-
     bool Open(DeviceContext* deviceContext) override;
     bool Close(DeviceContext* deviceContext) override;
-
     int CompleteIOs(DeviceContext* deviceContext) override;
     int CompleteErrors(DeviceContext* deviceContext) override;
-
     int SubmitAsyncIO(DeviceContext* deviceContext, UbioSmartPtr bio) override;
-
-    DeviceMonitor* GetDaemon(void);
-    int DeviceAttached(struct spdk_nvme_ns* ns, int num_devs,
-        const spdk_nvme_transport_id* trid);
-    int DeviceDetached(std::string sn);
+    DeviceMonitor* GetDaemon(void) override;
+    void DeviceAttached(struct spdk_nvme_ns* ns, int num_devs, const spdk_nvme_transport_id* trid);
+    void DeviceDetached(std::string sn);
 
 private:
-    int _RequestIO(UnvmeDeviceContext* deviceContext,
-        spdk_nvme_cmd_cb callbackFunc,
-        UnvmeIOContext* ioContext);
-
-    int _SubmitAsyncIOInternal(UnvmeDeviceContext* deviceContext,
-        UnvmeIOContext* ioCtx);
-
-    int _RequestWriteUncorrectable(UnvmeDeviceContext* deviceContext,
-        spdk_nvme_cmd_cb callbackFunc,
-        UnvmeIOContext* ioContext);
-
-    int _RequestDeallocate(UnvmeDeviceContext* deviceContext,
-        spdk_nvme_cmd_cb callbackFunc,
-        UnvmeIOContext* ioCtx);
-
+    int _RequestIO(UnvmeDeviceContext* deviceContext, spdk_nvme_cmd_cb callbackFunc, UnvmeIOContext* ioContext);
+    int _SubmitAsyncIOInternal(UnvmeDeviceContext* deviceContext, UnvmeIOContext* ioCtx);
+    int _RequestWriteUncorrectable(UnvmeDeviceContext* deviceContext, spdk_nvme_cmd_cb callbackFunc, UnvmeIOContext* ioContext);
+    int _RequestDeallocate(UnvmeDeviceContext* deviceContext, spdk_nvme_cmd_cb callbackFunc, UnvmeIOContext* ioCtx);
     int _CompleteIOs(DeviceContext* deviceContext, UnvmeIOContext* ioCtxToSkip);
 
     Nvme* nvmeSsd;
@@ -100,6 +83,4 @@ private:
 };
 
 const uint32_t UNVME_DRV_OUT_OF_MEMORY_RETRY_LIMIT = 10000000;
-
-using UnvmeDrvSingleton = Singleton<UnvmeDrv>;
 } // namespace pos

--- a/src/device/unvme/unvme_ssd.cpp
+++ b/src/device/unvme/unvme_ssd.cpp
@@ -75,6 +75,10 @@ UnvmeSsd::~UnvmeSsd(void)
     {
         delete spdkEnvCaller;
     }
+    if (destuctionCallback != nullptr)
+    {
+        destuctionCallback();
+    }
 }
 // LCOV_EXCL_STOP
 

--- a/src/device/unvme/unvme_ssd.h
+++ b/src/device/unvme/unvme_ssd.h
@@ -35,6 +35,7 @@
 
 #include <cstdint>
 #include <string>
+#include <functional>
 
 #include "spdk/nvme.h"
 #include "src/device/base/ublock_device.h"
@@ -45,6 +46,7 @@ namespace pos
 {
 class DeviceContext;
 class UnvmeDrv;
+using SsdDestructionNotification = std::function<void(void)>;
 
 class UnvmeSsd : public UBlockDevice
 {
@@ -59,8 +61,8 @@ public:
     virtual ~UnvmeSsd() override;
 
     struct spdk_nvme_ns* GetNs(void);
-
     void DecreaseOutstandingAdminCount(void);
+    void SetDestructionCallback(SsdDestructionNotification cb) { destuctionCallback = cb; }
 
 private:
     DeviceContext* _AllocateDeviceContext(void) override;
@@ -70,6 +72,7 @@ private:
     std::string _GetMN();
     int _GetNuma();
 
+    SsdDestructionNotification destuctionCallback = nullptr;
     spdk_nvme_ns* ns;
     SpdkNvmeCaller* spdkNvmeCaller;
     SpdkEnvCaller* spdkEnvCaller;

--- a/src/device/uram/uram_drv.cpp
+++ b/src/device/uram/uram_drv.cpp
@@ -268,9 +268,7 @@ UramDrv::SubmitIO(UramIOContext* ioCtx)
     }
     UramDeviceContext* devCtx = ioCtx->GetDeviceContext();
     spdk_bdev_io_completion_cb callbackFunc;
-
     callbackFunc = &AsyncIOComplete;
-
     retValue = _RequestIO(devCtx, callbackFunc, ioCtx);
     spdk_bdev_io_wait_cb retryFunc = [](void* arg) -> void {
         UramIOContext* ioCtx = static_cast<UramIOContext*>(arg);

--- a/src/device/uram/uram_drv.h
+++ b/src/device/uram/uram_drv.h
@@ -33,6 +33,7 @@
 #pragma once
 
 #include <vector>
+#include <functional>
 
 #include "spdk/bdev.h"
 #include "src/device/base/device_driver.h"

--- a/src/spdk_wrapper/nvme.cpp
+++ b/src/spdk_wrapper/nvme.cpp
@@ -63,8 +63,8 @@ std::list<NsEntry*> Nvme::namespaces;
 
 uint32_t ioSizeBytes = 4096;
 
-Nvme::SpdkAttachEvent Nvme::attachCb = nullptr;
-Nvme::SpdkDetachEvent Nvme::detachCb = nullptr;
+SpdkAttachEvent Nvme::attachCb = nullptr;
+SpdkDetachEvent Nvme::detachCb = nullptr;
 std::atomic<bool> Nvme::paused;
 std::atomic<bool> Nvme::triggerSpdkDetach;
 std::mutex Nvme::nvmeMutex;

--- a/src/spdk_wrapper/nvme.hpp
+++ b/src/spdk_wrapper/nvme.hpp
@@ -110,23 +110,19 @@ enum class RetryType
     RETRY_TYPE_COUNT,
 };
 
+using SpdkAttachEvent = function<void(struct spdk_nvme_ns* ns, int num_devs, const spdk_nvme_transport_id* trid)>;
+using SpdkDetachEvent = function<void(string sn)>;
+
 class Nvme : public DeviceMonitor
 {
 public:
-    typedef void (*SpdkAttachEvent)(struct spdk_nvme_ns* ns, int num_devs,
-        const spdk_nvme_transport_id* trid);
-    typedef void (*SpdkDetachEvent)(string sn);
-
     virtual std::list<NsEntry*>* InitController(void);
-
     void Start(void) override;
     void Stop(void) override;
     void Pause(void) override;
     void Resume(void) override;
     bool IsPaused(void) override;
-
-    void
-    SetCallback(SpdkAttachEvent attach, SpdkDetachEvent detach)
+    void SetCallback(SpdkAttachEvent attach, SpdkDetachEvent detach)
     {
         attachCb = attach;
         detachCb = detach;

--- a/src/spdk_wrapper/nvme_spdk_test/nvme_spdk_test.cpp
+++ b/src/spdk_wrapper/nvme_spdk_test/nvme_spdk_test.cpp
@@ -154,8 +154,7 @@ test2_ctrl_reset(void)
 
     Nvme* nvmeSsd = new Nvme("Test");
     nvmeSsd->Pause();
-
-    UnvmeDrvSingleton::Instance()->DeviceDetached(targetDevice->GetSN());
+    DeviceManagerSingleton::Instance()->GetUnvmeDriver()->DeviceDetached(targetDevice->GetSN());
 
     while (nvmeSsd->IsPaused())
     {

--- a/test/unit-tests/device/unvme/unvme_drv_test.cpp
+++ b/test/unit-tests/device/unvme/unvme_drv_test.cpp
@@ -102,10 +102,9 @@ TEST(UnvmeDrv, DeviceAttached_testIfAttachEventIsNull)
     UnvmeDrv unvmeDrv;
 
     // When
-    int ret = unvmeDrv.DeviceAttached(nullptr, 0, nullptr);
+    unvmeDrv.DeviceAttached(nullptr, 0, nullptr);
 
     // Then
-    EXPECT_EQ(ret, expectedEventId);
 }
 
 TEST(UnvmeDrv, DeviceDetached_testIfDetachEventIsNull)
@@ -115,10 +114,9 @@ TEST(UnvmeDrv, DeviceDetached_testIfDetachEventIsNull)
     UnvmeDrv unvmeDrv;
 
     // When
-    int ret = unvmeDrv.DeviceDetached("");
+    unvmeDrv.DeviceDetached("");
 
     // Then
-    EXPECT_EQ(ret, expectedEventId);
 }
 
 TEST(UnvmeDrv, CompleteErrors_testIfRetryCountIsNotZero)

--- a/test/unit-tests/device/uram/uram_drv_test.cpp
+++ b/test/unit-tests/device/uram/uram_drv_test.cpp
@@ -369,11 +369,11 @@ TEST(UramDrv, SubmitIO_testIfRetryCallbackTriggerdProperly)
         callbackFunc(nullptr);
         return true;
     });
+
     NiceMock<MockSpdkBdevCaller>* mockBdevCaller =
         new NiceMock<MockSpdkBdevCaller>();
     EXPECT_CALL(*mockBdevCaller, SpdkBdevRead)
         .WillOnce(Return(-ENOMEM));
-
     UramDrv uramDrv(mockBdevCaller);
 
     // When


### PR DESCRIPTION
현상: device 탈착과정에서 spdk의 tr 구조체 nullptr로 인한 assert 발생
원인: pending i/o 가 남아있는채로 pos에서 spdk_detach수행시, spdk 사이드의 tr 구조체가 미리 정리되어 발생
개선: pending i/o가 정리되어 ssd 객체가 소멸되는 시점에 spdk_detach가 수행되도록 monitoring daemon의 resume시점을 미룸
추가로 불필요한 singleton 객체 제거 및 코딩 스탠다드 개선
Signed-off-by: minjoon.ahn <minjoon.ahn@samsung.com>