### PR TITLE
[AWIBOF-6664] enables jaeger-exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,10 @@ lib/spdk-prefix/
 lib/spdk/
 lib/spdlog-1.4.2/
 lib/spdlog-prefix/
+lib/opentelemetry-cpp-prefix/
+lib/opentelemetry-cpp/
+lib/thrift-prefix/
+lib/thrift/
 tool/cli/vendor
 tool/cli/docs/manpage
 tool/pkg/

--- a/.gitignore
+++ b/.gitignore
@@ -87,8 +87,6 @@ lib/spdlog-1.4.2/
 lib/spdlog-prefix/
 lib/opentelemetry-cpp-prefix/
 lib/opentelemetry-cpp/
-lib/thrift-prefix/
-lib/thrift/
 tool/cli/vendor
 tool/cli/docs/manpage
 tool/pkg/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SPDK_ROOT_DIR := $(abspath $(CURDIR)/lib/spdk)
 SPDLOG_SOURCE := spdlog-1.4.2
 SPDLOG_ROOT_DIR := $(abspath $(CURDIR)/lib/$(SPDLOG_SOURCE))
 OTEL_ROOT_DIR := $(abspath $(POS_ROOT_DIR)/lib/opentelemetry-cpp)
+THRIFT_ROOT_DIR := $(abspath $(POS_ROOT_DIR)/lib/thrift)
 
 TOP = $(POS_ROOT_DIR)
 PROTO_DIR = $(TOP)/proto
@@ -125,8 +126,15 @@ DEFINE += -DAIR_CFG=$(TOP)/config/air.cfg
 INCLUDE += -I$(SPDLOG_ROOT_DIR)/include -I$(SPDLOG_ROOT_DIR)/include/spdlog
 LDFLAGS += -L./lib/$(SPDLOG_SOURCE)/lib -lspdlog
 
-INCLUDE += -I$(OTEL_ROOT_DIR)/include
-LDFLAGS += -L$(OTEL_ROOT_DIR)/lib
+INCLUDE += -I$(THRIFT_ROOT_DIR)/include -I$(OTEL_ROOT_DIR)/include
+LDFLAGS += -L$(THRIFT_ROOT_DIR)/lib -L$(OTEL_ROOT_DIR)/lib \
+				-lopentelemetry_common \
+				-lopentelemetry_trace \
+				-lopentelemetry_exporter_jaeger_trace \
+				-lopentelemetry_resources \
+				-lopentelemetry_common \
+				-lopentelemetry_http_client_curl \
+				-lthrift -lpthread -lcurl
 
 CXXFLAGS += $(INCLUDE)
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ SPDK_ROOT_DIR := $(abspath $(CURDIR)/lib/spdk)
 SPDLOG_SOURCE := spdlog-1.4.2
 SPDLOG_ROOT_DIR := $(abspath $(CURDIR)/lib/$(SPDLOG_SOURCE))
 OTEL_ROOT_DIR := $(abspath $(POS_ROOT_DIR)/lib/opentelemetry-cpp)
-THRIFT_ROOT_DIR := $(abspath $(POS_ROOT_DIR)/lib/thrift)
 
 TOP = $(POS_ROOT_DIR)
 PROTO_DIR = $(TOP)/proto
@@ -126,15 +125,18 @@ DEFINE += -DAIR_CFG=$(TOP)/config/air.cfg
 INCLUDE += -I$(SPDLOG_ROOT_DIR)/include -I$(SPDLOG_ROOT_DIR)/include/spdlog
 LDFLAGS += -L./lib/$(SPDLOG_SOURCE)/lib -lspdlog
 
-INCLUDE += -I$(THRIFT_ROOT_DIR)/include -I$(OTEL_ROOT_DIR)/include
-LDFLAGS += -L$(THRIFT_ROOT_DIR)/lib -L$(OTEL_ROOT_DIR)/lib \
-				-lopentelemetry_common \
-				-lopentelemetry_trace \
-				-lopentelemetry_exporter_jaeger_trace \
-				-lopentelemetry_resources \
-				-lopentelemetry_common \
-				-lopentelemetry_http_client_curl \
-				-lthrift -lpthread -lcurl
+INCLUDE += -I$(OTEL_ROOT_DIR)/include
+LDFLAGS += -L$(OTEL_ROOT_DIR)/lib \
+		-lopentelemetry_common \
+		-lopentelemetry_trace \
+		-lopentelemetry_exporter_otlp_http \
+		-lopentelemetry_exporter_otlp_http_client \
+		-lopentelemetry_otlp_recordable \
+		-lopentelemetry_proto \
+		-lopentelemetry_resources \
+		-lopentelemetry_common \
+		-lopentelemetry_http_client_curl \
+		-lpthread -lcurl -lprotobuf
 
 CXXFLAGS += $(INCLUDE)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -303,29 +303,6 @@ else()
     )
 endif()
 
