### PR TITLE
[AWIBOF-6870] Add Intel ISA-L library to POS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,7 @@ LDFLAGS += -lyaml-cpp
 LDFLAGS += -ltbb
 LDFLAGS += -lrocksdb
 LDFLAGS += -lstdc++fs
+LDFLAGS += -lisal
 
 CLI_CERT_DIR = /etc/pos/cert
 CLI_DIR = $(TOP)/tool/cli

--- a/package/src/DEBIAN/control
+++ b/package/src/DEBIAN/control
@@ -3,4 +3,4 @@ Version: 0.11.0-rc6-+
 Maintainer: PoseidonOS Packaging <packaging@poseidonos.com>
 Description: PoseidonOS
 Architecture: amd64
-Depends: libibverbs-dev (>= 17.1-1ubuntu0.2), librdmacm-dev (>= 17.1-1ubuntu0.2), libjsonrpccpp-dev (>= 0.7.0-1build2), libjsoncpp-dev (>= 1.7.4-3), libyaml-cpp-dev (>= 0.5.2-4ubuntu1), libtbb-dev (>= 2017~U7-8), libc-ares-dev (>= 1.14.0-1ubuntu0.1), libaio1 (>= 0.3.110-5ubuntu0.1), mandoc (>= 1.14.3-3), libgoogle-perftools-dev (>= 2.5-2.2ubuntu3), librocksdb-dev (>= 5.8.8-1), prometheus (>= 2.1.0+ds-1), prometheus-node-exporter (>= 0.15.2+ds-1)
+Depends: libibverbs-dev (>= 17.1-1ubuntu0.2), librdmacm-dev (>= 17.1-1ubuntu0.2), libjsonrpccpp-dev (>= 0.7.0-1build2), libjsoncpp-dev (>= 1.7.4-3), libyaml-cpp-dev (>= 0.5.2-4ubuntu1), libtbb-dev (>= 2017~U7-8), libc-ares-dev (>= 1.14.0-1ubuntu0.1), libaio1 (>= 0.3.110-5ubuntu0.1), mandoc (>= 1.14.3-3), libgoogle-perftools-dev (>= 2.5-2.2ubuntu3), librocksdb-dev (>= 5.8.8-1), prometheus (>= 2.1.0+ds-1), prometheus-node-exporter (>= 0.15.2+ds-1), libisal-dev (>=2.21.0-1)

--- a/script/pkgdep.sh
+++ b/script/pkgdep.sh
@@ -72,10 +72,11 @@ if [ -f /etc/debian_version ]; then
     # for rocksdb
     apt install -y librocksdb-dev
     # for markdownTable
-
     pip3 install py-markdown-table
     # for pyyaml
     pip3 install pyyaml
+    # for isal
+    apt install -y libisal-dev
 
 else
     echo "pkgdep: unknown system type."

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -455,6 +455,7 @@ SET(DEP_LIBRARIES
     pmem
     rocksdb
     stdc++fs
+    isal
 )
 
 find_package(PkgConfig REQUIRED)


### PR DESCRIPTION
Add Intel ISA-L library to POS. (https://github.com/intel/isa-l)

Add ISA-L packages to pkgdep.sh, Makefile, and package control file for RAID 6 support.

Signed-off-by: Junghyun Hong <jh34.hong@samsung.com>