### PR TITLE
[AWIBOF-6481] The nvme ctrlr detach timing of the hot-detached SSD is…

### DIFF
--- a/src/array/service/io_locker/stripe_locker.cpp
+++ b/src/array/service/io_locker/stripe_locker.cpp
@@ -91,7 +91,10 @@ StripeLocker::ResetBusyLock(bool force)
     {
         return false;
     }
-
+    if (force == true)
+    {
+        busyLocker->Clear();
+    }
     POS_TRACE_DEBUG((int)POS_EVENT_ID::LOCKER_DEBUG_MSG,
         "Reset Busylock, force_reset:{}", force);
     delete busyRange;
@@ -140,7 +143,10 @@ StripeLocker::Unlock(StripeId id)
 void
 StripeLocker::WriteBusyLog(void)
 {
+    POS_TRACE_WARN(EID(BUSY_LOCKER_WARN), "StripeLocker, isBusyRangeChanging:{}",
+        isBusyRangeChanging);
     busyLocker->WriteLog();
+    normalLocker->WriteLog();
 }
 
 } // namespace pos

--- a/src/array/service/io_locker/stripe_locker_busy_state.cpp
+++ b/src/array/service/io_locker/stripe_locker_busy_state.cpp
@@ -71,6 +71,13 @@ StripeLockerBusyState::Count(void)
 }
 
 void
+StripeLockerBusyState::Clear(void)
+{
+    unique_lock<mutex> lock(mtx);
+    busySet.clear();
+}
+
+void
 StripeLockerBusyState::WriteLog(void)
 {
     stringstream ss;

--- a/src/array/service/io_locker/stripe_locker_busy_state.h
+++ b/src/array/service/io_locker/stripe_locker_busy_state.h
@@ -50,6 +50,7 @@ public:
     void Unlock(StripeId val) override;
     bool Exists(StripeId val) override;
     uint32_t Count(void) override;
+    void Clear(void);
     void WriteLog(void);
 
 private:

--- a/src/array/service/io_locker/stripe_locker_normal_state.cpp
+++ b/src/array/service/io_locker/stripe_locker_normal_state.cpp
@@ -31,9 +31,10 @@
  */
 
 #include "stripe_locker_normal_state.h"
-
 #include "src/include/pos_event_id.h"
 #include "src/logger/logger.h"
+
+#include <sstream>
 
 namespace pos
 {
@@ -67,6 +68,18 @@ StripeLockerNormalState::Count(void)
 {
     unique_lock<mutex> lock(mtx);
     return workingSet.size();
+}
+
+void
+StripeLockerNormalState::WriteLog(void)
+{
+    stringstream ss;
+    for (auto item : workingSet)
+    {
+        ss << "(id:" << item.id << ", owner:" << item.owner << "), ";
+    }
+    POS_TRACE_WARN(EID(BUSY_LOCKER_WARN), "NormalLocker, cnt:{}, items:{}",
+        workingSet.size(), ss.str());
 }
 
 }; // namespace pos

--- a/src/array/service/io_locker/stripe_locker_normal_state.h
+++ b/src/array/service/io_locker/stripe_locker_normal_state.h
@@ -50,6 +50,7 @@ public:
     void Unlock(StripeId val) override;
     bool Exists(StripeId val) override;
     uint32_t Count(void) override;
+    void WriteLog(void);
 
 private:
     multiset<StripeLockInfo> workingSet;

--- a/src/device/device_manager.cpp
+++ b/src/device/device_manager.cpp
@@ -290,6 +290,7 @@ DeviceManager::RemoveDevice(UblockSharedPtr dev)
     devices.erase(iter);
     if (type == DeviceType::SSD && ssd != nullptr)
     {
+        ssd->SetHotDetached();
         UnvmeDrvSingleton::Instance()->GetDaemon()->Resume();
     }
 

--- a/src/device/device_manager.cpp
+++ b/src/device/device_manager.cpp
@@ -290,6 +290,7 @@ DeviceManager::RemoveDevice(UblockSharedPtr dev)
     devices.erase(iter);
     if (type == DeviceType::SSD && ssd != nullptr)
     {
+        POS_TRACE_WARN(EID(DEVICEMGR_REMOVE_DEV), "SSD {}({}) is hot-removed", dev->GetName(), dev->GetSN());
         ssd->SetHotDetached();
         UnvmeDrvSingleton::Instance()->GetDaemon()->Resume();
     }

--- a/src/device/unvme/unvme_drv.cpp
+++ b/src/device/unvme/unvme_drv.cpp
@@ -247,6 +247,12 @@ UnvmeDrv::GetDaemon(void)
     return nvmeSsd;
 }
 
