### PR TITLE
[AWIBOF-6845] added lock for versioned segment info.

### DIFF
--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -143,7 +143,7 @@ VersionedSegmentCtx::_UpdateSegmentContext(int logGroupId)
     _CheckLogGroupIdValidity(logGroupId);
 
     shared_ptr<VersionedSegmentInfo> targetSegInfo = segmentInfoDiffs[logGroupId];
-    std::unordered_map<SegmentId, int> changedValidBlkCount = targetSegInfo->GetChangedValidBlockCount();
+    tbb::concurrent_unordered_map<SegmentId, int> changedValidBlkCount = targetSegInfo->GetChangedValidBlockCount();
     for (auto it = changedValidBlkCount.begin(); it != changedValidBlkCount.end(); it++)
     {
         auto segmentId = it->first;
@@ -152,7 +152,7 @@ VersionedSegmentCtx::_UpdateSegmentContext(int logGroupId)
         segmentInfos[segmentId].SetValidBlockCount(segmentInfos[segmentId].GetValidBlockCount() + validBlockCountDiff);
     }
 
-    std::unordered_map<uint32_t, uint32_t> changedOccupiedCount = targetSegInfo->GetChangedOccupiedStripeCount();
+    tbb::concurrent_unordered_map<SegmentId, uint32_t> changedOccupiedCount = targetSegInfo->GetChangedOccupiedStripeCount();
     for (auto it = changedOccupiedCount.begin(); it != changedOccupiedCount.end(); it++)
     {
         auto segmentId = it->first;

--- a/src/journal_manager/log_buffer/versioned_segment_info.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_info.cpp
@@ -32,8 +32,6 @@
 
 #include "versioned_segment_info.h"
 
-#include <unordered_map>
-
 namespace pos
 {
 VersionedSegmentInfo::VersionedSegmentInfo(void)
@@ -42,8 +40,7 @@ VersionedSegmentInfo::VersionedSegmentInfo(void)
 
 VersionedSegmentInfo::~VersionedSegmentInfo(void)
 {
-    changedValidBlockCount.clear();
-    changedOccupiedStripeCount.clear();
+    Reset();
 }
 
 void
@@ -71,13 +68,13 @@ VersionedSegmentInfo::IncreaseOccupiedStripeCount(SegmentId segId)
     changedOccupiedStripeCount[segId]++;
 }
 
-std::unordered_map<SegmentId, int>
+tbb::concurrent_unordered_map<SegmentId, int>
 VersionedSegmentInfo::GetChangedValidBlockCount(void)
 {
     return this->changedValidBlockCount;
 }
 
-std::unordered_map<SegmentId, uint32_t>
+tbb::concurrent_unordered_map<SegmentId, uint32_t>
 VersionedSegmentInfo::GetChangedOccupiedStripeCount(void)
 {
     return this->changedOccupiedStripeCount;

--- a/src/journal_manager/log_buffer/versioned_segment_info.h
+++ b/src/journal_manager/log_buffer/versioned_segment_info.h
@@ -33,9 +33,8 @@
 #pragma once
 
 #include <atomic>
-#include <unordered_map>
-
 #include "src/include/address_type.h"
+#include "tbb/concurrent_unordered_map.h"
 
 namespace pos
 {
@@ -50,12 +49,12 @@ public:
     virtual void DecreaseValidBlockCount(SegmentId segId, uint32_t cnt);
     virtual void IncreaseOccupiedStripeCount(SegmentId segId);
 
-    virtual std::unordered_map<SegmentId, int> GetChangedValidBlockCount(void);
-    virtual std::unordered_map<SegmentId, uint32_t> GetChangedOccupiedStripeCount(void);
+    virtual tbb::concurrent_unordered_map<SegmentId, int> GetChangedValidBlockCount(void);
+    virtual tbb::concurrent_unordered_map<SegmentId, uint32_t> GetChangedOccupiedStripeCount(void);
 
 private:
-    std::unordered_map<SegmentId, int> changedValidBlockCount;
-    std::unordered_map<SegmentId, uint32_t> changedOccupiedStripeCount;
+    tbb::concurrent_unordered_map<SegmentId, int> changedValidBlockCount;
+    tbb::concurrent_unordered_map<SegmentId, uint32_t> changedOccupiedStripeCount;
 };
 
 } // namespace pos

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_test.cpp
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_test.cpp
@@ -164,17 +164,19 @@ TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfChangedValueIsReturned)
     // When
     int targetLogGroup = 0;
 