-# Set Thrift build options
-set(POS_DEP_THRIFT "thrift")
-if (${USE_LOCAL_REPO} STREQUAL "y")
-    set(REPO_THRIFT "${LOCAL_REPO}/thrift.git")
-else()
-    set(REPO_THRIFT "https://github.com/apache/thrift.git")
-endif()
-
-# Build and install Thrift
-ExternalProject_Add(thrift
-    GIT_REPOSITORY ${REPO_THRIFT}
-    GIT_TAG "v0.14.1"
-    SOURCE_DIR ${PROJ_ROOT}/lib/${POS_DEP_THRIFT}
-    BUILD_IN_SOURCE 1
-    LOG_DOWNLOAD ON
-    LOG_CONFIGURE ON
-    LOG_BUILD ON
-    LOG_INSTALL ON
-    CONFIGURE_COMMAND cmake -G Ninja . -DBUILD_COMPILER=OFF -DBUILD_CPP=ON -DBUILD_LIBRARIES=ON -DBUILD_NODEJS=OFF -DBUILD_PYTHON=OFF -DBUILD_JAVASCRIPT=OFF -DBUILD_C_GLIB=OFF -DBUILD_JAVA=OFF -DBUILD_TESTING=OFF -DBUILD_TUTORIALS=OFF -DWITH_STDTHREADS=ON -DWITH_BOOSTTHREADS=OFF -DWITH_BOOST_FUNCTIONAL=OFF -DWITH_BOOST_SMART_PTR=OFF -DCMAKE_INSTALL_PREFIX=${PROJ_ROOT}/lib/${POS_DEP_THRIFT} -DCMAKE_PREFIX_PATH=${PROJ_ROOT}/lib/${POS_DEP_THRIFT} .
-    BUILD_COMMAND ninja -j ${NUM_BUILD_CORE}
-    INSTALL_COMMAND ninja install
-)
-
 # Set opentelemetry-cpp build options
 set(POS_DEP_OTEL "opentelemetry-cpp")
 if (${USE_LOCAL_REPO} STREQUAL "y")
@@ -344,7 +321,7 @@ ExternalProject_Add(opentelemetry-cpp
     LOG_CONFIGURE ON
     LOG_BUILD ON
     LOG_INSTALL ON
-    CONFIGURE_COMMAND cmake ${PROJ_ROOT}/lib/${POS_DEP_OTEL} -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX:PATH=${PROJ_ROOT}/lib/${POS_DEP_OTEL} -DWITH_JAEGER=on
+    CONFIGURE_COMMAND cmake ${PROJ_ROOT}/lib/${POS_DEP_OTEL} -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX:PATH=${PROJ_ROOT}/lib/${POS_DEP_OTEL} -DWITH_OTLP=on
     BUILD_COMMAND make -j ${NUM_BUILD_CORE} all
     INSTALL_COMMAND make install
 )