+void
+UnvmeDrv::SpdkDetach(struct spdk_nvme_ns* ns)
+{
+    nvmeSsd->SpdkDetach(ns);
+}
+
 int
 UnvmeDrv::DeviceDetached(std::string sn)
 {

--- a/src/device/unvme/unvme_drv.h
+++ b/src/device/unvme/unvme_drv.h
@@ -74,6 +74,7 @@ public:
     int DeviceAttached(struct spdk_nvme_ns* ns, int num_devs,
         const spdk_nvme_transport_id* trid);
     int DeviceDetached(std::string sn);
+    void SpdkDetach(struct spdk_nvme_ns* ns);
 
 private:
     int _RequestIO(UnvmeDeviceContext* deviceContext,

--- a/src/device/unvme/unvme_ssd.cpp
+++ b/src/device/unvme/unvme_ssd.cpp
@@ -52,6 +52,7 @@ UnvmeSsd::UnvmeSsd(
     SpdkNvmeCaller* spdkNvmeCaller,
     SpdkEnvCaller* spdkEnvCaller)
 : UBlockDevice(name, size, driverToUse),
+  driver(driverToUse),
   ns(namespaceToUse),
   spdkNvmeCaller(spdkNvmeCaller),
   spdkEnvCaller(spdkEnvCaller)
@@ -67,6 +68,10 @@ UnvmeSsd::UnvmeSsd(
 // LCOV_EXCL_START
 UnvmeSsd::~UnvmeSsd(void)
 {
+    if (isHotDetached == true)
+    {
+        driver->SpdkDetach(ns);
+    }
     if (spdkNvmeCaller != nullptr)
     {
         delete spdkNvmeCaller;

--- a/src/device/unvme/unvme_ssd.cpp
+++ b/src/device/unvme/unvme_ssd.cpp
@@ -70,6 +70,7 @@ UnvmeSsd::~UnvmeSsd(void)
 {
     if (isHotDetached == true)
     {
+        POS_TRACE_WARN(EID(DEVICEMGR_REMOVE_DEV), "Free SSD ctrlr {}({})", GetName(), GetSN());
         driver->SpdkDetach(ns);
     }
     if (spdkNvmeCaller != nullptr)

--- a/src/device/unvme/unvme_ssd.h
+++ b/src/device/unvme/unvme_ssd.h
@@ -57,10 +57,9 @@ public:
         SpdkNvmeCaller* spdkNvmeCaller = new SpdkNvmeCaller(),
         SpdkEnvCaller* spdkEnvCaller = new SpdkEnvCaller());
     virtual ~UnvmeSsd() override;
-
     struct spdk_nvme_ns* GetNs(void);
-
     void DecreaseOutstandingAdminCount(void);
+    void SetHotDetached(void) { isHotDetached = true; }
 
 private:
     DeviceContext* _AllocateDeviceContext(void) override;
@@ -70,9 +69,11 @@ private:
     std::string _GetMN();
     int _GetNuma();
 
+    UnvmeDrv* driver;
     spdk_nvme_ns* ns;
     SpdkNvmeCaller* spdkNvmeCaller;
     SpdkEnvCaller* spdkEnvCaller;
+    bool isHotDetached = false;
 };
 } // namespace pos
 

--- a/src/rebuild/stripe_based_race_rebuild.cpp
+++ b/src/rebuild/stripe_based_race_rebuild.cpp
@@ -134,7 +134,8 @@ StripeBasedRaceRebuild::Read(void)
         }
         else
         {
-             POS_TRACE_INFO(EID(REBUILD_DEBUG_MSG), "Busy lock successfully reset, rebuild_result:{}", ctx->GetResult());
+            resetLockRetryCnt = 0;
+            POS_TRACE_INFO(EID(REBUILD_DEBUG_MSG), "Busy lock successfully reset, rebuild_result:{}", ctx->GetResult());
         }
         if (ctx->GetResult() == RebuildState::CANCELLED)
         {

--- a/src/rebuild/stripe_based_race_rebuild.cpp
+++ b/src/rebuild/stripe_based_race_rebuild.cpp
@@ -132,6 +132,10 @@ StripeBasedRaceRebuild::Read(void)
             }
             return false;
         }
+        else
+        {
+             POS_TRACE_INFO(EID(REBUILD_DEBUG_MSG), "Busy lock successfully reset, rebuild_result:{}", ctx->GetResult());
+        }
         if (ctx->GetResult() == RebuildState::CANCELLED)
         {
             POS_TRACE_WARN((int)POS_EVENT_ID::REBUILD_STOPPED,

--- a/src/rebuild/stripe_based_race_rebuild.h
+++ b/src/rebuild/stripe_based_race_rebuild.h
@@ -57,7 +57,7 @@ private:
 
     StripeId baseStripe = 0;
     IIOLocker* locker = nullptr;
-    static const int TRY_LOCK_MAX_RETRY = 10000;
+    static const int TRY_LOCK_MAX_RETRY = 50000;
     int tryLockRetryCnt = 0;
     int resetLockRetryCnt = 0;
 };

--- a/src/spdk_wrapper/nvme.cpp
+++ b/src/spdk_wrapper/nvme.cpp
@@ -403,16 +403,12 @@ Nvme::_RemoveCallback(void* cbCtx, struct spdk_nvme_ctrlr* ctrlr)
         cdata = spdk_nvme_ctrlr_get_data(ctrlr);
         char sn[128];
         snprintf(sn, sizeof(cdata->sn) + 1, "%s", cdata->sn);
-        struct spdk_nvme_ns* ns = spdk_nvme_ctrlr_get_ns(ctrlr, 1);
-
         paused = true;
         auto f = async(launch::async, detachCb, string(sn));
         while (paused)
         {
             usleep(1);
         }
-
-        SpdkDetach(ns);
     }
     else
     {


### PR DESCRIPTION
… changed to be performed after the pending i/o processing is completed

Signed-off-by: minjoon.ahn <minjoon.ahn@samsung.com>
현상: device 탈착과정에서 spdk의 tr 구조체 nullptr로 인한 assert 발생
원인: pending i/o 가 남아있는채로 pos에서 spdk_detach수행시, spdk 사이드의 tr 구조체가 미리 정리되어 발생
개선: pending i/o가 정리되어 ssd 객체가 소멸되는 시점에 spdk_detach가 수행되도록 변경