-    std::unordered_map<SegmentId, int> changedValidBlkCount;
+    tbb::concurrent_unordered_map<SegmentId, int> changedValidBlkCount;
     changedValidBlkCount.emplace(0, 10);
     changedValidBlkCount.emplace(1, 2);
     changedValidBlkCount.emplace(2, 40);
-    EXPECT_CALL(*std::static_pointer_cast<MockVersionedSegmentInfo>(versionedSegmentInfo[targetLogGroup]), GetChangedValidBlockCount).WillOnce(Return(changedValidBlkCount));
+    EXPECT_CALL(*std::static_pointer_cast<MockVersionedSegmentInfo>(versionedSegmentInfo[targetLogGroup]),
+        GetChangedValidBlockCount).WillOnce(Return(changedValidBlkCount));
 
-    std::unordered_map<SegmentId, uint32_t> changedOccupiedStripeCount;
+    tbb::concurrent_unordered_map<SegmentId, uint32_t> changedOccupiedStripeCount;
     changedOccupiedStripeCount.emplace(0, 1);
     changedOccupiedStripeCount.emplace(1, 1);
     changedOccupiedStripeCount.emplace(2, 0);
-    EXPECT_CALL(*std::static_pointer_cast<MockVersionedSegmentInfo>(versionedSegmentInfo[targetLogGroup]), GetChangedOccupiedStripeCount).WillOnce(Return(changedOccupiedStripeCount));
+    EXPECT_CALL(*std::static_pointer_cast<MockVersionedSegmentInfo>(versionedSegmentInfo[targetLogGroup]),
+        GetChangedOccupiedStripeCount).WillOnce(Return(changedOccupiedStripeCount));
 
     SegmentInfo* result = versionedSegCtx.GetUpdatedInfoToFlush(targetLogGroup);
 
@@ -218,13 +220,13 @@ TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfChangedValueIsApplied)
 
     // When
     int targetLogGroup = 0;
-    std::unordered_map<SegmentId, int> changedValidBlkCount;
+    tbb::concurrent_unordered_map<SegmentId, int> changedValidBlkCount;
     changedValidBlkCount.emplace(0, -5);
     changedValidBlkCount.emplace(1, 2);
     changedValidBlkCount.emplace(2, 40);
     EXPECT_CALL(*std::static_pointer_cast<MockVersionedSegmentInfo>(versionedSegmentInfo[targetLogGroup]), GetChangedValidBlockCount).WillOnce(Return(changedValidBlkCount));
 
-    std::unordered_map<SegmentId, uint32_t> changedOccupiedStripeCount;
+    tbb::concurrent_unordered_map<SegmentId, uint32_t> changedOccupiedStripeCount;
     changedOccupiedStripeCount.emplace(0, 2);
     changedOccupiedStripeCount.emplace(1, 1);
     changedOccupiedStripeCount.emplace(2, 0);
@@ -319,11 +321,13 @@ TEST(VersionedSegmentCtx, ResetFlushedInfo_testIfInfoIsResetted)
     versionedSegCtx.Init(&config, segmentInfos, 3, versionedSegmentInfo);
 
     int targetLogGroup = 0;
-    std::unordered_map<SegmentId, int> changedValidBlkCount;
-    EXPECT_CALL(*std::static_pointer_cast<MockVersionedSegmentInfo>(versionedSegmentInfo[targetLogGroup]), GetChangedValidBlockCount).WillOnce(Return(changedValidBlkCount));
+    tbb::concurrent_unordered_map<SegmentId, int> changedValidBlkCount;
+    EXPECT_CALL(*std::static_pointer_cast<MockVersionedSegmentInfo>(versionedSegmentInfo[targetLogGroup]),
+        GetChangedValidBlockCount).WillOnce(Return(changedValidBlkCount));
 
