### PR TITLE
[AWIBOF-5045] Add default io_unit_size for transport creation

### DIFF
--- a/src/cli/command_processor.cpp
+++ b/src/cli/command_processor.cpp
@@ -9,6 +9,7 @@
 #include "src/array/array.h"
 #include "src/cli/request_handler.h"
 #include "src/cli/cli_server.h"
+#include "src/include/nvmf_const.h"
 #include "src/logger/logger.h"
 #include "src/mbr/mbr_info.h"
 #include "src/master_context/version_provider.h"
@@ -1480,16 +1481,16 @@ grpc::Status
 CommandProcessor::ExecuteCreateTransportCommand(const CreateTransportRequest* request, CreateTransportResponse* reply)
 {
     string DEFAULT_TRTYPE = "tcp";
-    uint32_t DEFAULT_BUF_CACHE_SIZE = 64;
-    uint32_t DEFAULT_NUM_SHARED_BUF = 4096;
 
     string command = request->command();
     reply->set_command(command);
     reply->set_rid(request->rid());
 
     string trType = DEFAULT_TRTYPE;
-    int32_t bufCacheSize = DEFAULT_BUF_CACHE_SIZE;
-    int32_t numSharedBuf = DEFAULT_NUM_SHARED_BUF; 
+    uint32_t bufCacheSize = DEFAULT_BUF_CACHE_SIZE;
+    uint32_t numSharedBuf = DEFAULT_NUM_SHARED_BUF;
+    uint32_t ioUnitSize = DEFAULT_IO_UNIT_SIZE;
+     
 
     trType = (request->param()).transporttype();
     bufCacheSize = (request->param()).bufcachesize();
@@ -1500,7 +1501,8 @@ CommandProcessor::ExecuteCreateTransportCommand(const CreateTransportRequest* re
     auto ret = rpcClient.TransportCreate(
         trType,
         bufCacheSize,
-        numSharedBuf);
+        numSharedBuf,
+        ioUnitSize);
 
     if (ret.first != SUCCESS)
     {

--- a/src/cli/create_transport_command.cpp
+++ b/src/cli/create_transport_command.cpp
@@ -37,6 +37,7 @@
 
 #include "src/cli/cli_event_code.h"
 #include "src/helper/rpc/spdk_rpc_client.h"
+#include "src/include/nvmf_const.h"
 
 namespace pos_cli
 {
@@ -76,7 +77,7 @@ CreateTransportCommand::_CreateTransport(json& doc)
     SpdkRpcClient rpcClient;
     string trtype = doc["param"]["transport_type"].get<string>();
 
-    _SetDefaultConfig(trtype);
+    _SetDefaultConfig();
 
     if (doc["param"].contains("buf_cache_size"))
     {
@@ -90,7 +91,8 @@ CreateTransportCommand::_CreateTransport(json& doc)
     auto ret = rpcClient.TransportCreate(
         trtype,
         bufCacheSize,
-        numSharedBuf);
+        numSharedBuf,
+        ioUnitSize);
     if (ret.first != SUCCESS)
     {
         errorMessage = "Failed to create transport. " + ret.second;
@@ -99,13 +101,10 @@ CreateTransportCommand::_CreateTransport(json& doc)
 }
 
 void
-CreateTransportCommand::_SetDefaultConfig(string trtype)
+CreateTransportCommand::_SetDefaultConfig()
 {
-    std::transform(trtype.begin(), trtype.end(), trtype.begin(), ::tolower);
-    if ("tcp" == trtype)
-    {
-        bufCacheSize = DEFAULT_BUF_CACHE_SIZE;
-        numSharedBuf = DEFAULT_NUM_SHARED_BUF;
-    }
+    bufCacheSize = DEFAULT_BUF_CACHE_SIZE;
+    numSharedBuf = DEFAULT_NUM_SHARED_BUF;
+    ioUnitSize = DEFAULT_IO_UNIT_SIZE;
 }
 } // namespace pos_cli

--- a/src/cli/create_transport_command.h
+++ b/src/cli/create_transport_command.h
@@ -47,11 +47,10 @@ public:
 
 private:
     int _CreateTransport(json& doc);
-    void _SetDefaultConfig(string trtype);
-    uint32_t DEFAULT_BUF_CACHE_SIZE = 64;
-    uint32_t DEFAULT_NUM_SHARED_BUF = 4096;
+    void _SetDefaultConfig();
     uint32_t bufCacheSize = 0;
     uint32_t numSharedBuf = 0;
+    uint32_t ioUnitSize = 0;
     string errorMessage;
 };
 }; // namespace pos_cli

--- a/src/helper/rpc/spdk_rpc_client.cpp
+++ b/src/helper/rpc/spdk_rpc_client.cpp
@@ -197,7 +197,7 @@ SpdkRpcClient::SubsystemList(void)
 }
 
 pair<int, std::string>
