### PR TITLE
[AWIBOF-6709] relocated set_tls_thread_to_reactor

### DIFF
--- a/lib/spdk-22.01.1.patch
+++ b/lib/spdk-22.01.1.patch
@@ -3584,7 +3584,7 @@ index 4e6541e96..cab4aa177 100644
  
  struct spdk_nvmf_tgt_conf {
 diff --git module/event/subsystems/nvmf/nvmf_tgt.c module/event/subsystems/nvmf/nvmf_tgt.c
-index b6573a237..49c1ba5d4 100644
+index b6573a237..e82103dba 100644
 --- module/event/subsystems/nvmf/nvmf_tgt.c
 +++ module/event/subsystems/nvmf/nvmf_tgt.c
 @@ -36,6 +36,7 @@
@@ -3614,12 +3614,19 @@ index b6573a237..49c1ba5d4 100644
  	spdk_thread_exit(spdk_get_thread());
  }
  
-@@ -224,7 +226,7 @@ nvmf_tgt_create_poll_groups(void)
+@@ -202,6 +204,7 @@ nvmf_tgt_create_poll_group(void *ctx)
+ 
+ 	pg->thread = spdk_get_thread();
+ 	pg->group = spdk_nvmf_poll_group_create(g_spdk_nvmf_tgt);
++	set_tls_thread_to_reactor(spdk_env_get_current_core(), spdk_get_thread());
+ 
+ 	spdk_thread_send_msg(g_tgt_init_thread, nvmf_tgt_create_poll_group_done, pg);
+ }
+@@ -224,7 +227,6 @@ nvmf_tgt_create_poll_groups(void)
  
  		thread = spdk_thread_create(thread_name, g_poll_groups_mask);
  		assert(thread != NULL);
 -
-+		set_tls_thread_to_reactor(i, thread);
  		spdk_thread_send_msg(thread, nvmf_tgt_create_poll_group, NULL);
  	}
  }


### PR DESCRIPTION
이전 spdk 버전에서는 thread 생성 시, 단일 core를 지정하여 인자로 넘겨 생성할 수 있었지만,
spdk 버전 업 되면서 특정 core에 pinning 되지 않는 방향으로 수정되어 spdk 내부 로직에의해 thread 가 생성되면 round-robin으로 reactor가 매핑되도록 변경되었습니다.
따라서 저희가 지정한 core가 아니라 자동적으로 core가 지정되면서 처음 poll_group create 호출을 시작하는 reactor 0에서 모든 thread-reactor pinning 정보를 저장하면 잘못된 정보가 저장되게 됩니다. 이 시점에는 해당 thread가 어떤 core에서 돌지 모르기 때문입니다.

따라서, .pinning 하는 함수를 안전하게 현재 돌고 있는 core에서 호출할 수 있도록 수정하였습니다.