### PR TITLE
[AWIBOF-6799] Set CLI request timeout to 180 seconds

### DIFF
--- a/tool/cli/cmd/grpcmgr/grpcmgr.go
+++ b/tool/cli/cmd/grpcmgr/grpcmgr.go
@@ -15,7 +15,7 @@ import (
 
 const dialErrorMsg = "Could not connect to the CLI server. Is PoseidonOS running?"
 const dialTimeout = 10
-const reqTimeout = 90
+const reqTimeout = 180
 
 func dialToCliServer() (*grpc.ClientConn, error) {
 	nodeName := globals.NodeName


### PR DESCRIPTION
Increase the CLI request timeout from 90 seconds to 180 seconds
as some commands take longer than 90 seconds.

TODO: the timeout value is arbitrarily set. We need a systemical
approach to decided the value.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>