-SpdkRpcClient::TransportCreate(std::string trtype, uint32_t bufCacheSize, uint32_t numSharedBuf)
+SpdkRpcClient::TransportCreate(std::string trtype, uint32_t bufCacheSize, uint32_t numSharedBuf, uint32_t ioUnitSize)
 {
     const int SUCCESS = 0;
     const string method = "nvmf_create_transport";
@@ -205,27 +205,25 @@ SpdkRpcClient::TransportCreate(std::string trtype, uint32_t bufCacheSize, uint32
     Json::Value param;
     param["trtype"] = trtype;
 
-    std::for_each(trtype.begin(), trtype.end(), [](char & c)
+    std::for_each(trtype.begin(), trtype.end(), [](char& c)
     {
         c = tolower(c);
     });
 
-    if ("tcp" == trtype)
+    uint32_t coreCount = spdkEnvCaller->SpdkEnvGetCoreCount();
+    uint32_t minSharedBuffers = coreCount * bufCacheSize;
+    if (minSharedBuffers > numSharedBuf)
     {
-        uint32_t coreCount = spdkEnvCaller->SpdkEnvGetCoreCount();
-        uint32_t minSharedBuffers = coreCount * bufCacheSize;
-        if (minSharedBuffers > numSharedBuf)
-        {
-            POS_EVENT_ID eventId =
-                POS_EVENT_ID::IONVMF_TRANSPORT_NUM_SHARED_BUFFER_CHANGED;
-            POS_TRACE_INFO(static_cast<int>(eventId),
-            "Transport's num_shared_buffer size has changed from {} to {} due to reactor core number of system",
-            numSharedBuf, minSharedBuffers);
-            numSharedBuf = minSharedBuffers;
-        }
-        param["buf_cache_size"] = bufCacheSize;
-        param["num_shared_buffers"] = numSharedBuf;
+        POS_EVENT_ID eventId =
+            POS_EVENT_ID::IONVMF_TRANSPORT_NUM_SHARED_BUFFER_CHANGED;
+        POS_TRACE_INFO(static_cast<int>(eventId),
+        "Transport's num_shared_buffer size has changed from {} to {} due to reactor core number of system",
+        numSharedBuf, minSharedBuffers);
+        numSharedBuf = minSharedBuffers;
     }
+    param["buf_cache_size"] = bufCacheSize;
+    param["num_shared_buffers"] = numSharedBuf;
+    param["io_unit_size"] = ioUnitSize;
 
     try
     {

--- a/src/helper/rpc/spdk_rpc_client.h
+++ b/src/helper/rpc/spdk_rpc_client.h
@@ -53,7 +53,7 @@ public:
     std::pair<int, std::string> SubsystemDelete(std::string subnqn);
     std::pair<int, std::string> SubsystemAddListener(std::string subnqn, std::string trtype, std::string adrfam, std::string traddr, std::string trsvcid);
     Json::Value SubsystemList(void);
-    virtual std::pair<int, std::string> TransportCreate(std::string trtype, uint32_t bufCacheSize, uint32_t numSharedBuf);
+    virtual std::pair<int, std::string> TransportCreate(std::string trtype, uint32_t bufCacheSize, uint32_t numSharedBuf, uint32_t ioUnitSize);
 
 private:
     void _SetClient(void);

--- a/src/include/nvmf_const.h
+++ b/src/include/nvmf_const.h
@@ -40,4 +40,8 @@ static const uint64_t NS_CREATE_TIMEOUT = 15000000000ULL;
 static const uint64_t NS_DELETE_TIMEOUT = 15000000000ULL;
 static const uint64_t NS_ATTACH_TIMEOUT = 15000000000ULL;
 static const uint64_t NS_DETACH_TIMEOUT = 15000000000ULL;
+    
+static const uint32_t DEFAULT_BUF_CACHE_SIZE = 64;
+static const uint32_t DEFAULT_NUM_SHARED_BUF = 4096;
+static const uint32_t DEFAULT_IO_UNIT_SIZE = 131072;
 } // namespace pos

--- a/src/network/nvmf.cpp
+++ b/src/network/nvmf.cpp
@@ -222,7 +222,7 @@ Nvmf::VolumeLoaded(VolumeEventBase* volEventBase, VolumeEventPerf* volEventPerf,
         if (false == ret)
         {
             int rid = EID(VOL_NOT_FOUND);
-            POS_TRACE_WARN(rid, "Volume {} does not exist. Unable to load, start creating new volume.", vInfo->name);
+            POS_TRACE_INFO(rid, "Volume {} does not exist. Start creating volume again with the same volume info.", vInfo->name);
             ret = volume->VolumeCreated(vInfo);
         }
         delete vInfo;

--- a/src/network/transport_configuration.cpp
+++ b/src/network/transport_configuration.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <string>
 
+#include "src/include/nvmf_const.h"
 #include "src/include/pos_event_id.hpp"
 #include "src/logger/logger.h"
 
@@ -48,7 +49,8 @@ TransportConfiguration::TransportConfiguration(ConfigManager* configManager, Spd
 : configManager(configManager),
   trtype(DEFAULT_TRANSPORT_TYPE),
   bufCacheSize(DEFAULT_BUF_CACHE_SIZE),
-  numSharedBuf(DEFAULT_NUM_SHARED_BUFFER),
+  numSharedBuf(DEFAULT_NUM_SHARED_BUF),
+  ioUnitSize(DEFAULT_IO_UNIT_SIZE),
   rpcClient(inputRpcClient)
 {
     if (nullptr == rpcClient)
@@ -103,7 +105,7 @@ TransportConfiguration::CreateTransport(void)
     ReadConfig();
 
     std::transform(trtype.begin(), trtype.end(), trtype.begin(), ::tolower);
-    auto result = rpcClient->TransportCreate(trtype, bufCacheSize, numSharedBuf);
+    auto result = rpcClient->TransportCreate(trtype, bufCacheSize, numSharedBuf, ioUnitSize);
     if (result.first != 0)
     {
         POS_EVENT_ID eventId = POS_EVENT_ID::IONVMF_FAIL_TO_CREATE_TRANSPORT;

--- a/src/network/transport_configuration.h
+++ b/src/network/transport_configuration.h
@@ -49,13 +49,12 @@ public:
     virtual void CreateTransport(void);
 
 private:
-    uint32_t const DEFAULT_NUM_SHARED_BUFFER = 4096;
-    uint32_t const DEFAULT_BUF_CACHE_SIZE = 64;
     std::string const DEFAULT_TRANSPORT_TYPE = "tcp";
     ConfigManager* configManager;
     std::string trtype = "";
     uint32_t bufCacheSize = 0;
     uint32_t numSharedBuf = 0;
+    uint32_t ioUnitSize = 0;
     SpdkRpcClient* rpcClient;
     bool _IsEnabled(void);
 };

--- a/test/unit-tests/helper/spdk_rpc_client_mock.h
+++ b/test/unit-tests/helper/spdk_rpc_client_mock.h
@@ -45,7 +45,7 @@ class MockSpdkRpcClient : public SpdkRpcClient
 {
 public:
     using SpdkRpcClient::SpdkRpcClient;
-    MOCK_METHOD((std::pair<int, std::string>), TransportCreate, (std::string trtype, uint32_t bufCacheSize, uint32_t numSharedBuf), (override));
+    MOCK_METHOD((std::pair<int, std::string>), TransportCreate, (std::string trtype, uint32_t bufCacheSize, uint32_t numSharedBuf, uint32_t ioUnitSize), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/network/transport_configuration_test.cpp
+++ b/test/unit-tests/network/transport_configuration_test.cpp
@@ -147,7 +147,7 @@ TEST_F(TransportConfigurationFixture, CreateTransport_Success)
         *targetToChange = true;
         return SUCCESS;
     }).WillRepeatedly(Return(SUCCESS));
-    EXPECT_CALL(*mockSpdkRpcClient, TransportCreate(_, _, _)).WillOnce(Return(value));
+    EXPECT_CALL(*mockSpdkRpcClient, TransportCreate(_, _, _, _)).WillOnce(Return(value));
 
     TransportConfiguration transportConfiguration(&mockConfigManager, mockSpdkRpcClient);
     transportConfiguration.CreateTransport();
@@ -171,7 +171,7 @@ TEST_F(TransportConfigurationFixture, CreateTransport_CreateTransport_Fail)
         *targetToChange = true;
         return SUCCESS;
     }).WillRepeatedly(Return(SUCCESS));
-    EXPECT_CALL(*mockSpdkRpcClient, TransportCreate(_, _, _)).WillOnce(Return(value));
+    EXPECT_CALL(*mockSpdkRpcClient, TransportCreate(_, _, _, _)).WillOnce(Return(value));
 
     TransportConfiguration transportConfiguration(&mockConfigManager, mockSpdkRpcClient);
     transportConfiguration.CreateTransport();


### PR DESCRIPTION
transport 생성 시 io unit size를 pos 에서 원하는 디폴트 값으로 설정하여 생성되도록 수정한 내용입니다. 
전에 한 번 리뷰를 받았던 내용인데 main에 누락되어서 다시 올립니다.
Signed-off-by: syeon.shin <syeon.shin@samsung.com>