### PR TITLE
[AWIBOF-6897] Add Galois field calculation functions for one device error case

### DIFF
--- a/src/array/ft/raid6.h
+++ b/src/array/ft/raid6.h
@@ -40,6 +40,8 @@
 #include <list>
 #include <vector>
 #include <map>
+#include <mutex>
+
 namespace pos
 {
 class PartitionPhysicalSize;
@@ -82,7 +84,9 @@ private:
     unsigned char* g_tbls = nullptr;
     map<uint32_t, unsigned char*> g_tbls_map;
     void _MakeEncodingGFTable();
-    void _MakeRebuildGFTable();
+    void _DecodeData(void* dst, void* src, uint32_t key, uint32_t dstSize, uint32_t destCnt, vector<uint32_t> targetIndex);
+    void _DecodeData(void* dst, void* src, uint32_t dstSize, vector<uint32_t> targets, vector<uint32_t> excluded);
+    mutex rebuildMutex;
 };
 
 } // namespace pos

--- a/src/array/ft/raid6.h
+++ b/src/array/ft/raid6.h
@@ -39,6 +39,7 @@
 
 #include <list>
 #include <vector>
+#include <map>
 namespace pos
 {
 class PartitionPhysicalSize;
@@ -79,6 +80,9 @@ private:
     uint32_t parityCnt = 2;
     unsigned char* encode_matrix = nullptr;
     unsigned char* g_tbls = nullptr;
+    map<uint32_t, unsigned char*> g_tbls_map;
+    void _MakeEncodingGFTable();
+    void _MakeRebuildGFTable();
 };
 
 } // namespace pos

--- a/src/include/array_config.h
+++ b/src/include/array_config.h
@@ -65,6 +65,7 @@ public:
     static const uint32_t OVER_PROVISIONING_RATIO = 10;
     static const uint32_t REBUILD_STRIPES_UNIT = STRIPES_PER_SEGMENT;
     static const uint32_t REBUILD_CHUNK_SIZE_BYTE = BLOCKS_PER_CHUNK * BLOCK_SIZE_BYTE;
+    static const uint32_t MAX_CHUNK_CNT = 32;
 };
 
 } // namespace pos


### PR DESCRIPTION
Add _MakeRebuildGFTable function to RAID6 to make Galois field table in advance for one device error case.

Move dynamic allocations and ISA-L Galois field table calculations from rebuild to RAID6 constructor.

Signed-off-by: jh34.hong <jh34.hong@samsung.com>