### PR TITLE
[AWIBOF-6773] Copy pos_event.yaml for unit testing

### DIFF
--- a/.github/workflows/script/unit/ut_build_run_unittest.sh
+++ b/.github/workflows/script/unit/ut_build_run_unittest.sh
@@ -23,7 +23,7 @@ if [ $retVal -ne 0 ]; then
 fi
 
 echo "Building test files..."
-cd ${pos_working_dir}/test/; sudo make -j 8
+cd ${pos_working_dir}/test/; sudo make -j 12
 retVal=$?
 if [ $retVal -ne 0 ]; then
     echo "Cannot proceed due to UT build error."

--- a/.github/workflows/script/unit/ut_build_run_unittest.sh
+++ b/.github/workflows/script/unit/ut_build_run_unittest.sh
@@ -11,6 +11,9 @@ pwd
 echo "Install library"
 cd ${pos_working_dir}/lib/; sudo ./build_lib.sh
 
+echo "Copying event file..."
+sudo cp ${pos_working_dir}/src/event/pos_event.yaml /etc/pos/pos_event.yaml
+
 echo "Running cmake..."
 cd ${pos_working_dir}/test/; sudo cmake . 
 retVal=$?
@@ -20,7 +23,7 @@ if [ $retVal -ne 0 ]; then
 fi
 
 echo "Building test files..."
-cd ${pos_working_dir}/test/; sudo make -j 12
+cd ${pos_working_dir}/test/; sudo make -j 8
 retVal=$?
 if [ $retVal -ne 0 ]; then
     echo "Cannot proceed due to UT build error."


### PR DESCRIPTION
Copy pos_event.yaml to the pos_conf directory for unit testing.

Previously, unit testing failed because pos_event.yaml was not copied
to the config directory. It was because unit testing script
did not execute $make install, which copies pos_event.yaml to the config
directory.

To fix the problem, this commit adds a copy command to the unit testing
script for github action.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>