-    std::unordered_map<SegmentId, uint32_t> changedOccupiedStripeCount;
-    EXPECT_CALL(*std::static_pointer_cast<MockVersionedSegmentInfo>(versionedSegmentInfo[targetLogGroup]), GetChangedOccupiedStripeCount).WillOnce(Return(changedOccupiedStripeCount));
+    tbb::concurrent_unordered_map<SegmentId, uint32_t> changedOccupiedStripeCount;
+    EXPECT_CALL(*std::static_pointer_cast<MockVersionedSegmentInfo>(versionedSegmentInfo[targetLogGroup]),
+        GetChangedOccupiedStripeCount).WillOnce(Return(changedOccupiedStripeCount));
 
     SegmentInfo* result = versionedSegCtx.GetUpdatedInfoToFlush(targetLogGroup);
 

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_info_mock.h
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_info_mock.h
@@ -34,7 +34,7 @@
 
 #include <list>
 #include <string>
-#include <unordered_map>
+#include "tbb/concurrent_unordered_map.h"
 #include <vector>
 
 #include "src/journal_manager/log_buffer/versioned_segment_info.h"
@@ -49,8 +49,8 @@ public:
     MOCK_METHOD(void, IncreaseValidBlockCount, (SegmentId segId, uint32_t cnt), (override));
     MOCK_METHOD(void, DecreaseValidBlockCount, (SegmentId segId, uint32_t cnt), (override));
     MOCK_METHOD(void, IncreaseOccupiedStripeCount, (SegmentId segId), (override));
-    MOCK_METHOD((std::unordered_map<SegmentId, int>), GetChangedValidBlockCount, (), (override));
-    MOCK_METHOD((std::unordered_map<SegmentId, uint32_t>), GetChangedOccupiedStripeCount, (), (override));
+    MOCK_METHOD((tbb::concurrent_unordered_map<SegmentId, int>), GetChangedValidBlockCount, (), (override));
+    MOCK_METHOD((tbb::concurrent_unordered_map<SegmentId, uint32_t>), GetChangedOccupiedStripeCount, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_info_test.cpp
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_info_test.cpp
@@ -31,7 +31,7 @@
  */
 
 #include "src/journal_manager/log_buffer/versioned_segment_info.h"
-
+#include "tbb/concurrent_unordered_map.h"
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -52,11 +52,14 @@ TEST(VersionedSegmentInfo, IncreaseValidBlockCount_testIfValidBlockCountIsIncrea
     versionedSegInfo.IncreaseValidBlockCount(1, 4);
 
     // Then
-    std::unordered_map<uint32_t, int> expectChangedValidCount;
+    tbb::concurrent_unordered_map<SegmentId, int> expectChangedValidCount;
     expectChangedValidCount[2] = 2;
     expectChangedValidCount[1] = 4;
 
-    EXPECT_EQ(expectChangedValidCount, versionedSegInfo.GetChangedValidBlockCount());
+    auto var = versionedSegInfo.GetChangedValidBlockCount();
+
+    EXPECT_EQ(expectChangedValidCount[1], var[1]);
+    EXPECT_EQ(expectChangedValidCount[2], var[2]);
 
     // When
     versionedSegInfo.Reset();
@@ -71,7 +74,7 @@ TEST(VersionedSegmentInfo, IncreaseOccupiedStripeCount_testIfOccupiedStripeCount
     VersionedSegmentInfo versionedSegInfo;
 
     // When
-    std::unordered_map<uint32_t, uint32_t> expectChangedOccupiedCount;
+    tbb::concurrent_unordered_map<SegmentId, uint32_t> expectChangedOccupiedCount;
     SegmentId targetSegment = 3;
     int increasedOccupiedCount = 5;
     for (int index = 0; index < increasedOccupiedCount; index++)
@@ -89,7 +92,10 @@ TEST(VersionedSegmentInfo, IncreaseOccupiedStripeCount_testIfOccupiedStripeCount
     }
 
     // Then
-    EXPECT_EQ(expectChangedOccupiedCount, versionedSegInfo.GetChangedOccupiedStripeCount());
+    auto var = versionedSegInfo.GetChangedOccupiedStripeCount();
+
+    EXPECT_EQ(expectChangedOccupiedCount[3], var[3]);
+    EXPECT_EQ(expectChangedOccupiedCount[2], var[2]);
 
     // When
     versionedSegInfo.Reset();


### PR DESCRIPTION
Code changes:
added lock before reset, get values from versioned segment info.

Signed-off-by: dh.ihm <dh.ihm@samsung.com>