@@ -397,12 +374,6 @@ add_custom_target(
 )
 
 add_custom_target(
-    clean_thrift
-    WORKING_DIRECTORY ${PROJ_ROOT}/lib/${POS_DEP_THRIFT}
-    COMMAND rm -rf lib/*.a
-)
-
-add_custom_target(
     clean_opentelemetry-cpp
     WORKING_DIRECTORY ${PROJ_ROOT}/lib/${POS_DEP_OTEL}
     COMMAND make clean
@@ -436,10 +407,6 @@ endif()
 
 if(EXISTS ${PROJ_ROOT}/lib/${POS_DEP_GTEST}/libgtest.a)
     list(APPEND CLEAN_ALL_TARGETS clean_gtest)
-endif()
-
-if(EXISTS ${PROJ_ROOT}/lib/${POS_DEP_THRIFT})
-    list(APPEND CLEAN_ALL_TARGETS clean_thrift)
 endif()
 
 if(EXISTS ${PROJ_ROOT}/lib/${POS_DEP_OTEL}/Makefile)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -303,6 +303,29 @@ else()
     )
 endif()
 
+# Set Thrift build options
+set(POS_DEP_THRIFT "thrift")
+if (${USE_LOCAL_REPO} STREQUAL "y")
+    set(REPO_THRIFT "${LOCAL_REPO}/thrift.git")
+else()
+    set(REPO_THRIFT "https://github.com/apache/thrift.git")
+endif()
+
+# Build and install Thrift
+ExternalProject_Add(thrift
+    GIT_REPOSITORY ${REPO_THRIFT}
+    GIT_TAG "v0.14.1"
+    SOURCE_DIR ${PROJ_ROOT}/lib/${POS_DEP_THRIFT}
+    BUILD_IN_SOURCE 1
+    LOG_DOWNLOAD ON
+    LOG_CONFIGURE ON
+    LOG_BUILD ON
+    LOG_INSTALL ON
+    CONFIGURE_COMMAND cmake -G Ninja . -DBUILD_COMPILER=OFF -DBUILD_CPP=ON -DBUILD_LIBRARIES=ON -DBUILD_NODEJS=OFF -DBUILD_PYTHON=OFF -DBUILD_JAVASCRIPT=OFF -DBUILD_C_GLIB=OFF -DBUILD_JAVA=OFF -DBUILD_TESTING=OFF -DBUILD_TUTORIALS=OFF -DWITH_STDTHREADS=ON -DWITH_BOOSTTHREADS=OFF -DWITH_BOOST_FUNCTIONAL=OFF -DWITH_BOOST_SMART_PTR=OFF -DCMAKE_INSTALL_PREFIX=${PROJ_ROOT}/lib/${POS_DEP_THRIFT} -DCMAKE_PREFIX_PATH=${PROJ_ROOT}/lib/${POS_DEP_THRIFT} .
+    BUILD_COMMAND ninja -j ${NUM_BUILD_CORE}
+    INSTALL_COMMAND ninja install
+)
+
 # Set opentelemetry-cpp build options
 set(POS_DEP_OTEL "opentelemetry-cpp")
 if (${USE_LOCAL_REPO} STREQUAL "y")
@@ -321,7 +344,7 @@ ExternalProject_Add(opentelemetry-cpp
     LOG_CONFIGURE ON
     LOG_BUILD ON
     LOG_INSTALL ON
-    CONFIGURE_COMMAND cmake ${PROJ_ROOT}/lib/${POS_DEP_OTEL} -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX:PATH=${PROJ_ROOT}/lib/${POS_DEP_OTEL}
+    CONFIGURE_COMMAND cmake ${PROJ_ROOT}/lib/${POS_DEP_OTEL} -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX:PATH=${PROJ_ROOT}/lib/${POS_DEP_OTEL} -DWITH_JAEGER=on
     BUILD_COMMAND make -j ${NUM_BUILD_CORE} all
     INSTALL_COMMAND make install
 )
@@ -374,6 +397,12 @@ add_custom_target(
 )
 
 add_custom_target(
+    clean_thrift
+    WORKING_DIRECTORY ${PROJ_ROOT}/lib/${POS_DEP_THRIFT}
+    COMMAND rm -rf lib/*.a
+)
+
+add_custom_target(
     clean_opentelemetry-cpp
     WORKING_DIRECTORY ${PROJ_ROOT}/lib/${POS_DEP_OTEL}
     COMMAND make clean
@@ -407,6 +436,10 @@ endif()
 
 if(EXISTS ${PROJ_ROOT}/lib/${POS_DEP_GTEST}/libgtest.a)
     list(APPEND CLEAN_ALL_TARGETS clean_gtest)
+endif()
+
+if(EXISTS ${PROJ_ROOT}/lib/${POS_DEP_THRIFT})
+    list(APPEND CLEAN_ALL_TARGETS clean_thrift)
 endif()
 
 if(EXISTS ${PROJ_ROOT}/lib/${POS_DEP_OTEL}/Makefile)

--- a/script/pkgdep.sh
+++ b/script/pkgdep.sh
@@ -70,12 +70,6 @@ if [ -f /etc/debian_version ]; then
     apt install -y libgoogle-perftools-dev
     # for rocksdb
     apt install -y librocksdb-dev
-    # for jaeger (in opentelemetry)
-    apt install -y --no-install-recommends \
-      libboost-locale-dev \
-      libevent-dev \
-      libssl-dev \
-      ninja-build
 
 else
     echo "pkgdep: unknown system type."

--- a/script/pkgdep.sh
+++ b/script/pkgdep.sh
@@ -70,7 +70,12 @@ if [ -f /etc/debian_version ]; then
     apt install -y libgoogle-perftools-dev
     # for rocksdb
     apt install -y librocksdb-dev
-
+    # for jaeger (in opentelemetry)
+    apt install -y --no-install-recommends \
+      libboost-locale-dev \
+      libevent-dev \
+      libssl-dev \
+      ninja-build
 
 else
     echo "pkgdep: unknown system type."


### PR DESCRIPTION
opentelemetry에서 jaeger-exporter를 이용할 수 있도록 함 (Makefile)
 * jaeger-exporter에 dependency가 있는 thrift library를 설치를 build_lib 과정에 포함 (lib/CMakeLists.txt)
 * thrift library의 pakcage dependency 추가 (script/pkgdep.sh)