### PR TITLE
[AWIBOF-6878] fix a deadlock issue while attaching device

### DIFF
--- a/src/device/device_manager.cpp
+++ b/src/device/device_manager.cpp
@@ -423,12 +423,19 @@ DeviceManager::GetNvmeCtrlr(std::string& deviceName)
 void
 DeviceManager::AttachDevice(UblockSharedPtr dev)
 {
-    std::lock_guard<std::recursive_mutex> guard(deviceManagerMutex);
-    if (_CheckDuplication(dev) == true)
+    bool isNew = false;
     {
-        _PrepareDevice(dev);
+        std::lock_guard<std::recursive_mutex> guard(deviceManagerMutex);
+        if (_CheckDuplication(dev) == true)
+        {
+            _PrepareDevice(dev);
+            devices.push_back(dev);
+            isNew = true;
+        }
+    }
+    if (isNew == true)
+    {
         deviceEvent->DeviceAttached(dev);
-        devices.push_back(dev);
         POS_TRACE_TRACE(EID(POS_TRACE_DEVICE_ATTACHED),
             "device_name:{}, device_mn:{}, device_sn:{}",
             dev->GetName(), dev->GetMN(), dev->GetSN());


### PR DESCRIPTION
fix a deadlock issue while attaching device
attached device에 대한 mbr update가 실패할 시 deadlock발생