### PR TITLE
[AWIBOF-6972] Add SETTELEMETRYPROPERTY command

### DIFF
--- a/doc/guides/cli/pos_railroad.html
+++ b/doc/guides/cli/pos_railroad.html
@@ -362,9 +362,12 @@ svg.railroad-diagram g.diagram-text:hover path.diagram-text {
   </header>
   <nav>
     
-    <h3>Root element:</h3>
+    <h3>Root elements:</h3>
     <ul class="nav-alphabetical">
     <li class="root-node"><a href="#Cmd">Cmd</a>
+        
+        
+      </li><li class="root-node"><a href="#TelemetrySetPropertyCmd">TelemetrySetPropertyCmd</a>
         
         
       </li>
@@ -589,9 +592,6 @@ svg.railroad-diagram g.diagram-text:hover path.diagram-text {
       </li><li><a href="#TargetNVMSubsystemNVMeQualifiedName">TargetNVMSubsystemNVMeQualifiedName</a>
         
         
-      </li><li><a href="#TelemetryCmd">TelemetryCmd</a>
-        <dfn title="recursive">♺</dfn>
-        
       </li><li><a href="#TelemetryStartCmd">TelemetryStartCmd</a>
         
         
@@ -645,6 +645,9 @@ svg.railroad-diagram g.diagram-text:hover path.diagram-text {
         
       </li><li class="common-node"><a href="#SubsystemNQN">SubsystemNQN</a>
         
+        
+      </li><li class="common-node"><a href="#TelemetryCmd">TelemetryCmd</a>
+        <dfn title="recursive">♺</dfn>
         
       </li><li class="common-node"><a href="#TransportType">TransportType</a>
         
@@ -762,7 +765,7 @@ svg.railroad-diagram g.diagram-text:hover path.diagram-text {
   <code class="ebnf"><span class="ebnf-identifier">Identifier</span> = <a class="ebnf-non-terminal" href="#Letter">Letter</a> , { <a class="ebnf-non-terminal" href="#Letter">Letter</a> | <a class="ebnf-non-terminal" href="#Digit">Digit</a> | <span class="ebnf-terminal">"-"</span> | <span class="ebnf-terminal">"_"</span> } <span class="ebnf-end">;</span></code>
   <p>Items referencing <strong>Identifier</strong>:<p>
 <ul>
-<li><a href="#ArrayName">ArrayName</a></li><li><a href="#DeviceName">DeviceName</a></li><li><a href="#VolumeName">VolumeName</a></li><li><a href="#TargetNVMSubsystemNVMeQualifiedName">TargetNVMSubsystemNVMeQualifiedName</a></li><li><a href="#TransportServiceId">TransportServiceId</a></li><li><a href="#TargetAddress">TargetAddress</a></li><li><a href="#SerialNumber">SerialNumber</a></li><li><a href="#ModelNumber">ModelNumber</a></li><li><a href="#TransportType">TransportType</a></li>
+<li><a href="#ArrayName">ArrayName</a></li><li><a href="#DeviceName">DeviceName</a></li><li><a href="#VolumeName">VolumeName</a></li><li><a href="#TargetNVMSubsystemNVMeQualifiedName">TargetNVMSubsystemNVMeQualifiedName</a></li><li><a href="#TransportServiceId">TransportServiceId</a></li><li><a href="#TargetAddress">TargetAddress</a></li><li><a href="#SerialNumber">SerialNumber</a></li><li><a href="#ModelNumber">ModelNumber</a></li><li><a href="#TransportType">TransportType</a></li><li><a href="#TelemetrySetPropertyCmd">TelemetrySetPropertyCmd</a></li>
 </ul>
   <p><strong>Identifier</strong> is referencing:<p>
 <ul>
@@ -1932,7 +1935,7 @@ svg.railroad-diagram g.diagram-text:hover path.diagram-text {
   <code class="ebnf"><span class="ebnf-identifier">TelemetryCmd</span> = <span class="ebnf-terminal">"telemetry"</span> , ( <a class="ebnf-non-terminal" href="#TelemetryStartCmd">TelemetryStartCmd</a> | <a class="ebnf-non-terminal" href="#TelemetryStopCmd">TelemetryStopCmd</a> ) <span class="ebnf-end">;</span></code>
   <p>Items referencing <strong>TelemetryCmd</strong>:<p>
 <ul>
-<li><a href="#Cmd">Cmd</a></li><li><a href="#TelemetryStartCmd">TelemetryStartCmd</a></li><li><a href="#TelemetryStopCmd">TelemetryStopCmd</a></li>
+<li><a href="#Cmd">Cmd</a></li><li><a href="#TelemetryStartCmd">TelemetryStartCmd</a></li><li><a href="#TelemetryStopCmd">TelemetryStopCmd</a></li><li><a href="#TelemetrySetPropertyCmd">TelemetrySetPropertyCmd</a></li>
 </ul>
   <p><strong>TelemetryCmd</strong> is referencing:<p>
 <ul>
@@ -1965,6 +1968,18 @@ svg.railroad-diagram g.diagram-text:hover path.diagram-text {
   <p><strong>TelemetryStopCmd</strong> is referencing:<p>
 <ul>
 <li><a href="#TelemetryCmd">TelemetryCmd</a></li>
+</ul>
+</section>
+<section>
+  <h4 id="TelemetrySetPropertyCmd">TelemetrySetPropertyCmd</h4>
+  <div class="diagram-container"><svg class="railroad-diagram" width="531" style="max-height: 437px;" viewBox="0 0 531 437"><g transform="translate(.5 .5)"><g><path d="M20 81v20m0 -10h20"></path></g><path d="M40 91h10"></path><g><path d="M50 91h0"></path><path d="M50 91h10"></path><g><path d="M60 91h10"></path><path d="M461 91h10"></path><g><path d="M70 91h0"></path><path d="M461 91h0"></path><rect x="70" y="42" width="391" height="144" rx="10" ry="10" class="group-box"></rect><g><path d="M70 91h10"></path><path d="M451 91h10"></path><g class="terminal"><path d="M80 91h0"></path><path d="M176.5 91h0"></path><rect x="80" y="80" width="96.5" height="22" rx="10" ry="10"></rect><text x="128.25" y="95">telemetry</text></g><path d="M176.5 91h10"></path><g><path d="M186.5 91h0"></path><path d="M451 91h0"></path><path d="M186.5 91h20"></path><g><path d="M206.5 91h0"></path><path d="M431 91h0"></path><rect x="206.5" y="72" width="224.5" height="38" rx="10" ry="10" class="group-box"></rect><g><path d="M206.5 91h10"></path><path d="M421 91h10"></path><g class="non-terminal"><path d="M216.5 91h0"></path><path d="M338.5 91h0"></path><rect x="216.5" y="80" width="122" height="22"></rect><a xlink:href="#TelemetryCmd"><text x="277.5" y="95">TelemetryCmd</text></a></g><path d="M338.5 91h10"></path><path d="M348.5 91h10"></path><g class="terminal"><path d="M358.5 91h0"></path><path d="M421 91h0"></path><rect x="358.5" y="80" width="62.5" height="22" rx="10" ry="10"></rect><text x="389.75" y="95">start</text></g></g><g><path d="M206.5 61h0"></path><path d="M335.5 61h0"></path><a xlink:href="#TelemetryStartCmd"><text x="271" y="66" class="comment">TelemetryStartCmd</text></a></g></g><path d="M431 91h20"></path><path d="M186.5 91a10 10 0 0 1 10 10v48a10 10 0 0 0 10 10"></path><g><path d="M206.5 159h4.25"></path><path d="M426.75 159h4.25"></path><rect x="210.75" y="140" width="216" height="38" rx="10" ry="10" class="group-box"></rect><g><path d="M210.75 159h10"></path><path d="M416.75 159h10"></path><g class="non-terminal"><path d="M220.75 159h0"></path><path d="M342.75 159h0"></path><rect x="220.75" y="148" width="122" height="22"></rect><a xlink:href="#TelemetryCmd"><text x="281.75" y="163">TelemetryCmd</text></a></g><path d="M342.75 159h10"></path><path d="M352.75 159h10"></path><g class="terminal"><path d="M362.75 159h0"></path><path d="M416.75 159h0"></path><rect x="362.75" y="148" width="54" height="22" rx="10" ry="10"></rect><text x="389.75" y="163">stop</text></g></g><g><path d="M210.75 129h0"></path><path d="M332.75 129h0"></path><a xlink:href="#TelemetryStopCmd"><text x="271.75" y="134" class="comment">TelemetryStopCmd</text></a></g></g><path d="M431 159a10 10 0 0 0 10 -10v-48a10 10 0 0 1 10 -10"></path></g></g><g><path d="M70 31h0"></path><path d="M164 31h0"></path><a xlink:href="#TelemetryCmd"><text x="117" y="36" class="comment">TelemetryCmd</text></a></g></g></g><path d="M471 91a10 10 0 0 1 10 10v83a10 10 0 0 1 -10 10h-411a10 10 0 0 0 -10 10v8a10 10 0 0 0 10 10"></path><g><path d="M60 222h11.75"></path><path d="M459.25 222h11.75"></path><g class="terminal"><path d="M71.75 222h0"></path><path d="M193.75 222h0"></path><rect x="71.75" y="211" width="122" height="22" rx="10" ry="10"></rect><text x="132.75" y="226">set-property</text></g><path d="M193.75 222h10"></path><g><path d="M203.75 222h0"></path><path d="M459.25 222h0"></path><path d="M203.75 222a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g><path d="M223.75 202h215.5"></path></g><path d="M439.25 202a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M203.75 222h20"></path><g class="terminal"><path d="M223.75 222h0"></path><path d="M439.25 222h0"></path><rect x="223.75" y="211" width="215.5" height="22" rx="10" ry="10"></rect><text x="331.5" y="226">--publication-list-path</text></g><path d="M439.25 222h20"></path></g></g><path d="M471 222a10 10 0 0 1 10 10v0a10 10 0 0 1 -10 10h-411a10 10 0 0 0 -10 10v38a10 10 0 0 0 10 10"></path><g><path d="M60 300h69.5"></path><path d="M401.5 300h69.5"></path><g><path d="M129.5 300h0"></path><path d="M401.5 300h0"></path><rect x="129.5" y="272" width="272" height="145" rx="10" ry="10" class="group-box"></rect><g><path d="M129.5 300h10"></path><path d="M391.5 300h10"></path><g class="non-terminal"><path d="M139.5 300h0"></path><path d="M210.5 300h0"></path><rect x="139.5" y="289" width="71" height="22"></rect><a xlink:href="#Letter"><text x="175" y="304">Letter</text></a></g><path d="M210.5 300h10"></path><g><path d="M220.5 300h0"></path><path d="M391.5 300h0"></path><path d="M220.5 300a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g><path d="M240.5 280h131"></path></g><path d="M371.5 280a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M220.5 300h20"></path><g><path d="M240.5 300h0"></path><path d="M371.5 300h0"></path><path d="M240.5 300h10"></path><g><path d="M250.5 300h0"></path><path d="M361.5 300h0"></path><path d="M250.5 300h20"></path><g class="non-terminal"><path d="M270.5 300h0"></path><path d="M341.5 300h0"></path><rect x="270.5" y="289" width="71" height="22"></rect><a xlink:href="#Letter"><text x="306" y="304">Letter</text></a></g><path d="M341.5 300h20"></path><path d="M250.5 300a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="non-terminal"><path d="M270.5 330h4.25"></path><path d="M337.25 330h4.25"></path><rect x="274.75" y="319" width="62.5" height="22"></rect><a xlink:href="#Digit"><text x="306" y="334">Digit</text></a></g><path d="M341.5 330a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M250.5 300a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal"><path d="M270.5 360h21.25"></path><path d="M320.25 360h21.25"></path><rect x="291.75" y="349" width="28.5" height="22" rx="10" ry="10"></rect><text x="306" y="364">-</text></g><path d="M341.5 360a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M250.5 300a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal"><path d="M270.5 390h21.25"></path><path d="M320.25 390h21.25"></path><rect x="291.75" y="379" width="28.5" height="22" rx="10" ry="10"></rect><text x="306" y="394">&#95;</text></g><path d="M341.5 390a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path></g><path d="M361.5 300h10"></path><path d="M250.5 300a10 10 0 0 0 -10 10v89a10 10 0 0 0 10 10"></path><g><path d="M250.5 409h111"></path></g><path d="M361.5 409a10 10 0 0 0 10 -10v-89a10 10 0 0 0 -10 -10"></path></g><path d="M371.5 300h20"></path></g></g><g><path d="M129.5 261h0"></path><path d="M209.5 261h0"></path><a xlink:href="#Identifier"><text x="169.5" y="266" class="comment">Identifier</text></a></g></g></g><path d="M471 300h10"></path><path d="M481 300h0"></path></g><path d="M481 300h10"></path><path d="M 491 300 h 20 m 0 -10 v 20"></path></g></svg>
+</div>
+  <code class="ebnf"><span class="ebnf-identifier">TelemetrySetPropertyCmd</span> = <a class="ebnf-non-terminal" href="#TelemetryCmd">TelemetryCmd</a> ,
+  <span class="ebnf-terminal">"set-property"</span> , [ <span class="ebnf-terminal">"--publication-list-path"</span> ] ,
+  <a class="ebnf-non-terminal" href="#Identifier">Identifier</a> <span class="ebnf-end">;</span></code>
+  <p><strong>TelemetrySetPropertyCmd</strong> is referencing:<p>
+<ul>
+<li><a href="#TelemetryCmd">TelemetryCmd</a></li><li><a href="#Identifier">Identifier</a></li>
 </ul>
 </section>
 <section>
@@ -2098,7 +2113,7 @@ svg.railroad-diagram g.diagram-text:hover path.diagram-text {
 
   </article>
   <footer>
-    <p>Date: 2022-08-30T08:05 - <a href="?theme=dark" data-theme="dark">Dark</a> - <a href="?theme=light" data-theme="light">Light</a></p>
+    <p>Date: 2022-09-05T04:40 - <a href="?theme=dark" data-theme="dark">Dark</a> - <a href="?theme=light" data-theme="light">Light</a></p>
   </footer>
   </main>
   <script type="text/javascript">

--- a/doc/guides/cli/poseidonos-cli_telemetry.md
+++ b/doc/guides/cli/poseidonos-cli_telemetry.md
@@ -11,7 +11,7 @@ PoseidonOS will not gather the internal statistics once you execute
 the temeletry stop command.  
 
 Syntax: 
-  poseidonos-cli telemetry [start|stop]
+  poseidonos-cli telemetry [start|stop|set-property]
 
 Example (to start telemetry PoseidonOS):
   poseidonos-cli telemetry start
@@ -44,6 +44,7 @@ poseidonos-cli telemetry [flags]
 ### SEE ALSO
 
 * [poseidonos-cli](poseidonos-cli.md)	 - poseidonos-cli - A command-line interface for PoseidonOS
+* [poseidonos-cli telemetry set-property](poseidonos-cli_telemetry_set-property.md)	 - Set properties of telemetry.
 * [poseidonos-cli telemetry start](poseidonos-cli_telemetry_start.md)	 - Start the collection of telemetry data in PoseidonOS.
 * [poseidonos-cli telemetry stop](poseidonos-cli_telemetry_stop.md)	 - Stop the collection of telemetry data in PoseidonOS.
 

--- a/doc/guides/cli/poseidonos-cli_telemetry_set-property.md
+++ b/doc/guides/cli/poseidonos-cli_telemetry_set-property.md
@@ -1,0 +1,42 @@
+## poseidonos-cli telemetry set-property
+
+Set properties of telemetry.
+
+### Synopsis
+
+
+  Set properties of telemetry.
+
+Syntax:
+  poseidonos-cli telemetry set-property --publication-list-path path
+          
+
+```
+poseidonos-cli telemetry set-property [flags]
+```
+
+### Options
+
+```
+  -h, --help                           help for set-property
+      --publication-list-path string   The path of the telemetry publication list file.
+```
+
+### Options inherited from parent commands
+
+```
+      --debug            Print response for debug.
+      --fs string        Field separator for the output. (default "|")
+      --ip string        Set IPv4 address to PoseidonOS for this command. (default "127.0.0.1")
+      --json-req         Print request in JSON form.
+      --json-res         Print response in JSON form.
+      --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
+      --port string      Set the port number to PoseidonOS for this command. (default "18716")
+      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --unit             Display unit (B, KB, MB, ...) when displaying capacity.
+```
+
+### SEE ALSO
+
+* [poseidonos-cli telemetry](poseidonos-cli_telemetry.md)	 - Telemetry commands for PoseidonOS.
+

--- a/doc/guides/cli/poseidonos-cli_volume_set-property.md
+++ b/doc/guides/cli/poseidonos-cli_volume_set-property.md
@@ -14,7 +14,7 @@ Syntax:
 
 Example: 
 	poseidonos-cli volume set-property --volume-name Volume0 --array-name volume0 
-	--new-volume-name NewVolume0 --user-volume --primary-volume
+	--new-volume-name NewVolume0 --primary-volume
 
 
 ```

--- a/proto/cli.proto
+++ b/proto/cli.proto
@@ -43,6 +43,12 @@ service PosCli {
     	};
 	}
 
+	rpc SetTelemetryProperty (SetTelemetryPropertyRequest) returns (SetTelemetryPropertyResponse) {
+		option (google.api.http) = {
+      		get: "/v1/set_telemetry_property"
+    	};
+	}
+
 	rpc ResetEventWrr (ResetEventWrrRequest) returns (ResetEventWrrResponse);
 	rpc ResetMbr (ResetMbrRequest) returns (ResetMbrResponse);
 	rpc StopRebuilding (StopRebuildingRequest) returns (StopRebuildingResponse);
@@ -338,6 +344,26 @@ message StopTelemetryRequest {
 }
 
 message StopTelemetryResponse {
+	string command = 1;
+	string rid = 2;
+	message Result {
+		Status status = 1;
+	}
+	Result result = 3;
+	PosInfo info = 4;
+}
+
+message SetTelemetryPropertyRequest {
+	string command = 1;
+	string rid = 2;
+	string requestor = 3;
+	message Param {
+		string publicationListPath = 1;
+	}
+	Param param = 4;
+}
+
+message SetTelemetryPropertyResponse {
 	string command = 1;
 	string rid = 2;
 	message Result {

--- a/proto/generated/cpp/cli.grpc.pb.cc
+++ b/proto/generated/cpp/cli.grpc.pb.cc
@@ -28,6 +28,7 @@ static const char* PosCli_method_names[] = {
   "/grpc_cli.PosCli/SetSystemProperty",
   "/grpc_cli.PosCli/StartTelemetry",
   "/grpc_cli.PosCli/StopTelemetry",
+  "/grpc_cli.PosCli/SetTelemetryProperty",
   "/grpc_cli.PosCli/ResetEventWrr",
   "/grpc_cli.PosCli/ResetMbr",
   "/grpc_cli.PosCli/StopRebuilding",
@@ -74,37 +75,38 @@ PosCli::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, co
   , rpcmethod_SetSystemProperty_(PosCli_method_names[3], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_StartTelemetry_(PosCli_method_names[4], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_StopTelemetry_(PosCli_method_names[5], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ResetEventWrr_(PosCli_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ResetMbr_(PosCli_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_StopRebuilding_(PosCli_method_names[8], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_UpdateEventWrr_(PosCli_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_AddSpare_(PosCli_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_RemoveSpare_(PosCli_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ReplaceArrayDevice_(PosCli_method_names[12], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_CreateArray_(PosCli_method_names[13], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_AutocreateArray_(PosCli_method_names[14], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_DeleteArray_(PosCli_method_names[15], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_MountArray_(PosCli_method_names[16], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_UnmountArray_(PosCli_method_names[17], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ListArray_(PosCli_method_names[18], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ArrayInfo_(PosCli_method_names[19], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetLogPreference_(PosCli_method_names[20], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetLogLevel_(PosCli_method_names[21], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_LoggerInfo_(PosCli_method_names[22], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetLogLevel_(PosCli_method_names[23], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ApplyLogFilter_(PosCli_method_names[24], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_CreateDevice_(PosCli_method_names[25], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ScanDevice_(PosCli_method_names[26], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ListDevice_(PosCli_method_names[27], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_GetSmartLog_(PosCli_method_names[28], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_CreateSubsystem_(PosCli_method_names[29], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_DeleteSubsystem_(PosCli_method_names[30], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_AddListener_(PosCli_method_names[31], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_ListSubsystem_(PosCli_method_names[32], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SubsystemInfo_(PosCli_method_names[33], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_CreateTransport_(PosCli_method_names[34], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_CreateVolume_(PosCli_method_names[35], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_SetVolumeProperty_(PosCli_method_names[36], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetTelemetryProperty_(PosCli_method_names[6], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ResetEventWrr_(PosCli_method_names[7], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ResetMbr_(PosCli_method_names[8], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_StopRebuilding_(PosCli_method_names[9], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_UpdateEventWrr_(PosCli_method_names[10], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_AddSpare_(PosCli_method_names[11], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_RemoveSpare_(PosCli_method_names[12], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ReplaceArrayDevice_(PosCli_method_names[13], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_CreateArray_(PosCli_method_names[14], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_AutocreateArray_(PosCli_method_names[15], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_DeleteArray_(PosCli_method_names[16], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_MountArray_(PosCli_method_names[17], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_UnmountArray_(PosCli_method_names[18], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ListArray_(PosCli_method_names[19], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ArrayInfo_(PosCli_method_names[20], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetLogPreference_(PosCli_method_names[21], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetLogLevel_(PosCli_method_names[22], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_LoggerInfo_(PosCli_method_names[23], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetLogLevel_(PosCli_method_names[24], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ApplyLogFilter_(PosCli_method_names[25], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_CreateDevice_(PosCli_method_names[26], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ScanDevice_(PosCli_method_names[27], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ListDevice_(PosCli_method_names[28], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetSmartLog_(PosCli_method_names[29], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_CreateSubsystem_(PosCli_method_names[30], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_DeleteSubsystem_(PosCli_method_names[31], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_AddListener_(PosCli_method_names[32], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_ListSubsystem_(PosCli_method_names[33], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SubsystemInfo_(PosCli_method_names[34], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_CreateTransport_(PosCli_method_names[35], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_CreateVolume_(PosCli_method_names[36], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SetVolumeProperty_(PosCli_method_names[37], options.suffix_for_stats(),::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
 ::grpc::Status PosCli::Stub::SystemInfo(::grpc::ClientContext* context, const ::grpc_cli::SystemInfoRequest& request, ::grpc_cli::SystemInfoResponse* response) {
@@ -241,6 +243,29 @@ void PosCli::Stub::experimental_async::StopTelemetry(::grpc::ClientContext* cont
 ::grpc::ClientAsyncResponseReader< ::grpc_cli::StopTelemetryResponse>* PosCli::Stub::AsyncStopTelemetryRaw(::grpc::ClientContext* context, const ::grpc_cli::StopTelemetryRequest& request, ::grpc::CompletionQueue* cq) {
   auto* result =
     this->PrepareAsyncStopTelemetryRaw(context, request, cq);
+  result->StartCall();
+  return result;
+}
+
+::grpc::Status PosCli::Stub::SetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest& request, ::grpc_cli::SetTelemetryPropertyResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall< ::grpc_cli::SetTelemetryPropertyRequest, ::grpc_cli::SetTelemetryPropertyResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), rpcmethod_SetTelemetryProperty_, context, request, response);
+}
+
+void PosCli::Stub::experimental_async::SetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest* request, ::grpc_cli::SetTelemetryPropertyResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc::internal::CallbackUnaryCall< ::grpc_cli::SetTelemetryPropertyRequest, ::grpc_cli::SetTelemetryPropertyResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetTelemetryProperty_, context, request, response, std::move(f));
+}
+
+void PosCli::Stub::experimental_async::SetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest* request, ::grpc_cli::SetTelemetryPropertyResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc::internal::ClientCallbackUnaryFactory::Create< ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(stub_->channel_.get(), stub_->rpcmethod_SetTelemetryProperty_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::grpc_cli::SetTelemetryPropertyResponse>* PosCli::Stub::PrepareAsyncSetTelemetryPropertyRaw(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderHelper::Create< ::grpc_cli::SetTelemetryPropertyResponse, ::grpc_cli::SetTelemetryPropertyRequest, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(channel_.get(), cq, rpcmethod_SetTelemetryProperty_, context, request);
+}
+
+::grpc::ClientAsyncResponseReader< ::grpc_cli::SetTelemetryPropertyResponse>* PosCli::Stub::AsyncSetTelemetryPropertyRaw(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest& request, ::grpc::CompletionQueue* cq) {
+  auto* result =
+    this->PrepareAsyncSetTelemetryPropertyRaw(context, request, cq);
   result->StartCall();
   return result;
 }
@@ -1022,6 +1047,16 @@ PosCli::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       PosCli_method_names[6],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::SetTelemetryPropertyRequest, ::grpc_cli::SetTelemetryPropertyResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
+          [](PosCli::Service* service,
+             ::grpc::ServerContext* ctx,
+             const ::grpc_cli::SetTelemetryPropertyRequest* req,
+             ::grpc_cli::SetTelemetryPropertyResponse* resp) {
+               return service->SetTelemetryProperty(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      PosCli_method_names[7],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::ResetEventWrrRequest, ::grpc_cli::ResetEventWrrResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
              ::grpc::ServerContext* ctx,
@@ -1030,7 +1065,7 @@ PosCli::Service::Service() {
                return service->ResetEventWrr(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[7],
+      PosCli_method_names[8],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::ResetMbrRequest, ::grpc_cli::ResetMbrResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1040,7 +1075,7 @@ PosCli::Service::Service() {
                return service->ResetMbr(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[8],
+      PosCli_method_names[9],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::StopRebuildingRequest, ::grpc_cli::StopRebuildingResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1050,7 +1085,7 @@ PosCli::Service::Service() {
                return service->StopRebuilding(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[9],
+      PosCli_method_names[10],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::UpdateEventWrrRequest, ::grpc_cli::UpdateEventWrrResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1060,7 +1095,7 @@ PosCli::Service::Service() {
                return service->UpdateEventWrr(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[10],
+      PosCli_method_names[11],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::AddSpareRequest, ::grpc_cli::AddSpareResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1070,7 +1105,7 @@ PosCli::Service::Service() {
                return service->AddSpare(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[11],
+      PosCli_method_names[12],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::RemoveSpareRequest, ::grpc_cli::RemoveSpareResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1080,7 +1115,7 @@ PosCli::Service::Service() {
                return service->RemoveSpare(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[12],
+      PosCli_method_names[13],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::ReplaceArrayDeviceRequest, ::grpc_cli::ReplaceArrayDeviceResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1090,7 +1125,7 @@ PosCli::Service::Service() {
                return service->ReplaceArrayDevice(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[13],
+      PosCli_method_names[14],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::CreateArrayRequest, ::grpc_cli::CreateArrayResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1100,7 +1135,7 @@ PosCli::Service::Service() {
                return service->CreateArray(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[14],
+      PosCli_method_names[15],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::AutocreateArrayRequest, ::grpc_cli::AutocreateArrayResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1110,7 +1145,7 @@ PosCli::Service::Service() {
                return service->AutocreateArray(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[15],
+      PosCli_method_names[16],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::DeleteArrayRequest, ::grpc_cli::DeleteArrayResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1120,7 +1155,7 @@ PosCli::Service::Service() {
                return service->DeleteArray(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[16],
+      PosCli_method_names[17],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::MountArrayRequest, ::grpc_cli::MountArrayResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1130,7 +1165,7 @@ PosCli::Service::Service() {
                return service->MountArray(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[17],
+      PosCli_method_names[18],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::UnmountArrayRequest, ::grpc_cli::UnmountArrayResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1140,7 +1175,7 @@ PosCli::Service::Service() {
                return service->UnmountArray(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[18],
+      PosCli_method_names[19],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::ListArrayRequest, ::grpc_cli::ListArrayResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1150,7 +1185,7 @@ PosCli::Service::Service() {
                return service->ListArray(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[19],
+      PosCli_method_names[20],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::ArrayInfoRequest, ::grpc_cli::ArrayInfoResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1160,7 +1195,7 @@ PosCli::Service::Service() {
                return service->ArrayInfo(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[20],
+      PosCli_method_names[21],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::SetLogPreferenceRequest, ::grpc_cli::SetLogPreferenceResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1170,7 +1205,7 @@ PosCli::Service::Service() {
                return service->SetLogPreference(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[21],
+      PosCli_method_names[22],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::SetLogLevelRequest, ::grpc_cli::SetLogLevelResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1180,7 +1215,7 @@ PosCli::Service::Service() {
                return service->SetLogLevel(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[22],
+      PosCli_method_names[23],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::LoggerInfoRequest, ::grpc_cli::LoggerInfoResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1190,7 +1225,7 @@ PosCli::Service::Service() {
                return service->LoggerInfo(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[23],
+      PosCli_method_names[24],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::GetLogLevelRequest, ::grpc_cli::GetLogLevelResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1200,7 +1235,7 @@ PosCli::Service::Service() {
                return service->GetLogLevel(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[24],
+      PosCli_method_names[25],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::ApplyLogFilterRequest, ::grpc_cli::ApplyLogFilterResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1210,7 +1245,7 @@ PosCli::Service::Service() {
                return service->ApplyLogFilter(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[25],
+      PosCli_method_names[26],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::CreateDeviceRequest, ::grpc_cli::CreateDeviceResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1220,7 +1255,7 @@ PosCli::Service::Service() {
                return service->CreateDevice(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[26],
+      PosCli_method_names[27],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::ScanDeviceRequest, ::grpc_cli::ScanDeviceResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1230,7 +1265,7 @@ PosCli::Service::Service() {
                return service->ScanDevice(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[27],
+      PosCli_method_names[28],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::ListDeviceRequest, ::grpc_cli::ListDeviceResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1240,7 +1275,7 @@ PosCli::Service::Service() {
                return service->ListDevice(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[28],
+      PosCli_method_names[29],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::GetSmartLogRequest, ::grpc_cli::GetSmartLogResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1250,7 +1285,7 @@ PosCli::Service::Service() {
                return service->GetSmartLog(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[29],
+      PosCli_method_names[30],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::CreateSubsystemRequest, ::grpc_cli::CreateSubsystemResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1260,7 +1295,7 @@ PosCli::Service::Service() {
                return service->CreateSubsystem(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[30],
+      PosCli_method_names[31],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::DeleteSubsystemRequest, ::grpc_cli::DeleteSubsystemResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1270,7 +1305,7 @@ PosCli::Service::Service() {
                return service->DeleteSubsystem(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[31],
+      PosCli_method_names[32],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::AddListenerRequest, ::grpc_cli::AddListenerResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1280,7 +1315,7 @@ PosCli::Service::Service() {
                return service->AddListener(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[32],
+      PosCli_method_names[33],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::ListSubsystemRequest, ::grpc_cli::ListSubsystemResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1290,7 +1325,7 @@ PosCli::Service::Service() {
                return service->ListSubsystem(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[33],
+      PosCli_method_names[34],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::SubsystemInfoRequest, ::grpc_cli::SubsystemInfoResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1300,7 +1335,7 @@ PosCli::Service::Service() {
                return service->SubsystemInfo(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[34],
+      PosCli_method_names[35],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::CreateTransportRequest, ::grpc_cli::CreateTransportResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1310,7 +1345,7 @@ PosCli::Service::Service() {
                return service->CreateTransport(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[35],
+      PosCli_method_names[36],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::CreateVolumeRequest, ::grpc_cli::CreateVolumeResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1320,7 +1355,7 @@ PosCli::Service::Service() {
                return service->CreateVolume(ctx, req, resp);
              }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      PosCli_method_names[36],
+      PosCli_method_names[37],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< PosCli::Service, ::grpc_cli::SetVolumePropertyRequest, ::grpc_cli::SetVolumePropertyResponse, ::grpc::protobuf::MessageLite, ::grpc::protobuf::MessageLite>(
           [](PosCli::Service* service,
@@ -1370,6 +1405,13 @@ PosCli::Service::~Service() {
 }
 
 ::grpc::Status PosCli::Service::StopTelemetry(::grpc::ServerContext* context, const ::grpc_cli::StopTelemetryRequest* request, ::grpc_cli::StopTelemetryResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status PosCli::Service::SetTelemetryProperty(::grpc::ServerContext* context, const ::grpc_cli::SetTelemetryPropertyRequest* request, ::grpc_cli::SetTelemetryPropertyResponse* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/proto/generated/cpp/cli.grpc.pb.h
+++ b/proto/generated/cpp/cli.grpc.pb.h
@@ -78,6 +78,13 @@ class PosCli final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::StopTelemetryResponse>> PrepareAsyncStopTelemetry(::grpc::ClientContext* context, const ::grpc_cli::StopTelemetryRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::StopTelemetryResponse>>(PrepareAsyncStopTelemetryRaw(context, request, cq));
     }
+    virtual ::grpc::Status SetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest& request, ::grpc_cli::SetTelemetryPropertyResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::SetTelemetryPropertyResponse>> AsyncSetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::SetTelemetryPropertyResponse>>(AsyncSetTelemetryPropertyRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::SetTelemetryPropertyResponse>> PrepareAsyncSetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::SetTelemetryPropertyResponse>>(PrepareAsyncSetTelemetryPropertyRaw(context, request, cq));
+    }
     virtual ::grpc::Status ResetEventWrr(::grpc::ClientContext* context, const ::grpc_cli::ResetEventWrrRequest& request, ::grpc_cli::ResetEventWrrResponse* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::ResetEventWrrResponse>> AsyncResetEventWrr(::grpc::ClientContext* context, const ::grpc_cli::ResetEventWrrRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::ResetEventWrrResponse>>(AsyncResetEventWrrRaw(context, request, cq));
@@ -335,6 +342,12 @@ class PosCli final {
       #else
       virtual void StopTelemetry(::grpc::ClientContext* context, const ::grpc_cli::StopTelemetryRequest* request, ::grpc_cli::StopTelemetryResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       #endif
+      virtual void SetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest* request, ::grpc_cli::SetTelemetryPropertyResponse* response, std::function<void(::grpc::Status)>) = 0;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void SetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest* request, ::grpc_cli::SetTelemetryPropertyResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
+      virtual void SetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest* request, ::grpc_cli::SetTelemetryPropertyResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
       virtual void ResetEventWrr(::grpc::ClientContext* context, const ::grpc_cli::ResetEventWrrRequest* request, ::grpc_cli::ResetEventWrrResponse* response, std::function<void(::grpc::Status)>) = 0;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       virtual void ResetEventWrr(::grpc::ClientContext* context, const ::grpc_cli::ResetEventWrrRequest* request, ::grpc_cli::ResetEventWrrResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
@@ -543,6 +556,8 @@ class PosCli final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::StartTelemetryResponse>* PrepareAsyncStartTelemetryRaw(::grpc::ClientContext* context, const ::grpc_cli::StartTelemetryRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::StopTelemetryResponse>* AsyncStopTelemetryRaw(::grpc::ClientContext* context, const ::grpc_cli::StopTelemetryRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::StopTelemetryResponse>* PrepareAsyncStopTelemetryRaw(::grpc::ClientContext* context, const ::grpc_cli::StopTelemetryRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::SetTelemetryPropertyResponse>* AsyncSetTelemetryPropertyRaw(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::SetTelemetryPropertyResponse>* PrepareAsyncSetTelemetryPropertyRaw(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::ResetEventWrrResponse>* AsyncResetEventWrrRaw(::grpc::ClientContext* context, const ::grpc_cli::ResetEventWrrRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::ResetEventWrrResponse>* PrepareAsyncResetEventWrrRaw(::grpc::ClientContext* context, const ::grpc_cli::ResetEventWrrRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_cli::ResetMbrResponse>* AsyncResetMbrRaw(::grpc::ClientContext* context, const ::grpc_cli::ResetMbrRequest& request, ::grpc::CompletionQueue* cq) = 0;
@@ -650,6 +665,13 @@ class PosCli final {
     }
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_cli::StopTelemetryResponse>> PrepareAsyncStopTelemetry(::grpc::ClientContext* context, const ::grpc_cli::StopTelemetryRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_cli::StopTelemetryResponse>>(PrepareAsyncStopTelemetryRaw(context, request, cq));
+    }
+    ::grpc::Status SetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest& request, ::grpc_cli::SetTelemetryPropertyResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_cli::SetTelemetryPropertyResponse>> AsyncSetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_cli::SetTelemetryPropertyResponse>>(AsyncSetTelemetryPropertyRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_cli::SetTelemetryPropertyResponse>> PrepareAsyncSetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_cli::SetTelemetryPropertyResponse>>(PrepareAsyncSetTelemetryPropertyRaw(context, request, cq));
     }
     ::grpc::Status ResetEventWrr(::grpc::ClientContext* context, const ::grpc_cli::ResetEventWrrRequest& request, ::grpc_cli::ResetEventWrrResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_cli::ResetEventWrrResponse>> AsyncResetEventWrr(::grpc::ClientContext* context, const ::grpc_cli::ResetEventWrrRequest& request, ::grpc::CompletionQueue* cq) {
@@ -907,6 +929,12 @@ class PosCli final {
       #else
       void StopTelemetry(::grpc::ClientContext* context, const ::grpc_cli::StopTelemetryRequest* request, ::grpc_cli::StopTelemetryResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
       #endif
+      void SetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest* request, ::grpc_cli::SetTelemetryPropertyResponse* response, std::function<void(::grpc::Status)>) override;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void SetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest* request, ::grpc_cli::SetTelemetryPropertyResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
+      void SetTelemetryProperty(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest* request, ::grpc_cli::SetTelemetryPropertyResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
       void ResetEventWrr(::grpc::ClientContext* context, const ::grpc_cli::ResetEventWrrRequest* request, ::grpc_cli::ResetEventWrrResponse* response, std::function<void(::grpc::Status)>) override;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
       void ResetEventWrr(::grpc::ClientContext* context, const ::grpc_cli::ResetEventWrrRequest* request, ::grpc_cli::ResetEventWrrResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
@@ -1116,6 +1144,8 @@ class PosCli final {
     ::grpc::ClientAsyncResponseReader< ::grpc_cli::StartTelemetryResponse>* PrepareAsyncStartTelemetryRaw(::grpc::ClientContext* context, const ::grpc_cli::StartTelemetryRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_cli::StopTelemetryResponse>* AsyncStopTelemetryRaw(::grpc::ClientContext* context, const ::grpc_cli::StopTelemetryRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_cli::StopTelemetryResponse>* PrepareAsyncStopTelemetryRaw(::grpc::ClientContext* context, const ::grpc_cli::StopTelemetryRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_cli::SetTelemetryPropertyResponse>* AsyncSetTelemetryPropertyRaw(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_cli::SetTelemetryPropertyResponse>* PrepareAsyncSetTelemetryPropertyRaw(::grpc::ClientContext* context, const ::grpc_cli::SetTelemetryPropertyRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_cli::ResetEventWrrResponse>* AsyncResetEventWrrRaw(::grpc::ClientContext* context, const ::grpc_cli::ResetEventWrrRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_cli::ResetEventWrrResponse>* PrepareAsyncResetEventWrrRaw(::grpc::ClientContext* context, const ::grpc_cli::ResetEventWrrRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_cli::ResetMbrResponse>* AsyncResetMbrRaw(::grpc::ClientContext* context, const ::grpc_cli::ResetMbrRequest& request, ::grpc::CompletionQueue* cq) override;
@@ -1184,6 +1214,7 @@ class PosCli final {
     const ::grpc::internal::RpcMethod rpcmethod_SetSystemProperty_;
     const ::grpc::internal::RpcMethod rpcmethod_StartTelemetry_;
     const ::grpc::internal::RpcMethod rpcmethod_StopTelemetry_;
+    const ::grpc::internal::RpcMethod rpcmethod_SetTelemetryProperty_;
     const ::grpc::internal::RpcMethod rpcmethod_ResetEventWrr_;
     const ::grpc::internal::RpcMethod rpcmethod_ResetMbr_;
     const ::grpc::internal::RpcMethod rpcmethod_StopRebuilding_;
@@ -1228,6 +1259,7 @@ class PosCli final {
     virtual ::grpc::Status SetSystemProperty(::grpc::ServerContext* context, const ::grpc_cli::SetSystemPropertyRequest* request, ::grpc_cli::SetSystemPropertyResponse* response);
     virtual ::grpc::Status StartTelemetry(::grpc::ServerContext* context, const ::grpc_cli::StartTelemetryRequest* request, ::grpc_cli::StartTelemetryResponse* response);
     virtual ::grpc::Status StopTelemetry(::grpc::ServerContext* context, const ::grpc_cli::StopTelemetryRequest* request, ::grpc_cli::StopTelemetryResponse* response);
+    virtual ::grpc::Status SetTelemetryProperty(::grpc::ServerContext* context, const ::grpc_cli::SetTelemetryPropertyRequest* request, ::grpc_cli::SetTelemetryPropertyResponse* response);
     virtual ::grpc::Status ResetEventWrr(::grpc::ServerContext* context, const ::grpc_cli::ResetEventWrrRequest* request, ::grpc_cli::ResetEventWrrResponse* response);
     virtual ::grpc::Status ResetMbr(::grpc::ServerContext* context, const ::grpc_cli::ResetMbrRequest* request, ::grpc_cli::ResetMbrResponse* response);
     virtual ::grpc::Status StopRebuilding(::grpc::ServerContext* context, const ::grpc_cli::StopRebuildingRequest* request, ::grpc_cli::StopRebuildingResponse* response);
@@ -1382,12 +1414,32 @@ class PosCli final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_SetTelemetryProperty : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_SetTelemetryProperty() {
+      ::grpc::Service::MarkMethodAsync(6);
+    }
+    ~WithAsyncMethod_SetTelemetryProperty() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetTelemetryProperty(::grpc::ServerContext* /*context*/, const ::grpc_cli::SetTelemetryPropertyRequest* /*request*/, ::grpc_cli::SetTelemetryPropertyResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetTelemetryProperty(::grpc::ServerContext* context, ::grpc_cli::SetTelemetryPropertyRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::SetTelemetryPropertyResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_ResetEventWrr : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ResetEventWrr() {
-      ::grpc::Service::MarkMethodAsync(6);
+      ::grpc::Service::MarkMethodAsync(7);
     }
     ~WithAsyncMethod_ResetEventWrr() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1398,7 +1450,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestResetEventWrr(::grpc::ServerContext* context, ::grpc_cli::ResetEventWrrRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::ResetEventWrrResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1407,7 +1459,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ResetMbr() {
-      ::grpc::Service::MarkMethodAsync(7);
+      ::grpc::Service::MarkMethodAsync(8);
     }
     ~WithAsyncMethod_ResetMbr() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1418,7 +1470,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestResetMbr(::grpc::ServerContext* context, ::grpc_cli::ResetMbrRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::ResetMbrResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1427,7 +1479,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_StopRebuilding() {
-      ::grpc::Service::MarkMethodAsync(8);
+      ::grpc::Service::MarkMethodAsync(9);
     }
     ~WithAsyncMethod_StopRebuilding() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1438,7 +1490,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestStopRebuilding(::grpc::ServerContext* context, ::grpc_cli::StopRebuildingRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::StopRebuildingResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1447,7 +1499,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_UpdateEventWrr() {
-      ::grpc::Service::MarkMethodAsync(9);
+      ::grpc::Service::MarkMethodAsync(10);
     }
     ~WithAsyncMethod_UpdateEventWrr() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1458,7 +1510,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestUpdateEventWrr(::grpc::ServerContext* context, ::grpc_cli::UpdateEventWrrRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::UpdateEventWrrResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1467,7 +1519,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_AddSpare() {
-      ::grpc::Service::MarkMethodAsync(10);
+      ::grpc::Service::MarkMethodAsync(11);
     }
     ~WithAsyncMethod_AddSpare() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1478,7 +1530,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestAddSpare(::grpc::ServerContext* context, ::grpc_cli::AddSpareRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::AddSpareResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1487,7 +1539,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_RemoveSpare() {
-      ::grpc::Service::MarkMethodAsync(11);
+      ::grpc::Service::MarkMethodAsync(12);
     }
     ~WithAsyncMethod_RemoveSpare() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1498,7 +1550,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRemoveSpare(::grpc::ServerContext* context, ::grpc_cli::RemoveSpareRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::RemoveSpareResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1507,7 +1559,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ReplaceArrayDevice() {
-      ::grpc::Service::MarkMethodAsync(12);
+      ::grpc::Service::MarkMethodAsync(13);
     }
     ~WithAsyncMethod_ReplaceArrayDevice() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1518,7 +1570,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReplaceArrayDevice(::grpc::ServerContext* context, ::grpc_cli::ReplaceArrayDeviceRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::ReplaceArrayDeviceResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1527,7 +1579,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_CreateArray() {
-      ::grpc::Service::MarkMethodAsync(13);
+      ::grpc::Service::MarkMethodAsync(14);
     }
     ~WithAsyncMethod_CreateArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1538,7 +1590,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCreateArray(::grpc::ServerContext* context, ::grpc_cli::CreateArrayRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::CreateArrayResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1547,7 +1599,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_AutocreateArray() {
-      ::grpc::Service::MarkMethodAsync(14);
+      ::grpc::Service::MarkMethodAsync(15);
     }
     ~WithAsyncMethod_AutocreateArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1558,7 +1610,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestAutocreateArray(::grpc::ServerContext* context, ::grpc_cli::AutocreateArrayRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::AutocreateArrayResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1567,7 +1619,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_DeleteArray() {
-      ::grpc::Service::MarkMethodAsync(15);
+      ::grpc::Service::MarkMethodAsync(16);
     }
     ~WithAsyncMethod_DeleteArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1578,7 +1630,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestDeleteArray(::grpc::ServerContext* context, ::grpc_cli::DeleteArrayRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::DeleteArrayResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1587,7 +1639,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_MountArray() {
-      ::grpc::Service::MarkMethodAsync(16);
+      ::grpc::Service::MarkMethodAsync(17);
     }
     ~WithAsyncMethod_MountArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1598,7 +1650,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestMountArray(::grpc::ServerContext* context, ::grpc_cli::MountArrayRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::MountArrayResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1607,7 +1659,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_UnmountArray() {
-      ::grpc::Service::MarkMethodAsync(17);
+      ::grpc::Service::MarkMethodAsync(18);
     }
     ~WithAsyncMethod_UnmountArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1618,7 +1670,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestUnmountArray(::grpc::ServerContext* context, ::grpc_cli::UnmountArrayRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::UnmountArrayResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1627,7 +1679,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ListArray() {
-      ::grpc::Service::MarkMethodAsync(18);
+      ::grpc::Service::MarkMethodAsync(19);
     }
     ~WithAsyncMethod_ListArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1638,7 +1690,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestListArray(::grpc::ServerContext* context, ::grpc_cli::ListArrayRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::ListArrayResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1647,7 +1699,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ArrayInfo() {
-      ::grpc::Service::MarkMethodAsync(19);
+      ::grpc::Service::MarkMethodAsync(20);
     }
     ~WithAsyncMethod_ArrayInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1658,7 +1710,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestArrayInfo(::grpc::ServerContext* context, ::grpc_cli::ArrayInfoRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::ArrayInfoResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(20, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1667,7 +1719,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetLogPreference() {
-      ::grpc::Service::MarkMethodAsync(20);
+      ::grpc::Service::MarkMethodAsync(21);
     }
     ~WithAsyncMethod_SetLogPreference() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1678,7 +1730,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetLogPreference(::grpc::ServerContext* context, ::grpc_cli::SetLogPreferenceRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::SetLogPreferenceResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(20, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(21, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1687,7 +1739,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetLogLevel() {
-      ::grpc::Service::MarkMethodAsync(21);
+      ::grpc::Service::MarkMethodAsync(22);
     }
     ~WithAsyncMethod_SetLogLevel() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1698,7 +1750,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetLogLevel(::grpc::ServerContext* context, ::grpc_cli::SetLogLevelRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::SetLogLevelResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(21, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(22, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1707,7 +1759,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_LoggerInfo() {
-      ::grpc::Service::MarkMethodAsync(22);
+      ::grpc::Service::MarkMethodAsync(23);
     }
     ~WithAsyncMethod_LoggerInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1718,7 +1770,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestLoggerInfo(::grpc::ServerContext* context, ::grpc_cli::LoggerInfoRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::LoggerInfoResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(22, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(23, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1727,7 +1779,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetLogLevel() {
-      ::grpc::Service::MarkMethodAsync(23);
+      ::grpc::Service::MarkMethodAsync(24);
     }
     ~WithAsyncMethod_GetLogLevel() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1738,7 +1790,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetLogLevel(::grpc::ServerContext* context, ::grpc_cli::GetLogLevelRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::GetLogLevelResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(23, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(24, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1747,7 +1799,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ApplyLogFilter() {
-      ::grpc::Service::MarkMethodAsync(24);
+      ::grpc::Service::MarkMethodAsync(25);
     }
     ~WithAsyncMethod_ApplyLogFilter() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1758,7 +1810,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestApplyLogFilter(::grpc::ServerContext* context, ::grpc_cli::ApplyLogFilterRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::ApplyLogFilterResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(24, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(25, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1767,7 +1819,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_CreateDevice() {
-      ::grpc::Service::MarkMethodAsync(25);
+      ::grpc::Service::MarkMethodAsync(26);
     }
     ~WithAsyncMethod_CreateDevice() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1778,7 +1830,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCreateDevice(::grpc::ServerContext* context, ::grpc_cli::CreateDeviceRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::CreateDeviceResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(25, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(26, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1787,7 +1839,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ScanDevice() {
-      ::grpc::Service::MarkMethodAsync(26);
+      ::grpc::Service::MarkMethodAsync(27);
     }
     ~WithAsyncMethod_ScanDevice() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1798,7 +1850,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestScanDevice(::grpc::ServerContext* context, ::grpc_cli::ScanDeviceRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::ScanDeviceResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(26, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(27, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1807,7 +1859,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ListDevice() {
-      ::grpc::Service::MarkMethodAsync(27);
+      ::grpc::Service::MarkMethodAsync(28);
     }
     ~WithAsyncMethod_ListDevice() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1818,7 +1870,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestListDevice(::grpc::ServerContext* context, ::grpc_cli::ListDeviceRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::ListDeviceResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(27, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(28, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1827,7 +1879,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_GetSmartLog() {
-      ::grpc::Service::MarkMethodAsync(28);
+      ::grpc::Service::MarkMethodAsync(29);
     }
     ~WithAsyncMethod_GetSmartLog() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1838,7 +1890,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetSmartLog(::grpc::ServerContext* context, ::grpc_cli::GetSmartLogRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::GetSmartLogResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(28, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(29, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1847,7 +1899,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_CreateSubsystem() {
-      ::grpc::Service::MarkMethodAsync(29);
+      ::grpc::Service::MarkMethodAsync(30);
     }
     ~WithAsyncMethod_CreateSubsystem() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1858,7 +1910,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCreateSubsystem(::grpc::ServerContext* context, ::grpc_cli::CreateSubsystemRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::CreateSubsystemResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(29, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(30, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1867,7 +1919,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_DeleteSubsystem() {
-      ::grpc::Service::MarkMethodAsync(30);
+      ::grpc::Service::MarkMethodAsync(31);
     }
     ~WithAsyncMethod_DeleteSubsystem() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1878,7 +1930,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestDeleteSubsystem(::grpc::ServerContext* context, ::grpc_cli::DeleteSubsystemRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::DeleteSubsystemResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(30, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(31, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1887,7 +1939,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_AddListener() {
-      ::grpc::Service::MarkMethodAsync(31);
+      ::grpc::Service::MarkMethodAsync(32);
     }
     ~WithAsyncMethod_AddListener() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1898,7 +1950,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestAddListener(::grpc::ServerContext* context, ::grpc_cli::AddListenerRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::AddListenerResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(31, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1907,7 +1959,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_ListSubsystem() {
-      ::grpc::Service::MarkMethodAsync(32);
+      ::grpc::Service::MarkMethodAsync(33);
     }
     ~WithAsyncMethod_ListSubsystem() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1918,7 +1970,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestListSubsystem(::grpc::ServerContext* context, ::grpc_cli::ListSubsystemRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::ListSubsystemResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(33, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1927,7 +1979,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SubsystemInfo() {
-      ::grpc::Service::MarkMethodAsync(33);
+      ::grpc::Service::MarkMethodAsync(34);
     }
     ~WithAsyncMethod_SubsystemInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1938,7 +1990,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubsystemInfo(::grpc::ServerContext* context, ::grpc_cli::SubsystemInfoRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::SubsystemInfoResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(33, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1947,7 +1999,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_CreateTransport() {
-      ::grpc::Service::MarkMethodAsync(34);
+      ::grpc::Service::MarkMethodAsync(35);
     }
     ~WithAsyncMethod_CreateTransport() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1958,7 +2010,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCreateTransport(::grpc::ServerContext* context, ::grpc_cli::CreateTransportRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::CreateTransportResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(35, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1967,7 +2019,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_CreateVolume() {
-      ::grpc::Service::MarkMethodAsync(35);
+      ::grpc::Service::MarkMethodAsync(36);
     }
     ~WithAsyncMethod_CreateVolume() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1978,7 +2030,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCreateVolume(::grpc::ServerContext* context, ::grpc_cli::CreateVolumeRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::CreateVolumeResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(35, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -1987,7 +2039,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_SetVolumeProperty() {
-      ::grpc::Service::MarkMethodAsync(36);
+      ::grpc::Service::MarkMethodAsync(37);
     }
     ~WithAsyncMethod_SetVolumeProperty() override {
       BaseClassMustBeDerivedFromService(this);
@@ -1998,10 +2050,10 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetVolumeProperty(::grpc::ServerContext* context, ::grpc_cli::SetVolumePropertyRequest* request, ::grpc::ServerAsyncResponseWriter< ::grpc_cli::SetVolumePropertyResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(37, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_SystemInfo<WithAsyncMethod_StopSystem<WithAsyncMethod_GetSystemProperty<WithAsyncMethod_SetSystemProperty<WithAsyncMethod_StartTelemetry<WithAsyncMethod_StopTelemetry<WithAsyncMethod_ResetEventWrr<WithAsyncMethod_ResetMbr<WithAsyncMethod_StopRebuilding<WithAsyncMethod_UpdateEventWrr<WithAsyncMethod_AddSpare<WithAsyncMethod_RemoveSpare<WithAsyncMethod_ReplaceArrayDevice<WithAsyncMethod_CreateArray<WithAsyncMethod_AutocreateArray<WithAsyncMethod_DeleteArray<WithAsyncMethod_MountArray<WithAsyncMethod_UnmountArray<WithAsyncMethod_ListArray<WithAsyncMethod_ArrayInfo<WithAsyncMethod_SetLogPreference<WithAsyncMethod_SetLogLevel<WithAsyncMethod_LoggerInfo<WithAsyncMethod_GetLogLevel<WithAsyncMethod_ApplyLogFilter<WithAsyncMethod_CreateDevice<WithAsyncMethod_ScanDevice<WithAsyncMethod_ListDevice<WithAsyncMethod_GetSmartLog<WithAsyncMethod_CreateSubsystem<WithAsyncMethod_DeleteSubsystem<WithAsyncMethod_AddListener<WithAsyncMethod_ListSubsystem<WithAsyncMethod_SubsystemInfo<WithAsyncMethod_CreateTransport<WithAsyncMethod_CreateVolume<WithAsyncMethod_SetVolumeProperty<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
+  typedef WithAsyncMethod_SystemInfo<WithAsyncMethod_StopSystem<WithAsyncMethod_GetSystemProperty<WithAsyncMethod_SetSystemProperty<WithAsyncMethod_StartTelemetry<WithAsyncMethod_StopTelemetry<WithAsyncMethod_SetTelemetryProperty<WithAsyncMethod_ResetEventWrr<WithAsyncMethod_ResetMbr<WithAsyncMethod_StopRebuilding<WithAsyncMethod_UpdateEventWrr<WithAsyncMethod_AddSpare<WithAsyncMethod_RemoveSpare<WithAsyncMethod_ReplaceArrayDevice<WithAsyncMethod_CreateArray<WithAsyncMethod_AutocreateArray<WithAsyncMethod_DeleteArray<WithAsyncMethod_MountArray<WithAsyncMethod_UnmountArray<WithAsyncMethod_ListArray<WithAsyncMethod_ArrayInfo<WithAsyncMethod_SetLogPreference<WithAsyncMethod_SetLogLevel<WithAsyncMethod_LoggerInfo<WithAsyncMethod_GetLogLevel<WithAsyncMethod_ApplyLogFilter<WithAsyncMethod_CreateDevice<WithAsyncMethod_ScanDevice<WithAsyncMethod_ListDevice<WithAsyncMethod_GetSmartLog<WithAsyncMethod_CreateSubsystem<WithAsyncMethod_DeleteSubsystem<WithAsyncMethod_AddListener<WithAsyncMethod_ListSubsystem<WithAsyncMethod_SubsystemInfo<WithAsyncMethod_CreateTransport<WithAsyncMethod_CreateVolume<WithAsyncMethod_SetVolumeProperty<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > AsyncService;
   template <class BaseClass>
   class ExperimentalWithCallbackMethod_SystemInfo : public BaseClass {
    private:
@@ -2285,6 +2337,53 @@ class PosCli final {
       { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithCallbackMethod_SetTelemetryProperty : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithCallbackMethod_SetTelemetryProperty() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodCallback(6,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::SetTelemetryPropertyRequest, ::grpc_cli::SetTelemetryPropertyResponse>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::grpc_cli::SetTelemetryPropertyRequest* request, ::grpc_cli::SetTelemetryPropertyResponse* response) { return this->SetTelemetryProperty(context, request, response); }));}
+    void SetMessageAllocatorFor_SetTelemetryProperty(
+        ::grpc::experimental::MessageAllocator< ::grpc_cli::SetTelemetryPropertyRequest, ::grpc_cli::SetTelemetryPropertyResponse>* allocator) {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(6);
+    #else
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(6);
+    #endif
+      static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::SetTelemetryPropertyRequest, ::grpc_cli::SetTelemetryPropertyResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~ExperimentalWithCallbackMethod_SetTelemetryProperty() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetTelemetryProperty(::grpc::ServerContext* /*context*/, const ::grpc_cli::SetTelemetryPropertyRequest* /*request*/, ::grpc_cli::SetTelemetryPropertyResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* SetTelemetryProperty(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc_cli::SetTelemetryPropertyRequest* /*request*/, ::grpc_cli::SetTelemetryPropertyResponse* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* SetTelemetryProperty(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc_cli::SetTelemetryPropertyRequest* /*request*/, ::grpc_cli::SetTelemetryPropertyResponse* /*response*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithCallbackMethod_ResetEventWrr : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -2295,7 +2394,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(6,
+        MarkMethodCallback(7,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ResetEventWrrRequest, ::grpc_cli::ResetEventWrrResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2307,9 +2406,9 @@ class PosCli final {
     void SetMessageAllocatorFor_ResetEventWrr(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::ResetEventWrrRequest, ::grpc_cli::ResetEventWrrResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(6);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(7);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(6);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(7);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ResetEventWrrRequest, ::grpc_cli::ResetEventWrrResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2342,7 +2441,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(7,
+        MarkMethodCallback(8,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ResetMbrRequest, ::grpc_cli::ResetMbrResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2354,9 +2453,9 @@ class PosCli final {
     void SetMessageAllocatorFor_ResetMbr(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::ResetMbrRequest, ::grpc_cli::ResetMbrResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(7);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(8);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(7);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(8);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ResetMbrRequest, ::grpc_cli::ResetMbrResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2389,7 +2488,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(8,
+        MarkMethodCallback(9,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::StopRebuildingRequest, ::grpc_cli::StopRebuildingResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2401,9 +2500,9 @@ class PosCli final {
     void SetMessageAllocatorFor_StopRebuilding(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::StopRebuildingRequest, ::grpc_cli::StopRebuildingResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(8);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(9);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(8);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(9);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::StopRebuildingRequest, ::grpc_cli::StopRebuildingResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2436,7 +2535,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(9,
+        MarkMethodCallback(10,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::UpdateEventWrrRequest, ::grpc_cli::UpdateEventWrrResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2448,9 +2547,9 @@ class PosCli final {
     void SetMessageAllocatorFor_UpdateEventWrr(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::UpdateEventWrrRequest, ::grpc_cli::UpdateEventWrrResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(9);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(10);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(9);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(10);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::UpdateEventWrrRequest, ::grpc_cli::UpdateEventWrrResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2483,7 +2582,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(10,
+        MarkMethodCallback(11,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::AddSpareRequest, ::grpc_cli::AddSpareResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2495,9 +2594,9 @@ class PosCli final {
     void SetMessageAllocatorFor_AddSpare(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::AddSpareRequest, ::grpc_cli::AddSpareResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(10);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(11);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(10);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(11);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::AddSpareRequest, ::grpc_cli::AddSpareResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2530,7 +2629,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(11,
+        MarkMethodCallback(12,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::RemoveSpareRequest, ::grpc_cli::RemoveSpareResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2542,9 +2641,9 @@ class PosCli final {
     void SetMessageAllocatorFor_RemoveSpare(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::RemoveSpareRequest, ::grpc_cli::RemoveSpareResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(11);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(12);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(11);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(12);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::RemoveSpareRequest, ::grpc_cli::RemoveSpareResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2577,7 +2676,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(12,
+        MarkMethodCallback(13,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ReplaceArrayDeviceRequest, ::grpc_cli::ReplaceArrayDeviceResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2589,9 +2688,9 @@ class PosCli final {
     void SetMessageAllocatorFor_ReplaceArrayDevice(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::ReplaceArrayDeviceRequest, ::grpc_cli::ReplaceArrayDeviceResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(12);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(13);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(12);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(13);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ReplaceArrayDeviceRequest, ::grpc_cli::ReplaceArrayDeviceResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2624,7 +2723,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(13,
+        MarkMethodCallback(14,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::CreateArrayRequest, ::grpc_cli::CreateArrayResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2636,9 +2735,9 @@ class PosCli final {
     void SetMessageAllocatorFor_CreateArray(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::CreateArrayRequest, ::grpc_cli::CreateArrayResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(13);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(14);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(13);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(14);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::CreateArrayRequest, ::grpc_cli::CreateArrayResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2671,7 +2770,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(14,
+        MarkMethodCallback(15,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::AutocreateArrayRequest, ::grpc_cli::AutocreateArrayResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2683,9 +2782,9 @@ class PosCli final {
     void SetMessageAllocatorFor_AutocreateArray(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::AutocreateArrayRequest, ::grpc_cli::AutocreateArrayResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(14);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(15);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(14);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(15);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::AutocreateArrayRequest, ::grpc_cli::AutocreateArrayResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2718,7 +2817,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(15,
+        MarkMethodCallback(16,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::DeleteArrayRequest, ::grpc_cli::DeleteArrayResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2730,9 +2829,9 @@ class PosCli final {
     void SetMessageAllocatorFor_DeleteArray(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::DeleteArrayRequest, ::grpc_cli::DeleteArrayResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(15);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(16);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(15);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(16);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::DeleteArrayRequest, ::grpc_cli::DeleteArrayResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2765,7 +2864,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(16,
+        MarkMethodCallback(17,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::MountArrayRequest, ::grpc_cli::MountArrayResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2777,9 +2876,9 @@ class PosCli final {
     void SetMessageAllocatorFor_MountArray(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::MountArrayRequest, ::grpc_cli::MountArrayResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(16);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(17);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(16);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(17);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::MountArrayRequest, ::grpc_cli::MountArrayResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2812,7 +2911,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(17,
+        MarkMethodCallback(18,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::UnmountArrayRequest, ::grpc_cli::UnmountArrayResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2824,9 +2923,9 @@ class PosCli final {
     void SetMessageAllocatorFor_UnmountArray(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::UnmountArrayRequest, ::grpc_cli::UnmountArrayResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(17);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(18);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(17);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(18);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::UnmountArrayRequest, ::grpc_cli::UnmountArrayResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2859,7 +2958,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(18,
+        MarkMethodCallback(19,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ListArrayRequest, ::grpc_cli::ListArrayResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2871,9 +2970,9 @@ class PosCli final {
     void SetMessageAllocatorFor_ListArray(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::ListArrayRequest, ::grpc_cli::ListArrayResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(18);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(19);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(18);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(19);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ListArrayRequest, ::grpc_cli::ListArrayResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2906,7 +3005,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(19,
+        MarkMethodCallback(20,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ArrayInfoRequest, ::grpc_cli::ArrayInfoResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2918,9 +3017,9 @@ class PosCli final {
     void SetMessageAllocatorFor_ArrayInfo(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::ArrayInfoRequest, ::grpc_cli::ArrayInfoResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(19);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(20);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(19);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(20);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ArrayInfoRequest, ::grpc_cli::ArrayInfoResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -2953,7 +3052,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(20,
+        MarkMethodCallback(21,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::SetLogPreferenceRequest, ::grpc_cli::SetLogPreferenceResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -2965,9 +3064,9 @@ class PosCli final {
     void SetMessageAllocatorFor_SetLogPreference(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::SetLogPreferenceRequest, ::grpc_cli::SetLogPreferenceResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(20);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(21);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(20);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(21);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::SetLogPreferenceRequest, ::grpc_cli::SetLogPreferenceResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3000,7 +3099,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(21,
+        MarkMethodCallback(22,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::SetLogLevelRequest, ::grpc_cli::SetLogLevelResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3012,9 +3111,9 @@ class PosCli final {
     void SetMessageAllocatorFor_SetLogLevel(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::SetLogLevelRequest, ::grpc_cli::SetLogLevelResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(21);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(22);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(21);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(22);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::SetLogLevelRequest, ::grpc_cli::SetLogLevelResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3047,7 +3146,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(22,
+        MarkMethodCallback(23,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::LoggerInfoRequest, ::grpc_cli::LoggerInfoResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3059,9 +3158,9 @@ class PosCli final {
     void SetMessageAllocatorFor_LoggerInfo(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::LoggerInfoRequest, ::grpc_cli::LoggerInfoResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(22);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(23);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(22);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(23);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::LoggerInfoRequest, ::grpc_cli::LoggerInfoResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3094,7 +3193,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(23,
+        MarkMethodCallback(24,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::GetLogLevelRequest, ::grpc_cli::GetLogLevelResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3106,9 +3205,9 @@ class PosCli final {
     void SetMessageAllocatorFor_GetLogLevel(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::GetLogLevelRequest, ::grpc_cli::GetLogLevelResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(23);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(24);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(23);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(24);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::GetLogLevelRequest, ::grpc_cli::GetLogLevelResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3141,7 +3240,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(24,
+        MarkMethodCallback(25,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ApplyLogFilterRequest, ::grpc_cli::ApplyLogFilterResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3153,9 +3252,9 @@ class PosCli final {
     void SetMessageAllocatorFor_ApplyLogFilter(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::ApplyLogFilterRequest, ::grpc_cli::ApplyLogFilterResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(24);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(25);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(24);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(25);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ApplyLogFilterRequest, ::grpc_cli::ApplyLogFilterResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3188,7 +3287,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(25,
+        MarkMethodCallback(26,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::CreateDeviceRequest, ::grpc_cli::CreateDeviceResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3200,9 +3299,9 @@ class PosCli final {
     void SetMessageAllocatorFor_CreateDevice(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::CreateDeviceRequest, ::grpc_cli::CreateDeviceResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(25);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(26);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(25);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(26);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::CreateDeviceRequest, ::grpc_cli::CreateDeviceResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3235,7 +3334,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(26,
+        MarkMethodCallback(27,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ScanDeviceRequest, ::grpc_cli::ScanDeviceResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3247,9 +3346,9 @@ class PosCli final {
     void SetMessageAllocatorFor_ScanDevice(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::ScanDeviceRequest, ::grpc_cli::ScanDeviceResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(26);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(27);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(26);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(27);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ScanDeviceRequest, ::grpc_cli::ScanDeviceResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3282,7 +3381,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(27,
+        MarkMethodCallback(28,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ListDeviceRequest, ::grpc_cli::ListDeviceResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3294,9 +3393,9 @@ class PosCli final {
     void SetMessageAllocatorFor_ListDevice(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::ListDeviceRequest, ::grpc_cli::ListDeviceResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(27);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(28);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(27);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(28);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ListDeviceRequest, ::grpc_cli::ListDeviceResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3329,7 +3428,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(28,
+        MarkMethodCallback(29,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::GetSmartLogRequest, ::grpc_cli::GetSmartLogResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3341,9 +3440,9 @@ class PosCli final {
     void SetMessageAllocatorFor_GetSmartLog(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::GetSmartLogRequest, ::grpc_cli::GetSmartLogResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(28);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(29);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(28);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(29);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::GetSmartLogRequest, ::grpc_cli::GetSmartLogResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3376,7 +3475,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(29,
+        MarkMethodCallback(30,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::CreateSubsystemRequest, ::grpc_cli::CreateSubsystemResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3388,9 +3487,9 @@ class PosCli final {
     void SetMessageAllocatorFor_CreateSubsystem(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::CreateSubsystemRequest, ::grpc_cli::CreateSubsystemResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(29);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(30);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(29);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(30);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::CreateSubsystemRequest, ::grpc_cli::CreateSubsystemResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3423,7 +3522,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(30,
+        MarkMethodCallback(31,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::DeleteSubsystemRequest, ::grpc_cli::DeleteSubsystemResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3435,9 +3534,9 @@ class PosCli final {
     void SetMessageAllocatorFor_DeleteSubsystem(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::DeleteSubsystemRequest, ::grpc_cli::DeleteSubsystemResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(30);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(31);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(30);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(31);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::DeleteSubsystemRequest, ::grpc_cli::DeleteSubsystemResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3470,7 +3569,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(31,
+        MarkMethodCallback(32,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::AddListenerRequest, ::grpc_cli::AddListenerResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3482,9 +3581,9 @@ class PosCli final {
     void SetMessageAllocatorFor_AddListener(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::AddListenerRequest, ::grpc_cli::AddListenerResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(31);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(32);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(31);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(32);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::AddListenerRequest, ::grpc_cli::AddListenerResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3517,7 +3616,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(32,
+        MarkMethodCallback(33,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ListSubsystemRequest, ::grpc_cli::ListSubsystemResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3529,9 +3628,9 @@ class PosCli final {
     void SetMessageAllocatorFor_ListSubsystem(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::ListSubsystemRequest, ::grpc_cli::ListSubsystemResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(32);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(33);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(32);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(33);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::ListSubsystemRequest, ::grpc_cli::ListSubsystemResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3564,7 +3663,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(33,
+        MarkMethodCallback(34,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::SubsystemInfoRequest, ::grpc_cli::SubsystemInfoResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3576,9 +3675,9 @@ class PosCli final {
     void SetMessageAllocatorFor_SubsystemInfo(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::SubsystemInfoRequest, ::grpc_cli::SubsystemInfoResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(33);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(34);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(33);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(34);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::SubsystemInfoRequest, ::grpc_cli::SubsystemInfoResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3611,7 +3710,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(34,
+        MarkMethodCallback(35,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::CreateTransportRequest, ::grpc_cli::CreateTransportResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3623,9 +3722,9 @@ class PosCli final {
     void SetMessageAllocatorFor_CreateTransport(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::CreateTransportRequest, ::grpc_cli::CreateTransportResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(34);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(35);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(34);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(35);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::CreateTransportRequest, ::grpc_cli::CreateTransportResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3658,7 +3757,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(35,
+        MarkMethodCallback(36,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::CreateVolumeRequest, ::grpc_cli::CreateVolumeResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3670,9 +3769,9 @@ class PosCli final {
     void SetMessageAllocatorFor_CreateVolume(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::CreateVolumeRequest, ::grpc_cli::CreateVolumeResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(35);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(36);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(35);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(36);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::CreateVolumeRequest, ::grpc_cli::CreateVolumeResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3705,7 +3804,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(36,
+        MarkMethodCallback(37,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc_cli::SetVolumePropertyRequest, ::grpc_cli::SetVolumePropertyResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -3717,9 +3816,9 @@ class PosCli final {
     void SetMessageAllocatorFor_SetVolumeProperty(
         ::grpc::experimental::MessageAllocator< ::grpc_cli::SetVolumePropertyRequest, ::grpc_cli::SetVolumePropertyResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(36);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(37);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(36);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(37);
     #endif
       static_cast<::grpc::internal::CallbackUnaryHandler< ::grpc_cli::SetVolumePropertyRequest, ::grpc_cli::SetVolumePropertyResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -3742,10 +3841,10 @@ class PosCli final {
       { return nullptr; }
   };
   #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-  typedef ExperimentalWithCallbackMethod_SystemInfo<ExperimentalWithCallbackMethod_StopSystem<ExperimentalWithCallbackMethod_GetSystemProperty<ExperimentalWithCallbackMethod_SetSystemProperty<ExperimentalWithCallbackMethod_StartTelemetry<ExperimentalWithCallbackMethod_StopTelemetry<ExperimentalWithCallbackMethod_ResetEventWrr<ExperimentalWithCallbackMethod_ResetMbr<ExperimentalWithCallbackMethod_StopRebuilding<ExperimentalWithCallbackMethod_UpdateEventWrr<ExperimentalWithCallbackMethod_AddSpare<ExperimentalWithCallbackMethod_RemoveSpare<ExperimentalWithCallbackMethod_ReplaceArrayDevice<ExperimentalWithCallbackMethod_CreateArray<ExperimentalWithCallbackMethod_AutocreateArray<ExperimentalWithCallbackMethod_DeleteArray<ExperimentalWithCallbackMethod_MountArray<ExperimentalWithCallbackMethod_UnmountArray<ExperimentalWithCallbackMethod_ListArray<ExperimentalWithCallbackMethod_ArrayInfo<ExperimentalWithCallbackMethod_SetLogPreference<ExperimentalWithCallbackMethod_SetLogLevel<ExperimentalWithCallbackMethod_LoggerInfo<ExperimentalWithCallbackMethod_GetLogLevel<ExperimentalWithCallbackMethod_ApplyLogFilter<ExperimentalWithCallbackMethod_CreateDevice<ExperimentalWithCallbackMethod_ScanDevice<ExperimentalWithCallbackMethod_ListDevice<ExperimentalWithCallbackMethod_GetSmartLog<ExperimentalWithCallbackMethod_CreateSubsystem<ExperimentalWithCallbackMethod_DeleteSubsystem<ExperimentalWithCallbackMethod_AddListener<ExperimentalWithCallbackMethod_ListSubsystem<ExperimentalWithCallbackMethod_SubsystemInfo<ExperimentalWithCallbackMethod_CreateTransport<ExperimentalWithCallbackMethod_CreateVolume<ExperimentalWithCallbackMethod_SetVolumeProperty<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
+  typedef ExperimentalWithCallbackMethod_SystemInfo<ExperimentalWithCallbackMethod_StopSystem<ExperimentalWithCallbackMethod_GetSystemProperty<ExperimentalWithCallbackMethod_SetSystemProperty<ExperimentalWithCallbackMethod_StartTelemetry<ExperimentalWithCallbackMethod_StopTelemetry<ExperimentalWithCallbackMethod_SetTelemetryProperty<ExperimentalWithCallbackMethod_ResetEventWrr<ExperimentalWithCallbackMethod_ResetMbr<ExperimentalWithCallbackMethod_StopRebuilding<ExperimentalWithCallbackMethod_UpdateEventWrr<ExperimentalWithCallbackMethod_AddSpare<ExperimentalWithCallbackMethod_RemoveSpare<ExperimentalWithCallbackMethod_ReplaceArrayDevice<ExperimentalWithCallbackMethod_CreateArray<ExperimentalWithCallbackMethod_AutocreateArray<ExperimentalWithCallbackMethod_DeleteArray<ExperimentalWithCallbackMethod_MountArray<ExperimentalWithCallbackMethod_UnmountArray<ExperimentalWithCallbackMethod_ListArray<ExperimentalWithCallbackMethod_ArrayInfo<ExperimentalWithCallbackMethod_SetLogPreference<ExperimentalWithCallbackMethod_SetLogLevel<ExperimentalWithCallbackMethod_LoggerInfo<ExperimentalWithCallbackMethod_GetLogLevel<ExperimentalWithCallbackMethod_ApplyLogFilter<ExperimentalWithCallbackMethod_CreateDevice<ExperimentalWithCallbackMethod_ScanDevice<ExperimentalWithCallbackMethod_ListDevice<ExperimentalWithCallbackMethod_GetSmartLog<ExperimentalWithCallbackMethod_CreateSubsystem<ExperimentalWithCallbackMethod_DeleteSubsystem<ExperimentalWithCallbackMethod_AddListener<ExperimentalWithCallbackMethod_ListSubsystem<ExperimentalWithCallbackMethod_SubsystemInfo<ExperimentalWithCallbackMethod_CreateTransport<ExperimentalWithCallbackMethod_CreateVolume<ExperimentalWithCallbackMethod_SetVolumeProperty<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > CallbackService;
   #endif
 
-  typedef ExperimentalWithCallbackMethod_SystemInfo<ExperimentalWithCallbackMethod_StopSystem<ExperimentalWithCallbackMethod_GetSystemProperty<ExperimentalWithCallbackMethod_SetSystemProperty<ExperimentalWithCallbackMethod_StartTelemetry<ExperimentalWithCallbackMethod_StopTelemetry<ExperimentalWithCallbackMethod_ResetEventWrr<ExperimentalWithCallbackMethod_ResetMbr<ExperimentalWithCallbackMethod_StopRebuilding<ExperimentalWithCallbackMethod_UpdateEventWrr<ExperimentalWithCallbackMethod_AddSpare<ExperimentalWithCallbackMethod_RemoveSpare<ExperimentalWithCallbackMethod_ReplaceArrayDevice<ExperimentalWithCallbackMethod_CreateArray<ExperimentalWithCallbackMethod_AutocreateArray<ExperimentalWithCallbackMethod_DeleteArray<ExperimentalWithCallbackMethod_MountArray<ExperimentalWithCallbackMethod_UnmountArray<ExperimentalWithCallbackMethod_ListArray<ExperimentalWithCallbackMethod_ArrayInfo<ExperimentalWithCallbackMethod_SetLogPreference<ExperimentalWithCallbackMethod_SetLogLevel<ExperimentalWithCallbackMethod_LoggerInfo<ExperimentalWithCallbackMethod_GetLogLevel<ExperimentalWithCallbackMethod_ApplyLogFilter<ExperimentalWithCallbackMethod_CreateDevice<ExperimentalWithCallbackMethod_ScanDevice<ExperimentalWithCallbackMethod_ListDevice<ExperimentalWithCallbackMethod_GetSmartLog<ExperimentalWithCallbackMethod_CreateSubsystem<ExperimentalWithCallbackMethod_DeleteSubsystem<ExperimentalWithCallbackMethod_AddListener<ExperimentalWithCallbackMethod_ListSubsystem<ExperimentalWithCallbackMethod_SubsystemInfo<ExperimentalWithCallbackMethod_CreateTransport<ExperimentalWithCallbackMethod_CreateVolume<ExperimentalWithCallbackMethod_SetVolumeProperty<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > ExperimentalCallbackService;
+  typedef ExperimentalWithCallbackMethod_SystemInfo<ExperimentalWithCallbackMethod_StopSystem<ExperimentalWithCallbackMethod_GetSystemProperty<ExperimentalWithCallbackMethod_SetSystemProperty<ExperimentalWithCallbackMethod_StartTelemetry<ExperimentalWithCallbackMethod_StopTelemetry<ExperimentalWithCallbackMethod_SetTelemetryProperty<ExperimentalWithCallbackMethod_ResetEventWrr<ExperimentalWithCallbackMethod_ResetMbr<ExperimentalWithCallbackMethod_StopRebuilding<ExperimentalWithCallbackMethod_UpdateEventWrr<ExperimentalWithCallbackMethod_AddSpare<ExperimentalWithCallbackMethod_RemoveSpare<ExperimentalWithCallbackMethod_ReplaceArrayDevice<ExperimentalWithCallbackMethod_CreateArray<ExperimentalWithCallbackMethod_AutocreateArray<ExperimentalWithCallbackMethod_DeleteArray<ExperimentalWithCallbackMethod_MountArray<ExperimentalWithCallbackMethod_UnmountArray<ExperimentalWithCallbackMethod_ListArray<ExperimentalWithCallbackMethod_ArrayInfo<ExperimentalWithCallbackMethod_SetLogPreference<ExperimentalWithCallbackMethod_SetLogLevel<ExperimentalWithCallbackMethod_LoggerInfo<ExperimentalWithCallbackMethod_GetLogLevel<ExperimentalWithCallbackMethod_ApplyLogFilter<ExperimentalWithCallbackMethod_CreateDevice<ExperimentalWithCallbackMethod_ScanDevice<ExperimentalWithCallbackMethod_ListDevice<ExperimentalWithCallbackMethod_GetSmartLog<ExperimentalWithCallbackMethod_CreateSubsystem<ExperimentalWithCallbackMethod_DeleteSubsystem<ExperimentalWithCallbackMethod_AddListener<ExperimentalWithCallbackMethod_ListSubsystem<ExperimentalWithCallbackMethod_SubsystemInfo<ExperimentalWithCallbackMethod_CreateTransport<ExperimentalWithCallbackMethod_CreateVolume<ExperimentalWithCallbackMethod_SetVolumeProperty<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_SystemInfo : public BaseClass {
    private:
@@ -3849,12 +3948,29 @@ class PosCli final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_SetTelemetryProperty : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_SetTelemetryProperty() {
+      ::grpc::Service::MarkMethodGeneric(6);
+    }
+    ~WithGenericMethod_SetTelemetryProperty() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetTelemetryProperty(::grpc::ServerContext* /*context*/, const ::grpc_cli::SetTelemetryPropertyRequest* /*request*/, ::grpc_cli::SetTelemetryPropertyResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_ResetEventWrr : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ResetEventWrr() {
-      ::grpc::Service::MarkMethodGeneric(6);
+      ::grpc::Service::MarkMethodGeneric(7);
     }
     ~WithGenericMethod_ResetEventWrr() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3871,7 +3987,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ResetMbr() {
-      ::grpc::Service::MarkMethodGeneric(7);
+      ::grpc::Service::MarkMethodGeneric(8);
     }
     ~WithGenericMethod_ResetMbr() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3888,7 +4004,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_StopRebuilding() {
-      ::grpc::Service::MarkMethodGeneric(8);
+      ::grpc::Service::MarkMethodGeneric(9);
     }
     ~WithGenericMethod_StopRebuilding() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3905,7 +4021,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_UpdateEventWrr() {
-      ::grpc::Service::MarkMethodGeneric(9);
+      ::grpc::Service::MarkMethodGeneric(10);
     }
     ~WithGenericMethod_UpdateEventWrr() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3922,7 +4038,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_AddSpare() {
-      ::grpc::Service::MarkMethodGeneric(10);
+      ::grpc::Service::MarkMethodGeneric(11);
     }
     ~WithGenericMethod_AddSpare() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3939,7 +4055,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_RemoveSpare() {
-      ::grpc::Service::MarkMethodGeneric(11);
+      ::grpc::Service::MarkMethodGeneric(12);
     }
     ~WithGenericMethod_RemoveSpare() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3956,7 +4072,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ReplaceArrayDevice() {
-      ::grpc::Service::MarkMethodGeneric(12);
+      ::grpc::Service::MarkMethodGeneric(13);
     }
     ~WithGenericMethod_ReplaceArrayDevice() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3973,7 +4089,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_CreateArray() {
-      ::grpc::Service::MarkMethodGeneric(13);
+      ::grpc::Service::MarkMethodGeneric(14);
     }
     ~WithGenericMethod_CreateArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -3990,7 +4106,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_AutocreateArray() {
-      ::grpc::Service::MarkMethodGeneric(14);
+      ::grpc::Service::MarkMethodGeneric(15);
     }
     ~WithGenericMethod_AutocreateArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4007,7 +4123,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_DeleteArray() {
-      ::grpc::Service::MarkMethodGeneric(15);
+      ::grpc::Service::MarkMethodGeneric(16);
     }
     ~WithGenericMethod_DeleteArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4024,7 +4140,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_MountArray() {
-      ::grpc::Service::MarkMethodGeneric(16);
+      ::grpc::Service::MarkMethodGeneric(17);
     }
     ~WithGenericMethod_MountArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4041,7 +4157,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_UnmountArray() {
-      ::grpc::Service::MarkMethodGeneric(17);
+      ::grpc::Service::MarkMethodGeneric(18);
     }
     ~WithGenericMethod_UnmountArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4058,7 +4174,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ListArray() {
-      ::grpc::Service::MarkMethodGeneric(18);
+      ::grpc::Service::MarkMethodGeneric(19);
     }
     ~WithGenericMethod_ListArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4075,7 +4191,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ArrayInfo() {
-      ::grpc::Service::MarkMethodGeneric(19);
+      ::grpc::Service::MarkMethodGeneric(20);
     }
     ~WithGenericMethod_ArrayInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4092,7 +4208,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetLogPreference() {
-      ::grpc::Service::MarkMethodGeneric(20);
+      ::grpc::Service::MarkMethodGeneric(21);
     }
     ~WithGenericMethod_SetLogPreference() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4109,7 +4225,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetLogLevel() {
-      ::grpc::Service::MarkMethodGeneric(21);
+      ::grpc::Service::MarkMethodGeneric(22);
     }
     ~WithGenericMethod_SetLogLevel() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4126,7 +4242,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_LoggerInfo() {
-      ::grpc::Service::MarkMethodGeneric(22);
+      ::grpc::Service::MarkMethodGeneric(23);
     }
     ~WithGenericMethod_LoggerInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4143,7 +4259,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetLogLevel() {
-      ::grpc::Service::MarkMethodGeneric(23);
+      ::grpc::Service::MarkMethodGeneric(24);
     }
     ~WithGenericMethod_GetLogLevel() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4160,7 +4276,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ApplyLogFilter() {
-      ::grpc::Service::MarkMethodGeneric(24);
+      ::grpc::Service::MarkMethodGeneric(25);
     }
     ~WithGenericMethod_ApplyLogFilter() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4177,7 +4293,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_CreateDevice() {
-      ::grpc::Service::MarkMethodGeneric(25);
+      ::grpc::Service::MarkMethodGeneric(26);
     }
     ~WithGenericMethod_CreateDevice() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4194,7 +4310,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ScanDevice() {
-      ::grpc::Service::MarkMethodGeneric(26);
+      ::grpc::Service::MarkMethodGeneric(27);
     }
     ~WithGenericMethod_ScanDevice() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4211,7 +4327,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ListDevice() {
-      ::grpc::Service::MarkMethodGeneric(27);
+      ::grpc::Service::MarkMethodGeneric(28);
     }
     ~WithGenericMethod_ListDevice() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4228,7 +4344,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_GetSmartLog() {
-      ::grpc::Service::MarkMethodGeneric(28);
+      ::grpc::Service::MarkMethodGeneric(29);
     }
     ~WithGenericMethod_GetSmartLog() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4245,7 +4361,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_CreateSubsystem() {
-      ::grpc::Service::MarkMethodGeneric(29);
+      ::grpc::Service::MarkMethodGeneric(30);
     }
     ~WithGenericMethod_CreateSubsystem() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4262,7 +4378,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_DeleteSubsystem() {
-      ::grpc::Service::MarkMethodGeneric(30);
+      ::grpc::Service::MarkMethodGeneric(31);
     }
     ~WithGenericMethod_DeleteSubsystem() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4279,7 +4395,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_AddListener() {
-      ::grpc::Service::MarkMethodGeneric(31);
+      ::grpc::Service::MarkMethodGeneric(32);
     }
     ~WithGenericMethod_AddListener() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4296,7 +4412,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_ListSubsystem() {
-      ::grpc::Service::MarkMethodGeneric(32);
+      ::grpc::Service::MarkMethodGeneric(33);
     }
     ~WithGenericMethod_ListSubsystem() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4313,7 +4429,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SubsystemInfo() {
-      ::grpc::Service::MarkMethodGeneric(33);
+      ::grpc::Service::MarkMethodGeneric(34);
     }
     ~WithGenericMethod_SubsystemInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4330,7 +4446,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_CreateTransport() {
-      ::grpc::Service::MarkMethodGeneric(34);
+      ::grpc::Service::MarkMethodGeneric(35);
     }
     ~WithGenericMethod_CreateTransport() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4347,7 +4463,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_CreateVolume() {
-      ::grpc::Service::MarkMethodGeneric(35);
+      ::grpc::Service::MarkMethodGeneric(36);
     }
     ~WithGenericMethod_CreateVolume() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4364,7 +4480,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_SetVolumeProperty() {
-      ::grpc::Service::MarkMethodGeneric(36);
+      ::grpc::Service::MarkMethodGeneric(37);
     }
     ~WithGenericMethod_SetVolumeProperty() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4496,12 +4612,32 @@ class PosCli final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_SetTelemetryProperty : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_SetTelemetryProperty() {
+      ::grpc::Service::MarkMethodRaw(6);
+    }
+    ~WithRawMethod_SetTelemetryProperty() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetTelemetryProperty(::grpc::ServerContext* /*context*/, const ::grpc_cli::SetTelemetryPropertyRequest* /*request*/, ::grpc_cli::SetTelemetryPropertyResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSetTelemetryProperty(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_ResetEventWrr : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ResetEventWrr() {
-      ::grpc::Service::MarkMethodRaw(6);
+      ::grpc::Service::MarkMethodRaw(7);
     }
     ~WithRawMethod_ResetEventWrr() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4512,7 +4648,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestResetEventWrr(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(6, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4521,7 +4657,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ResetMbr() {
-      ::grpc::Service::MarkMethodRaw(7);
+      ::grpc::Service::MarkMethodRaw(8);
     }
     ~WithRawMethod_ResetMbr() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4532,7 +4668,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestResetMbr(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(7, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4541,7 +4677,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_StopRebuilding() {
-      ::grpc::Service::MarkMethodRaw(8);
+      ::grpc::Service::MarkMethodRaw(9);
     }
     ~WithRawMethod_StopRebuilding() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4552,7 +4688,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestStopRebuilding(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(8, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4561,7 +4697,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_UpdateEventWrr() {
-      ::grpc::Service::MarkMethodRaw(9);
+      ::grpc::Service::MarkMethodRaw(10);
     }
     ~WithRawMethod_UpdateEventWrr() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4572,7 +4708,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestUpdateEventWrr(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(9, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4581,7 +4717,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_AddSpare() {
-      ::grpc::Service::MarkMethodRaw(10);
+      ::grpc::Service::MarkMethodRaw(11);
     }
     ~WithRawMethod_AddSpare() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4592,7 +4728,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestAddSpare(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(10, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4601,7 +4737,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_RemoveSpare() {
-      ::grpc::Service::MarkMethodRaw(11);
+      ::grpc::Service::MarkMethodRaw(12);
     }
     ~WithRawMethod_RemoveSpare() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4612,7 +4748,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestRemoveSpare(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(11, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4621,7 +4757,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ReplaceArrayDevice() {
-      ::grpc::Service::MarkMethodRaw(12);
+      ::grpc::Service::MarkMethodRaw(13);
     }
     ~WithRawMethod_ReplaceArrayDevice() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4632,7 +4768,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestReplaceArrayDevice(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(12, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4641,7 +4777,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_CreateArray() {
-      ::grpc::Service::MarkMethodRaw(13);
+      ::grpc::Service::MarkMethodRaw(14);
     }
     ~WithRawMethod_CreateArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4652,7 +4788,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCreateArray(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(13, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4661,7 +4797,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_AutocreateArray() {
-      ::grpc::Service::MarkMethodRaw(14);
+      ::grpc::Service::MarkMethodRaw(15);
     }
     ~WithRawMethod_AutocreateArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4672,7 +4808,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestAutocreateArray(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(14, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4681,7 +4817,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_DeleteArray() {
-      ::grpc::Service::MarkMethodRaw(15);
+      ::grpc::Service::MarkMethodRaw(16);
     }
     ~WithRawMethod_DeleteArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4692,7 +4828,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestDeleteArray(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(15, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4701,7 +4837,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_MountArray() {
-      ::grpc::Service::MarkMethodRaw(16);
+      ::grpc::Service::MarkMethodRaw(17);
     }
     ~WithRawMethod_MountArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4712,7 +4848,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestMountArray(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(16, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4721,7 +4857,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_UnmountArray() {
-      ::grpc::Service::MarkMethodRaw(17);
+      ::grpc::Service::MarkMethodRaw(18);
     }
     ~WithRawMethod_UnmountArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4732,7 +4868,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestUnmountArray(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(17, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4741,7 +4877,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ListArray() {
-      ::grpc::Service::MarkMethodRaw(18);
+      ::grpc::Service::MarkMethodRaw(19);
     }
     ~WithRawMethod_ListArray() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4752,7 +4888,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestListArray(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(18, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4761,7 +4897,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ArrayInfo() {
-      ::grpc::Service::MarkMethodRaw(19);
+      ::grpc::Service::MarkMethodRaw(20);
     }
     ~WithRawMethod_ArrayInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4772,7 +4908,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestArrayInfo(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(19, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(20, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4781,7 +4917,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetLogPreference() {
-      ::grpc::Service::MarkMethodRaw(20);
+      ::grpc::Service::MarkMethodRaw(21);
     }
     ~WithRawMethod_SetLogPreference() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4792,7 +4928,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetLogPreference(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(20, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(21, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4801,7 +4937,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetLogLevel() {
-      ::grpc::Service::MarkMethodRaw(21);
+      ::grpc::Service::MarkMethodRaw(22);
     }
     ~WithRawMethod_SetLogLevel() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4812,7 +4948,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetLogLevel(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(21, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(22, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4821,7 +4957,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_LoggerInfo() {
-      ::grpc::Service::MarkMethodRaw(22);
+      ::grpc::Service::MarkMethodRaw(23);
     }
     ~WithRawMethod_LoggerInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4832,7 +4968,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestLoggerInfo(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(22, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(23, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4841,7 +4977,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetLogLevel() {
-      ::grpc::Service::MarkMethodRaw(23);
+      ::grpc::Service::MarkMethodRaw(24);
     }
     ~WithRawMethod_GetLogLevel() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4852,7 +4988,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetLogLevel(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(23, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(24, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4861,7 +4997,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ApplyLogFilter() {
-      ::grpc::Service::MarkMethodRaw(24);
+      ::grpc::Service::MarkMethodRaw(25);
     }
     ~WithRawMethod_ApplyLogFilter() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4872,7 +5008,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestApplyLogFilter(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(24, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(25, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4881,7 +5017,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_CreateDevice() {
-      ::grpc::Service::MarkMethodRaw(25);
+      ::grpc::Service::MarkMethodRaw(26);
     }
     ~WithRawMethod_CreateDevice() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4892,7 +5028,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCreateDevice(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(25, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(26, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4901,7 +5037,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ScanDevice() {
-      ::grpc::Service::MarkMethodRaw(26);
+      ::grpc::Service::MarkMethodRaw(27);
     }
     ~WithRawMethod_ScanDevice() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4912,7 +5048,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestScanDevice(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(26, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(27, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4921,7 +5057,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ListDevice() {
-      ::grpc::Service::MarkMethodRaw(27);
+      ::grpc::Service::MarkMethodRaw(28);
     }
     ~WithRawMethod_ListDevice() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4932,7 +5068,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestListDevice(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(27, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(28, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4941,7 +5077,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_GetSmartLog() {
-      ::grpc::Service::MarkMethodRaw(28);
+      ::grpc::Service::MarkMethodRaw(29);
     }
     ~WithRawMethod_GetSmartLog() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4952,7 +5088,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestGetSmartLog(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(28, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(29, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4961,7 +5097,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_CreateSubsystem() {
-      ::grpc::Service::MarkMethodRaw(29);
+      ::grpc::Service::MarkMethodRaw(30);
     }
     ~WithRawMethod_CreateSubsystem() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4972,7 +5108,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCreateSubsystem(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(29, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(30, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -4981,7 +5117,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_DeleteSubsystem() {
-      ::grpc::Service::MarkMethodRaw(30);
+      ::grpc::Service::MarkMethodRaw(31);
     }
     ~WithRawMethod_DeleteSubsystem() override {
       BaseClassMustBeDerivedFromService(this);
@@ -4992,7 +5128,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestDeleteSubsystem(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(30, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(31, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5001,7 +5137,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_AddListener() {
-      ::grpc::Service::MarkMethodRaw(31);
+      ::grpc::Service::MarkMethodRaw(32);
     }
     ~WithRawMethod_AddListener() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5012,7 +5148,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestAddListener(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(31, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5021,7 +5157,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_ListSubsystem() {
-      ::grpc::Service::MarkMethodRaw(32);
+      ::grpc::Service::MarkMethodRaw(33);
     }
     ~WithRawMethod_ListSubsystem() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5032,7 +5168,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestListSubsystem(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(32, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(33, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5041,7 +5177,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SubsystemInfo() {
-      ::grpc::Service::MarkMethodRaw(33);
+      ::grpc::Service::MarkMethodRaw(34);
     }
     ~WithRawMethod_SubsystemInfo() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5052,7 +5188,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSubsystemInfo(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(33, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5061,7 +5197,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_CreateTransport() {
-      ::grpc::Service::MarkMethodRaw(34);
+      ::grpc::Service::MarkMethodRaw(35);
     }
     ~WithRawMethod_CreateTransport() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5072,7 +5208,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCreateTransport(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(34, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(35, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5081,7 +5217,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_CreateVolume() {
-      ::grpc::Service::MarkMethodRaw(35);
+      ::grpc::Service::MarkMethodRaw(36);
     }
     ~WithRawMethod_CreateVolume() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5092,7 +5228,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCreateVolume(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(35, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5101,7 +5237,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_SetVolumeProperty() {
-      ::grpc::Service::MarkMethodRaw(36);
+      ::grpc::Service::MarkMethodRaw(37);
     }
     ~WithRawMethod_SetVolumeProperty() override {
       BaseClassMustBeDerivedFromService(this);
@@ -5112,7 +5248,7 @@ class PosCli final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestSetVolumeProperty(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(36, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(37, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -5344,6 +5480,44 @@ class PosCli final {
       { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithRawCallbackMethod_SetTelemetryProperty : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithRawCallbackMethod_SetTelemetryProperty() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodRawCallback(6,
+          new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->SetTelemetryProperty(context, request, response); }));
+    }
+    ~ExperimentalWithRawCallbackMethod_SetTelemetryProperty() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SetTelemetryProperty(::grpc::ServerContext* /*context*/, const ::grpc_cli::SetTelemetryPropertyRequest* /*request*/, ::grpc_cli::SetTelemetryPropertyResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* SetTelemetryProperty(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* SetTelemetryProperty(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithRawCallbackMethod_ResetEventWrr : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -5354,7 +5528,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(6,
+        MarkMethodRawCallback(7,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5392,7 +5566,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(7,
+        MarkMethodRawCallback(8,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5430,7 +5604,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(8,
+        MarkMethodRawCallback(9,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5468,7 +5642,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(9,
+        MarkMethodRawCallback(10,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5506,7 +5680,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(10,
+        MarkMethodRawCallback(11,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5544,7 +5718,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(11,
+        MarkMethodRawCallback(12,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5582,7 +5756,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(12,
+        MarkMethodRawCallback(13,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5620,7 +5794,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(13,
+        MarkMethodRawCallback(14,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5658,7 +5832,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(14,
+        MarkMethodRawCallback(15,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5696,7 +5870,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(15,
+        MarkMethodRawCallback(16,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5734,7 +5908,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(16,
+        MarkMethodRawCallback(17,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5772,7 +5946,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(17,
+        MarkMethodRawCallback(18,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5810,7 +5984,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(18,
+        MarkMethodRawCallback(19,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5848,7 +6022,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(19,
+        MarkMethodRawCallback(20,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5886,7 +6060,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(20,
+        MarkMethodRawCallback(21,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5924,7 +6098,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(21,
+        MarkMethodRawCallback(22,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -5962,7 +6136,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(22,
+        MarkMethodRawCallback(23,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6000,7 +6174,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(23,
+        MarkMethodRawCallback(24,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6038,7 +6212,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(24,
+        MarkMethodRawCallback(25,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6076,7 +6250,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(25,
+        MarkMethodRawCallback(26,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6114,7 +6288,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(26,
+        MarkMethodRawCallback(27,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6152,7 +6326,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(27,
+        MarkMethodRawCallback(28,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6190,7 +6364,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(28,
+        MarkMethodRawCallback(29,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6228,7 +6402,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(29,
+        MarkMethodRawCallback(30,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6266,7 +6440,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(30,
+        MarkMethodRawCallback(31,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6304,7 +6478,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(31,
+        MarkMethodRawCallback(32,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6342,7 +6516,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(32,
+        MarkMethodRawCallback(33,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6380,7 +6554,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(33,
+        MarkMethodRawCallback(34,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6418,7 +6592,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(34,
+        MarkMethodRawCallback(35,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6456,7 +6630,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(35,
+        MarkMethodRawCallback(36,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6494,7 +6668,7 @@ class PosCli final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(36,
+        MarkMethodRawCallback(37,
           new ::grpc::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -6684,12 +6858,39 @@ class PosCli final {
     virtual ::grpc::Status StreamedStopTelemetry(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_cli::StopTelemetryRequest,::grpc_cli::StopTelemetryResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_SetTelemetryProperty : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_SetTelemetryProperty() {
+      ::grpc::Service::MarkMethodStreamed(6,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::grpc_cli::SetTelemetryPropertyRequest, ::grpc_cli::SetTelemetryPropertyResponse>(
+            [this](::grpc::ServerContext* context,
+                   ::grpc::ServerUnaryStreamer<
+                     ::grpc_cli::SetTelemetryPropertyRequest, ::grpc_cli::SetTelemetryPropertyResponse>* streamer) {
+                       return this->StreamedSetTelemetryProperty(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_SetTelemetryProperty() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SetTelemetryProperty(::grpc::ServerContext* /*context*/, const ::grpc_cli::SetTelemetryPropertyRequest* /*request*/, ::grpc_cli::SetTelemetryPropertyResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSetTelemetryProperty(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_cli::SetTelemetryPropertyRequest,::grpc_cli::SetTelemetryPropertyResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_ResetEventWrr : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ResetEventWrr() {
-      ::grpc::Service::MarkMethodStreamed(6,
+      ::grpc::Service::MarkMethodStreamed(7,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::ResetEventWrrRequest, ::grpc_cli::ResetEventWrrResponse>(
             [this](::grpc::ServerContext* context,
@@ -6716,7 +6917,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ResetMbr() {
-      ::grpc::Service::MarkMethodStreamed(7,
+      ::grpc::Service::MarkMethodStreamed(8,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::ResetMbrRequest, ::grpc_cli::ResetMbrResponse>(
             [this](::grpc::ServerContext* context,
@@ -6743,7 +6944,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_StopRebuilding() {
-      ::grpc::Service::MarkMethodStreamed(8,
+      ::grpc::Service::MarkMethodStreamed(9,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::StopRebuildingRequest, ::grpc_cli::StopRebuildingResponse>(
             [this](::grpc::ServerContext* context,
@@ -6770,7 +6971,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_UpdateEventWrr() {
-      ::grpc::Service::MarkMethodStreamed(9,
+      ::grpc::Service::MarkMethodStreamed(10,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::UpdateEventWrrRequest, ::grpc_cli::UpdateEventWrrResponse>(
             [this](::grpc::ServerContext* context,
@@ -6797,7 +6998,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_AddSpare() {
-      ::grpc::Service::MarkMethodStreamed(10,
+      ::grpc::Service::MarkMethodStreamed(11,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::AddSpareRequest, ::grpc_cli::AddSpareResponse>(
             [this](::grpc::ServerContext* context,
@@ -6824,7 +7025,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_RemoveSpare() {
-      ::grpc::Service::MarkMethodStreamed(11,
+      ::grpc::Service::MarkMethodStreamed(12,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::RemoveSpareRequest, ::grpc_cli::RemoveSpareResponse>(
             [this](::grpc::ServerContext* context,
@@ -6851,7 +7052,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ReplaceArrayDevice() {
-      ::grpc::Service::MarkMethodStreamed(12,
+      ::grpc::Service::MarkMethodStreamed(13,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::ReplaceArrayDeviceRequest, ::grpc_cli::ReplaceArrayDeviceResponse>(
             [this](::grpc::ServerContext* context,
@@ -6878,7 +7079,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_CreateArray() {
-      ::grpc::Service::MarkMethodStreamed(13,
+      ::grpc::Service::MarkMethodStreamed(14,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::CreateArrayRequest, ::grpc_cli::CreateArrayResponse>(
             [this](::grpc::ServerContext* context,
@@ -6905,7 +7106,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_AutocreateArray() {
-      ::grpc::Service::MarkMethodStreamed(14,
+      ::grpc::Service::MarkMethodStreamed(15,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::AutocreateArrayRequest, ::grpc_cli::AutocreateArrayResponse>(
             [this](::grpc::ServerContext* context,
@@ -6932,7 +7133,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_DeleteArray() {
-      ::grpc::Service::MarkMethodStreamed(15,
+      ::grpc::Service::MarkMethodStreamed(16,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::DeleteArrayRequest, ::grpc_cli::DeleteArrayResponse>(
             [this](::grpc::ServerContext* context,
@@ -6959,7 +7160,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_MountArray() {
-      ::grpc::Service::MarkMethodStreamed(16,
+      ::grpc::Service::MarkMethodStreamed(17,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::MountArrayRequest, ::grpc_cli::MountArrayResponse>(
             [this](::grpc::ServerContext* context,
@@ -6986,7 +7187,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_UnmountArray() {
-      ::grpc::Service::MarkMethodStreamed(17,
+      ::grpc::Service::MarkMethodStreamed(18,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::UnmountArrayRequest, ::grpc_cli::UnmountArrayResponse>(
             [this](::grpc::ServerContext* context,
@@ -7013,7 +7214,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ListArray() {
-      ::grpc::Service::MarkMethodStreamed(18,
+      ::grpc::Service::MarkMethodStreamed(19,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::ListArrayRequest, ::grpc_cli::ListArrayResponse>(
             [this](::grpc::ServerContext* context,
@@ -7040,7 +7241,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ArrayInfo() {
-      ::grpc::Service::MarkMethodStreamed(19,
+      ::grpc::Service::MarkMethodStreamed(20,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::ArrayInfoRequest, ::grpc_cli::ArrayInfoResponse>(
             [this](::grpc::ServerContext* context,
@@ -7067,7 +7268,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetLogPreference() {
-      ::grpc::Service::MarkMethodStreamed(20,
+      ::grpc::Service::MarkMethodStreamed(21,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::SetLogPreferenceRequest, ::grpc_cli::SetLogPreferenceResponse>(
             [this](::grpc::ServerContext* context,
@@ -7094,7 +7295,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetLogLevel() {
-      ::grpc::Service::MarkMethodStreamed(21,
+      ::grpc::Service::MarkMethodStreamed(22,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::SetLogLevelRequest, ::grpc_cli::SetLogLevelResponse>(
             [this](::grpc::ServerContext* context,
@@ -7121,7 +7322,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_LoggerInfo() {
-      ::grpc::Service::MarkMethodStreamed(22,
+      ::grpc::Service::MarkMethodStreamed(23,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::LoggerInfoRequest, ::grpc_cli::LoggerInfoResponse>(
             [this](::grpc::ServerContext* context,
@@ -7148,7 +7349,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetLogLevel() {
-      ::grpc::Service::MarkMethodStreamed(23,
+      ::grpc::Service::MarkMethodStreamed(24,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::GetLogLevelRequest, ::grpc_cli::GetLogLevelResponse>(
             [this](::grpc::ServerContext* context,
@@ -7175,7 +7376,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ApplyLogFilter() {
-      ::grpc::Service::MarkMethodStreamed(24,
+      ::grpc::Service::MarkMethodStreamed(25,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::ApplyLogFilterRequest, ::grpc_cli::ApplyLogFilterResponse>(
             [this](::grpc::ServerContext* context,
@@ -7202,7 +7403,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_CreateDevice() {
-      ::grpc::Service::MarkMethodStreamed(25,
+      ::grpc::Service::MarkMethodStreamed(26,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::CreateDeviceRequest, ::grpc_cli::CreateDeviceResponse>(
             [this](::grpc::ServerContext* context,
@@ -7229,7 +7430,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ScanDevice() {
-      ::grpc::Service::MarkMethodStreamed(26,
+      ::grpc::Service::MarkMethodStreamed(27,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::ScanDeviceRequest, ::grpc_cli::ScanDeviceResponse>(
             [this](::grpc::ServerContext* context,
@@ -7256,7 +7457,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ListDevice() {
-      ::grpc::Service::MarkMethodStreamed(27,
+      ::grpc::Service::MarkMethodStreamed(28,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::ListDeviceRequest, ::grpc_cli::ListDeviceResponse>(
             [this](::grpc::ServerContext* context,
@@ -7283,7 +7484,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_GetSmartLog() {
-      ::grpc::Service::MarkMethodStreamed(28,
+      ::grpc::Service::MarkMethodStreamed(29,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::GetSmartLogRequest, ::grpc_cli::GetSmartLogResponse>(
             [this](::grpc::ServerContext* context,
@@ -7310,7 +7511,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_CreateSubsystem() {
-      ::grpc::Service::MarkMethodStreamed(29,
+      ::grpc::Service::MarkMethodStreamed(30,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::CreateSubsystemRequest, ::grpc_cli::CreateSubsystemResponse>(
             [this](::grpc::ServerContext* context,
@@ -7337,7 +7538,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_DeleteSubsystem() {
-      ::grpc::Service::MarkMethodStreamed(30,
+      ::grpc::Service::MarkMethodStreamed(31,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::DeleteSubsystemRequest, ::grpc_cli::DeleteSubsystemResponse>(
             [this](::grpc::ServerContext* context,
@@ -7364,7 +7565,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_AddListener() {
-      ::grpc::Service::MarkMethodStreamed(31,
+      ::grpc::Service::MarkMethodStreamed(32,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::AddListenerRequest, ::grpc_cli::AddListenerResponse>(
             [this](::grpc::ServerContext* context,
@@ -7391,7 +7592,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_ListSubsystem() {
-      ::grpc::Service::MarkMethodStreamed(32,
+      ::grpc::Service::MarkMethodStreamed(33,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::ListSubsystemRequest, ::grpc_cli::ListSubsystemResponse>(
             [this](::grpc::ServerContext* context,
@@ -7418,7 +7619,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SubsystemInfo() {
-      ::grpc::Service::MarkMethodStreamed(33,
+      ::grpc::Service::MarkMethodStreamed(34,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::SubsystemInfoRequest, ::grpc_cli::SubsystemInfoResponse>(
             [this](::grpc::ServerContext* context,
@@ -7445,7 +7646,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_CreateTransport() {
-      ::grpc::Service::MarkMethodStreamed(34,
+      ::grpc::Service::MarkMethodStreamed(35,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::CreateTransportRequest, ::grpc_cli::CreateTransportResponse>(
             [this](::grpc::ServerContext* context,
@@ -7472,7 +7673,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_CreateVolume() {
-      ::grpc::Service::MarkMethodStreamed(35,
+      ::grpc::Service::MarkMethodStreamed(36,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::CreateVolumeRequest, ::grpc_cli::CreateVolumeResponse>(
             [this](::grpc::ServerContext* context,
@@ -7499,7 +7700,7 @@ class PosCli final {
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_SetVolumeProperty() {
-      ::grpc::Service::MarkMethodStreamed(36,
+      ::grpc::Service::MarkMethodStreamed(37,
         new ::grpc::internal::StreamedUnaryHandler<
           ::grpc_cli::SetVolumePropertyRequest, ::grpc_cli::SetVolumePropertyResponse>(
             [this](::grpc::ServerContext* context,
@@ -7520,9 +7721,9 @@ class PosCli final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedSetVolumeProperty(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_cli::SetVolumePropertyRequest,::grpc_cli::SetVolumePropertyResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_SystemInfo<WithStreamedUnaryMethod_StopSystem<WithStreamedUnaryMethod_GetSystemProperty<WithStreamedUnaryMethod_SetSystemProperty<WithStreamedUnaryMethod_StartTelemetry<WithStreamedUnaryMethod_StopTelemetry<WithStreamedUnaryMethod_ResetEventWrr<WithStreamedUnaryMethod_ResetMbr<WithStreamedUnaryMethod_StopRebuilding<WithStreamedUnaryMethod_UpdateEventWrr<WithStreamedUnaryMethod_AddSpare<WithStreamedUnaryMethod_RemoveSpare<WithStreamedUnaryMethod_ReplaceArrayDevice<WithStreamedUnaryMethod_CreateArray<WithStreamedUnaryMethod_AutocreateArray<WithStreamedUnaryMethod_DeleteArray<WithStreamedUnaryMethod_MountArray<WithStreamedUnaryMethod_UnmountArray<WithStreamedUnaryMethod_ListArray<WithStreamedUnaryMethod_ArrayInfo<WithStreamedUnaryMethod_SetLogPreference<WithStreamedUnaryMethod_SetLogLevel<WithStreamedUnaryMethod_LoggerInfo<WithStreamedUnaryMethod_GetLogLevel<WithStreamedUnaryMethod_ApplyLogFilter<WithStreamedUnaryMethod_CreateDevice<WithStreamedUnaryMethod_ScanDevice<WithStreamedUnaryMethod_ListDevice<WithStreamedUnaryMethod_GetSmartLog<WithStreamedUnaryMethod_CreateSubsystem<WithStreamedUnaryMethod_DeleteSubsystem<WithStreamedUnaryMethod_AddListener<WithStreamedUnaryMethod_ListSubsystem<WithStreamedUnaryMethod_SubsystemInfo<WithStreamedUnaryMethod_CreateTransport<WithStreamedUnaryMethod_CreateVolume<WithStreamedUnaryMethod_SetVolumeProperty<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_SystemInfo<WithStreamedUnaryMethod_StopSystem<WithStreamedUnaryMethod_GetSystemProperty<WithStreamedUnaryMethod_SetSystemProperty<WithStreamedUnaryMethod_StartTelemetry<WithStreamedUnaryMethod_StopTelemetry<WithStreamedUnaryMethod_SetTelemetryProperty<WithStreamedUnaryMethod_ResetEventWrr<WithStreamedUnaryMethod_ResetMbr<WithStreamedUnaryMethod_StopRebuilding<WithStreamedUnaryMethod_UpdateEventWrr<WithStreamedUnaryMethod_AddSpare<WithStreamedUnaryMethod_RemoveSpare<WithStreamedUnaryMethod_ReplaceArrayDevice<WithStreamedUnaryMethod_CreateArray<WithStreamedUnaryMethod_AutocreateArray<WithStreamedUnaryMethod_DeleteArray<WithStreamedUnaryMethod_MountArray<WithStreamedUnaryMethod_UnmountArray<WithStreamedUnaryMethod_ListArray<WithStreamedUnaryMethod_ArrayInfo<WithStreamedUnaryMethod_SetLogPreference<WithStreamedUnaryMethod_SetLogLevel<WithStreamedUnaryMethod_LoggerInfo<WithStreamedUnaryMethod_GetLogLevel<WithStreamedUnaryMethod_ApplyLogFilter<WithStreamedUnaryMethod_CreateDevice<WithStreamedUnaryMethod_ScanDevice<WithStreamedUnaryMethod_ListDevice<WithStreamedUnaryMethod_GetSmartLog<WithStreamedUnaryMethod_CreateSubsystem<WithStreamedUnaryMethod_DeleteSubsystem<WithStreamedUnaryMethod_AddListener<WithStreamedUnaryMethod_ListSubsystem<WithStreamedUnaryMethod_SubsystemInfo<WithStreamedUnaryMethod_CreateTransport<WithStreamedUnaryMethod_CreateVolume<WithStreamedUnaryMethod_SetVolumeProperty<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_SystemInfo<WithStreamedUnaryMethod_StopSystem<WithStreamedUnaryMethod_GetSystemProperty<WithStreamedUnaryMethod_SetSystemProperty<WithStreamedUnaryMethod_StartTelemetry<WithStreamedUnaryMethod_StopTelemetry<WithStreamedUnaryMethod_ResetEventWrr<WithStreamedUnaryMethod_ResetMbr<WithStreamedUnaryMethod_StopRebuilding<WithStreamedUnaryMethod_UpdateEventWrr<WithStreamedUnaryMethod_AddSpare<WithStreamedUnaryMethod_RemoveSpare<WithStreamedUnaryMethod_ReplaceArrayDevice<WithStreamedUnaryMethod_CreateArray<WithStreamedUnaryMethod_AutocreateArray<WithStreamedUnaryMethod_DeleteArray<WithStreamedUnaryMethod_MountArray<WithStreamedUnaryMethod_UnmountArray<WithStreamedUnaryMethod_ListArray<WithStreamedUnaryMethod_ArrayInfo<WithStreamedUnaryMethod_SetLogPreference<WithStreamedUnaryMethod_SetLogLevel<WithStreamedUnaryMethod_LoggerInfo<WithStreamedUnaryMethod_GetLogLevel<WithStreamedUnaryMethod_ApplyLogFilter<WithStreamedUnaryMethod_CreateDevice<WithStreamedUnaryMethod_ScanDevice<WithStreamedUnaryMethod_ListDevice<WithStreamedUnaryMethod_GetSmartLog<WithStreamedUnaryMethod_CreateSubsystem<WithStreamedUnaryMethod_DeleteSubsystem<WithStreamedUnaryMethod_AddListener<WithStreamedUnaryMethod_ListSubsystem<WithStreamedUnaryMethod_SubsystemInfo<WithStreamedUnaryMethod_CreateTransport<WithStreamedUnaryMethod_CreateVolume<WithStreamedUnaryMethod_SetVolumeProperty<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_SystemInfo<WithStreamedUnaryMethod_StopSystem<WithStreamedUnaryMethod_GetSystemProperty<WithStreamedUnaryMethod_SetSystemProperty<WithStreamedUnaryMethod_StartTelemetry<WithStreamedUnaryMethod_StopTelemetry<WithStreamedUnaryMethod_SetTelemetryProperty<WithStreamedUnaryMethod_ResetEventWrr<WithStreamedUnaryMethod_ResetMbr<WithStreamedUnaryMethod_StopRebuilding<WithStreamedUnaryMethod_UpdateEventWrr<WithStreamedUnaryMethod_AddSpare<WithStreamedUnaryMethod_RemoveSpare<WithStreamedUnaryMethod_ReplaceArrayDevice<WithStreamedUnaryMethod_CreateArray<WithStreamedUnaryMethod_AutocreateArray<WithStreamedUnaryMethod_DeleteArray<WithStreamedUnaryMethod_MountArray<WithStreamedUnaryMethod_UnmountArray<WithStreamedUnaryMethod_ListArray<WithStreamedUnaryMethod_ArrayInfo<WithStreamedUnaryMethod_SetLogPreference<WithStreamedUnaryMethod_SetLogLevel<WithStreamedUnaryMethod_LoggerInfo<WithStreamedUnaryMethod_GetLogLevel<WithStreamedUnaryMethod_ApplyLogFilter<WithStreamedUnaryMethod_CreateDevice<WithStreamedUnaryMethod_ScanDevice<WithStreamedUnaryMethod_ListDevice<WithStreamedUnaryMethod_GetSmartLog<WithStreamedUnaryMethod_CreateSubsystem<WithStreamedUnaryMethod_DeleteSubsystem<WithStreamedUnaryMethod_AddListener<WithStreamedUnaryMethod_ListSubsystem<WithStreamedUnaryMethod_SubsystemInfo<WithStreamedUnaryMethod_CreateTransport<WithStreamedUnaryMethod_CreateVolume<WithStreamedUnaryMethod_SetVolumeProperty<Service > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > StreamedService;
 };
 
 }  // namespace grpc_cli

--- a/proto/generated/cpp/cli.pb.cc
+++ b/proto/generated/cpp/cli.pb.cc
@@ -344,6 +344,60 @@ struct StopTelemetryResponseDefaultTypeInternal {
   };
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT StopTelemetryResponseDefaultTypeInternal _StopTelemetryResponse_default_instance_;
+constexpr SetTelemetryPropertyRequest_Param::SetTelemetryPropertyRequest_Param(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : publicationlistpath_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string){}
+struct SetTelemetryPropertyRequest_ParamDefaultTypeInternal {
+  constexpr SetTelemetryPropertyRequest_ParamDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~SetTelemetryPropertyRequest_ParamDefaultTypeInternal() {}
+  union {
+    SetTelemetryPropertyRequest_Param _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetTelemetryPropertyRequest_ParamDefaultTypeInternal _SetTelemetryPropertyRequest_Param_default_instance_;
+constexpr SetTelemetryPropertyRequest::SetTelemetryPropertyRequest(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : command_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , rid_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , requestor_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , param_(nullptr){}
+struct SetTelemetryPropertyRequestDefaultTypeInternal {
+  constexpr SetTelemetryPropertyRequestDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~SetTelemetryPropertyRequestDefaultTypeInternal() {}
+  union {
+    SetTelemetryPropertyRequest _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetTelemetryPropertyRequestDefaultTypeInternal _SetTelemetryPropertyRequest_default_instance_;
+constexpr SetTelemetryPropertyResponse_Result::SetTelemetryPropertyResponse_Result(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : status_(nullptr){}
+struct SetTelemetryPropertyResponse_ResultDefaultTypeInternal {
+  constexpr SetTelemetryPropertyResponse_ResultDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~SetTelemetryPropertyResponse_ResultDefaultTypeInternal() {}
+  union {
+    SetTelemetryPropertyResponse_Result _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetTelemetryPropertyResponse_ResultDefaultTypeInternal _SetTelemetryPropertyResponse_Result_default_instance_;
+constexpr SetTelemetryPropertyResponse::SetTelemetryPropertyResponse(
+  ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
+  : command_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , rid_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
+  , result_(nullptr)
+  , info_(nullptr){}
+struct SetTelemetryPropertyResponseDefaultTypeInternal {
+  constexpr SetTelemetryPropertyResponseDefaultTypeInternal()
+    : _instance(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized{}) {}
+  ~SetTelemetryPropertyResponseDefaultTypeInternal() {}
+  union {
+    SetTelemetryPropertyResponse _instance;
+  };
+};
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetTelemetryPropertyResponseDefaultTypeInternal _SetTelemetryPropertyResponse_default_instance_;
 constexpr ResetEventWrrRequest::ResetEventWrrRequest(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
   : command_(&::PROTOBUF_NAMESPACE_ID::internal::fixed_address_empty_string)
@@ -2442,7 +2496,7 @@ struct SetVolumePropertyResponseDefaultTypeInternal {
 };
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT SetVolumePropertyResponseDefaultTypeInternal _SetVolumePropertyResponse_default_instance_;
 }  // namespace grpc_cli
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_cli_2eproto[170];
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_cli_2eproto[174];
 static constexpr ::PROTOBUF_NAMESPACE_ID::EnumDescriptor const** file_level_enum_descriptors_cli_2eproto = nullptr;
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_cli_2eproto = nullptr;
 
@@ -2641,6 +2695,36 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_cli_2eproto::offsets[] PROTOBU
   PROTOBUF_FIELD_OFFSET(::grpc_cli::StopTelemetryResponse, rid_),
   PROTOBUF_FIELD_OFFSET(::grpc_cli::StopTelemetryResponse, result_),
   PROTOBUF_FIELD_OFFSET(::grpc_cli::StopTelemetryResponse, info_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyRequest_Param, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyRequest_Param, publicationlistpath_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyRequest, command_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyRequest, rid_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyRequest, requestor_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyRequest, param_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyResponse_Result, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyResponse_Result, status_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyResponse, command_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyResponse, rid_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyResponse, result_),
+  PROTOBUF_FIELD_OFFSET(::grpc_cli::SetTelemetryPropertyResponse, info_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::grpc_cli::ResetEventWrrRequest, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -3883,153 +3967,157 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 171, -1, sizeof(::grpc_cli::StopTelemetryRequest)},
   { 179, -1, sizeof(::grpc_cli::StopTelemetryResponse_Result)},
   { 185, -1, sizeof(::grpc_cli::StopTelemetryResponse)},
-  { 194, -1, sizeof(::grpc_cli::ResetEventWrrRequest)},
-  { 202, -1, sizeof(::grpc_cli::ResetEventWrrResponse_Result)},
-  { 208, -1, sizeof(::grpc_cli::ResetEventWrrResponse)},
-  { 217, -1, sizeof(::grpc_cli::ResetMbrRequest)},
-  { 225, -1, sizeof(::grpc_cli::ResetMbrResponse_Result)},
-  { 231, -1, sizeof(::grpc_cli::ResetMbrResponse)},
-  { 240, -1, sizeof(::grpc_cli::StopRebuildingRequest_Param)},
-  { 246, -1, sizeof(::grpc_cli::StopRebuildingRequest)},
-  { 255, -1, sizeof(::grpc_cli::StopRebuildingResponse_Result)},
-  { 261, -1, sizeof(::grpc_cli::StopRebuildingResponse)},
-  { 270, -1, sizeof(::grpc_cli::UpdateEventWrrRequest_Param)},
-  { 277, -1, sizeof(::grpc_cli::UpdateEventWrrRequest)},
-  { 286, -1, sizeof(::grpc_cli::UpdateEventWrrResponse_Result)},
-  { 292, -1, sizeof(::grpc_cli::UpdateEventWrrResponse)},
-  { 301, -1, sizeof(::grpc_cli::AddSpareRequest_SpareDeviceName)},
-  { 307, -1, sizeof(::grpc_cli::AddSpareRequest_Param)},
-  { 314, -1, sizeof(::grpc_cli::AddSpareRequest)},
-  { 323, -1, sizeof(::grpc_cli::AddSpareResponse_Result)},
-  { 329, -1, sizeof(::grpc_cli::AddSpareResponse)},
-  { 338, -1, sizeof(::grpc_cli::DeviceNameList)},
-  { 344, -1, sizeof(::grpc_cli::RemoveSpareRequest_SpareDeviceName)},
-  { 350, -1, sizeof(::grpc_cli::RemoveSpareRequest_Param)},
-  { 357, -1, sizeof(::grpc_cli::RemoveSpareRequest)},
-  { 366, -1, sizeof(::grpc_cli::RemoveSpareResponse_Result)},
-  { 372, -1, sizeof(::grpc_cli::RemoveSpareResponse)},
-  { 381, -1, sizeof(::grpc_cli::ReplaceArrayDeviceRequest_Param)},
-  { 388, -1, sizeof(::grpc_cli::ReplaceArrayDeviceRequest)},
-  { 397, -1, sizeof(::grpc_cli::ReplaceArrayDeviceResponse_Result)},
-  { 403, -1, sizeof(::grpc_cli::ReplaceArrayDeviceResponse)},
-  { 412, -1, sizeof(::grpc_cli::CreateArrayRequest_Param)},
-  { 422, -1, sizeof(::grpc_cli::CreateArrayRequest)},
-  { 431, -1, sizeof(::grpc_cli::CreateArrayResponse_Result)},
-  { 437, -1, sizeof(::grpc_cli::CreateArrayResponse)},
-  { 446, -1, sizeof(::grpc_cli::AutocreateArrayRequest_Param)},
-  { 456, -1, sizeof(::grpc_cli::AutocreateArrayRequest)},
-  { 465, -1, sizeof(::grpc_cli::AutocreateArrayResponse_Result)},
-  { 471, -1, sizeof(::grpc_cli::AutocreateArrayResponse)},
-  { 480, -1, sizeof(::grpc_cli::DeleteArrayRequest_Param)},
-  { 486, -1, sizeof(::grpc_cli::DeleteArrayRequest)},
-  { 495, -1, sizeof(::grpc_cli::DeleteArrayResponse_Result)},
-  { 501, -1, sizeof(::grpc_cli::DeleteArrayResponse)},
-  { 510, 517, sizeof(::grpc_cli::MountArrayRequest_Param)},
-  { 519, -1, sizeof(::grpc_cli::MountArrayRequest)},
-  { 528, -1, sizeof(::grpc_cli::MountArrayResponse_Result)},
-  { 534, -1, sizeof(::grpc_cli::MountArrayResponse)},
-  { 543, -1, sizeof(::grpc_cli::UnmountArrayRequest_Param)},
-  { 549, -1, sizeof(::grpc_cli::UnmountArrayRequest)},
-  { 558, -1, sizeof(::grpc_cli::UnmountArrayResponse_Result)},
-  { 564, -1, sizeof(::grpc_cli::UnmountArrayResponse)},
-  { 573, -1, sizeof(::grpc_cli::Array)},
-  { 594, -1, sizeof(::grpc_cli::ListArrayRequest)},
-  { 602, -1, sizeof(::grpc_cli::ListArrayResponse_Result_ArrayList)},
-  { 608, -1, sizeof(::grpc_cli::ListArrayResponse_Result)},
-  { 615, -1, sizeof(::grpc_cli::ListArrayResponse)},
-  { 624, -1, sizeof(::grpc_cli::ArrayInfoRequest_Param)},
-  { 630, -1, sizeof(::grpc_cli::ArrayInfoRequest)},
-  { 639, -1, sizeof(::grpc_cli::ArrayInfoResponse_Result)},
-  { 646, -1, sizeof(::grpc_cli::ArrayInfoResponse)},
-  { 655, -1, sizeof(::grpc_cli::ListNodeRequest)},
-  { 663, -1, sizeof(::grpc_cli::ListNodeResponse_Result_Node)},
-  { 671, -1, sizeof(::grpc_cli::ListNodeResponse_Result)},
-  { 678, -1, sizeof(::grpc_cli::ListNodeResponse)},
-  { 687, -1, sizeof(::grpc_cli::ListHaVolumeRequest)},
-  { 695, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result_Volume)},
-  { 706, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result)},
-  { 713, -1, sizeof(::grpc_cli::ListHaVolumeResponse)},
-  { 722, -1, sizeof(::grpc_cli::ListHaReplicationRequest)},
-  { 730, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result_Replication)},
-  { 740, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result)},
-  { 747, -1, sizeof(::grpc_cli::ListHaReplicationResponse)},
-  { 756, -1, sizeof(::grpc_cli::StartHaReplicationRequest_Param)},
-  { 771, -1, sizeof(::grpc_cli::StartHaReplicationRequest)},
-  { 780, -1, sizeof(::grpc_cli::StartHaReplicationResponse_Result)},
-  { 786, -1, sizeof(::grpc_cli::StartHaReplicationResponse)},
-  { 795, -1, sizeof(::grpc_cli::SetLogLevelRequest_Param)},
-  { 801, -1, sizeof(::grpc_cli::SetLogLevelRequest)},
-  { 810, -1, sizeof(::grpc_cli::SetLogLevelResponse_Result)},
-  { 816, -1, sizeof(::grpc_cli::SetLogLevelResponse)},
-  { 825, -1, sizeof(::grpc_cli::SetLogPreferenceRequest_Param)},
-  { 831, -1, sizeof(::grpc_cli::SetLogPreferenceRequest)},
-  { 840, -1, sizeof(::grpc_cli::SetLogPreferenceResponse_Result)},
-  { 846, -1, sizeof(::grpc_cli::SetLogPreferenceResponse)},
-  { 855, -1, sizeof(::grpc_cli::LoggerInfoRequest)},
-  { 863, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result_LoggerInfo)},
-  { 877, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result)},
-  { 884, -1, sizeof(::grpc_cli::LoggerInfoResponse)},
-  { 893, -1, sizeof(::grpc_cli::GetLogLevelRequest)},
-  { 901, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result_LogLevel)},
-  { 907, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result)},
-  { 914, -1, sizeof(::grpc_cli::GetLogLevelResponse)},
-  { 923, -1, sizeof(::grpc_cli::ApplyLogFilterRequest)},
-  { 931, -1, sizeof(::grpc_cli::ApplyLogFilterResponse_Result)},
-  { 937, -1, sizeof(::grpc_cli::ApplyLogFilterResponse)},
-  { 946, -1, sizeof(::grpc_cli::CreateDeviceRequest_Param)},
-  { 956, -1, sizeof(::grpc_cli::CreateDeviceRequest)},
-  { 965, -1, sizeof(::grpc_cli::CreateDeviceResponse_Result)},
-  { 971, -1, sizeof(::grpc_cli::CreateDeviceResponse)},
-  { 980, -1, sizeof(::grpc_cli::ScanDeviceRequest)},
-  { 988, -1, sizeof(::grpc_cli::ScanDeviceResponse_Result)},
-  { 994, -1, sizeof(::grpc_cli::ScanDeviceResponse)},
-  { 1003, -1, sizeof(::grpc_cli::Device)},
-  { 1016, -1, sizeof(::grpc_cli::ListDeviceRequest)},
-  { 1024, -1, sizeof(::grpc_cli::ListDeviceResponse_Result_DeviceList)},
-  { 1030, -1, sizeof(::grpc_cli::ListDeviceResponse_Result)},
-  { 1037, -1, sizeof(::grpc_cli::ListDeviceResponse)},
-  { 1046, -1, sizeof(::grpc_cli::SmartLog)},
-  { 1073, -1, sizeof(::grpc_cli::GetSmartLogRequest_Param)},
-  { 1079, -1, sizeof(::grpc_cli::GetSmartLogRequest)},
-  { 1088, -1, sizeof(::grpc_cli::GetSmartLogResponse_Result)},
-  { 1095, -1, sizeof(::grpc_cli::GetSmartLogResponse)},
-  { 1104, -1, sizeof(::grpc_cli::CreateSubsystemRequest_Param)},
-  { 1115, -1, sizeof(::grpc_cli::CreateSubsystemRequest)},
-  { 1124, -1, sizeof(::grpc_cli::CreateSubsystemResponse_Result)},
-  { 1130, -1, sizeof(::grpc_cli::CreateSubsystemResponse)},
-  { 1139, -1, sizeof(::grpc_cli::DeleteSubsystemRequest_Param)},
-  { 1145, -1, sizeof(::grpc_cli::DeleteSubsystemRequest)},
-  { 1154, -1, sizeof(::grpc_cli::DeleteSubsystemResponse_Result)},
-  { 1160, -1, sizeof(::grpc_cli::DeleteSubsystemResponse)},
-  { 1169, -1, sizeof(::grpc_cli::AddListenerRequest_Param)},
-  { 1178, -1, sizeof(::grpc_cli::AddListenerRequest)},
-  { 1187, -1, sizeof(::grpc_cli::AddListenerResponse_Result)},
-  { 1193, -1, sizeof(::grpc_cli::AddListenerResponse)},
-  { 1202, -1, sizeof(::grpc_cli::Subsystem_AddressInfo)},
-  { 1211, -1, sizeof(::grpc_cli::Subsystem_Host)},
-  { 1217, -1, sizeof(::grpc_cli::Subsystem_Namespace)},
-  { 1225, -1, sizeof(::grpc_cli::Subsystem)},
-  { 1239, -1, sizeof(::grpc_cli::ListSubsystemRequest)},
-  { 1247, -1, sizeof(::grpc_cli::ListSubsystemResponse_Result_SubsystemList)},
-  { 1253, -1, sizeof(::grpc_cli::ListSubsystemResponse_Result)},
-  { 1260, -1, sizeof(::grpc_cli::ListSubsystemResponse)},
-  { 1269, -1, sizeof(::grpc_cli::SubsystemInfoRequest_Param)},
-  { 1275, -1, sizeof(::grpc_cli::SubsystemInfoRequest)},
-  { 1284, -1, sizeof(::grpc_cli::SubsystemInfoResponse_Result_SubsystemList)},
-  { 1290, -1, sizeof(::grpc_cli::SubsystemInfoResponse_Result)},
-  { 1297, -1, sizeof(::grpc_cli::SubsystemInfoResponse)},
-  { 1306, -1, sizeof(::grpc_cli::CreateTransportRequest_Param)},
-  { 1314, -1, sizeof(::grpc_cli::CreateTransportRequest)},
-  { 1323, -1, sizeof(::grpc_cli::CreateTransportResponse_Result)},
-  { 1329, -1, sizeof(::grpc_cli::CreateTransportResponse)},
-  { 1338, -1, sizeof(::grpc_cli::CreateVolumeRequest_Param)},
-  { 1350, -1, sizeof(::grpc_cli::CreateVolumeRequest)},
-  { 1359, -1, sizeof(::grpc_cli::CreateVolumeResponse_Result)},
-  { 1365, -1, sizeof(::grpc_cli::CreateVolumeResponse)},
-  { 1374, -1, sizeof(::grpc_cli::SetVolumePropertyRequest_Param)},
-  { 1387, -1, sizeof(::grpc_cli::SetVolumePropertyRequest)},
-  { 1396, -1, sizeof(::grpc_cli::SetVolumePropertyResponse_Result)},
-  { 1402, -1, sizeof(::grpc_cli::SetVolumePropertyResponse)},
+  { 194, -1, sizeof(::grpc_cli::SetTelemetryPropertyRequest_Param)},
+  { 200, -1, sizeof(::grpc_cli::SetTelemetryPropertyRequest)},
+  { 209, -1, sizeof(::grpc_cli::SetTelemetryPropertyResponse_Result)},
+  { 215, -1, sizeof(::grpc_cli::SetTelemetryPropertyResponse)},
+  { 224, -1, sizeof(::grpc_cli::ResetEventWrrRequest)},
+  { 232, -1, sizeof(::grpc_cli::ResetEventWrrResponse_Result)},
+  { 238, -1, sizeof(::grpc_cli::ResetEventWrrResponse)},
+  { 247, -1, sizeof(::grpc_cli::ResetMbrRequest)},
+  { 255, -1, sizeof(::grpc_cli::ResetMbrResponse_Result)},
+  { 261, -1, sizeof(::grpc_cli::ResetMbrResponse)},
+  { 270, -1, sizeof(::grpc_cli::StopRebuildingRequest_Param)},
+  { 276, -1, sizeof(::grpc_cli::StopRebuildingRequest)},
+  { 285, -1, sizeof(::grpc_cli::StopRebuildingResponse_Result)},
+  { 291, -1, sizeof(::grpc_cli::StopRebuildingResponse)},
+  { 300, -1, sizeof(::grpc_cli::UpdateEventWrrRequest_Param)},
+  { 307, -1, sizeof(::grpc_cli::UpdateEventWrrRequest)},
+  { 316, -1, sizeof(::grpc_cli::UpdateEventWrrResponse_Result)},
+  { 322, -1, sizeof(::grpc_cli::UpdateEventWrrResponse)},
+  { 331, -1, sizeof(::grpc_cli::AddSpareRequest_SpareDeviceName)},
+  { 337, -1, sizeof(::grpc_cli::AddSpareRequest_Param)},
+  { 344, -1, sizeof(::grpc_cli::AddSpareRequest)},
+  { 353, -1, sizeof(::grpc_cli::AddSpareResponse_Result)},
+  { 359, -1, sizeof(::grpc_cli::AddSpareResponse)},
+  { 368, -1, sizeof(::grpc_cli::DeviceNameList)},
+  { 374, -1, sizeof(::grpc_cli::RemoveSpareRequest_SpareDeviceName)},
+  { 380, -1, sizeof(::grpc_cli::RemoveSpareRequest_Param)},
+  { 387, -1, sizeof(::grpc_cli::RemoveSpareRequest)},
+  { 396, -1, sizeof(::grpc_cli::RemoveSpareResponse_Result)},
+  { 402, -1, sizeof(::grpc_cli::RemoveSpareResponse)},
+  { 411, -1, sizeof(::grpc_cli::ReplaceArrayDeviceRequest_Param)},
+  { 418, -1, sizeof(::grpc_cli::ReplaceArrayDeviceRequest)},
+  { 427, -1, sizeof(::grpc_cli::ReplaceArrayDeviceResponse_Result)},
+  { 433, -1, sizeof(::grpc_cli::ReplaceArrayDeviceResponse)},
+  { 442, -1, sizeof(::grpc_cli::CreateArrayRequest_Param)},
+  { 452, -1, sizeof(::grpc_cli::CreateArrayRequest)},
+  { 461, -1, sizeof(::grpc_cli::CreateArrayResponse_Result)},
+  { 467, -1, sizeof(::grpc_cli::CreateArrayResponse)},
+  { 476, -1, sizeof(::grpc_cli::AutocreateArrayRequest_Param)},
+  { 486, -1, sizeof(::grpc_cli::AutocreateArrayRequest)},
+  { 495, -1, sizeof(::grpc_cli::AutocreateArrayResponse_Result)},
+  { 501, -1, sizeof(::grpc_cli::AutocreateArrayResponse)},
+  { 510, -1, sizeof(::grpc_cli::DeleteArrayRequest_Param)},
+  { 516, -1, sizeof(::grpc_cli::DeleteArrayRequest)},
+  { 525, -1, sizeof(::grpc_cli::DeleteArrayResponse_Result)},
+  { 531, -1, sizeof(::grpc_cli::DeleteArrayResponse)},
+  { 540, 547, sizeof(::grpc_cli::MountArrayRequest_Param)},
+  { 549, -1, sizeof(::grpc_cli::MountArrayRequest)},
+  { 558, -1, sizeof(::grpc_cli::MountArrayResponse_Result)},
+  { 564, -1, sizeof(::grpc_cli::MountArrayResponse)},
+  { 573, -1, sizeof(::grpc_cli::UnmountArrayRequest_Param)},
+  { 579, -1, sizeof(::grpc_cli::UnmountArrayRequest)},
+  { 588, -1, sizeof(::grpc_cli::UnmountArrayResponse_Result)},
+  { 594, -1, sizeof(::grpc_cli::UnmountArrayResponse)},
+  { 603, -1, sizeof(::grpc_cli::Array)},
+  { 624, -1, sizeof(::grpc_cli::ListArrayRequest)},
+  { 632, -1, sizeof(::grpc_cli::ListArrayResponse_Result_ArrayList)},
+  { 638, -1, sizeof(::grpc_cli::ListArrayResponse_Result)},
+  { 645, -1, sizeof(::grpc_cli::ListArrayResponse)},
+  { 654, -1, sizeof(::grpc_cli::ArrayInfoRequest_Param)},
+  { 660, -1, sizeof(::grpc_cli::ArrayInfoRequest)},
+  { 669, -1, sizeof(::grpc_cli::ArrayInfoResponse_Result)},
+  { 676, -1, sizeof(::grpc_cli::ArrayInfoResponse)},
+  { 685, -1, sizeof(::grpc_cli::ListNodeRequest)},
+  { 693, -1, sizeof(::grpc_cli::ListNodeResponse_Result_Node)},
+  { 701, -1, sizeof(::grpc_cli::ListNodeResponse_Result)},
+  { 708, -1, sizeof(::grpc_cli::ListNodeResponse)},
+  { 717, -1, sizeof(::grpc_cli::ListHaVolumeRequest)},
+  { 725, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result_Volume)},
+  { 736, -1, sizeof(::grpc_cli::ListHaVolumeResponse_Result)},
+  { 743, -1, sizeof(::grpc_cli::ListHaVolumeResponse)},
+  { 752, -1, sizeof(::grpc_cli::ListHaReplicationRequest)},
+  { 760, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result_Replication)},
+  { 770, -1, sizeof(::grpc_cli::ListHaReplicationResponse_Result)},
+  { 777, -1, sizeof(::grpc_cli::ListHaReplicationResponse)},
+  { 786, -1, sizeof(::grpc_cli::StartHaReplicationRequest_Param)},
+  { 801, -1, sizeof(::grpc_cli::StartHaReplicationRequest)},
+  { 810, -1, sizeof(::grpc_cli::StartHaReplicationResponse_Result)},
+  { 816, -1, sizeof(::grpc_cli::StartHaReplicationResponse)},
+  { 825, -1, sizeof(::grpc_cli::SetLogLevelRequest_Param)},
+  { 831, -1, sizeof(::grpc_cli::SetLogLevelRequest)},
+  { 840, -1, sizeof(::grpc_cli::SetLogLevelResponse_Result)},
+  { 846, -1, sizeof(::grpc_cli::SetLogLevelResponse)},
+  { 855, -1, sizeof(::grpc_cli::SetLogPreferenceRequest_Param)},
+  { 861, -1, sizeof(::grpc_cli::SetLogPreferenceRequest)},
+  { 870, -1, sizeof(::grpc_cli::SetLogPreferenceResponse_Result)},
+  { 876, -1, sizeof(::grpc_cli::SetLogPreferenceResponse)},
+  { 885, -1, sizeof(::grpc_cli::LoggerInfoRequest)},
+  { 893, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result_LoggerInfo)},
+  { 907, -1, sizeof(::grpc_cli::LoggerInfoResponse_Result)},
+  { 914, -1, sizeof(::grpc_cli::LoggerInfoResponse)},
+  { 923, -1, sizeof(::grpc_cli::GetLogLevelRequest)},
+  { 931, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result_LogLevel)},
+  { 937, -1, sizeof(::grpc_cli::GetLogLevelResponse_Result)},
+  { 944, -1, sizeof(::grpc_cli::GetLogLevelResponse)},
+  { 953, -1, sizeof(::grpc_cli::ApplyLogFilterRequest)},
+  { 961, -1, sizeof(::grpc_cli::ApplyLogFilterResponse_Result)},
+  { 967, -1, sizeof(::grpc_cli::ApplyLogFilterResponse)},
+  { 976, -1, sizeof(::grpc_cli::CreateDeviceRequest_Param)},
+  { 986, -1, sizeof(::grpc_cli::CreateDeviceRequest)},
+  { 995, -1, sizeof(::grpc_cli::CreateDeviceResponse_Result)},
+  { 1001, -1, sizeof(::grpc_cli::CreateDeviceResponse)},
+  { 1010, -1, sizeof(::grpc_cli::ScanDeviceRequest)},
+  { 1018, -1, sizeof(::grpc_cli::ScanDeviceResponse_Result)},
+  { 1024, -1, sizeof(::grpc_cli::ScanDeviceResponse)},
+  { 1033, -1, sizeof(::grpc_cli::Device)},
+  { 1046, -1, sizeof(::grpc_cli::ListDeviceRequest)},
+  { 1054, -1, sizeof(::grpc_cli::ListDeviceResponse_Result_DeviceList)},
+  { 1060, -1, sizeof(::grpc_cli::ListDeviceResponse_Result)},
+  { 1067, -1, sizeof(::grpc_cli::ListDeviceResponse)},
+  { 1076, -1, sizeof(::grpc_cli::SmartLog)},
+  { 1103, -1, sizeof(::grpc_cli::GetSmartLogRequest_Param)},
+  { 1109, -1, sizeof(::grpc_cli::GetSmartLogRequest)},
+  { 1118, -1, sizeof(::grpc_cli::GetSmartLogResponse_Result)},
+  { 1125, -1, sizeof(::grpc_cli::GetSmartLogResponse)},
+  { 1134, -1, sizeof(::grpc_cli::CreateSubsystemRequest_Param)},
+  { 1145, -1, sizeof(::grpc_cli::CreateSubsystemRequest)},
+  { 1154, -1, sizeof(::grpc_cli::CreateSubsystemResponse_Result)},
+  { 1160, -1, sizeof(::grpc_cli::CreateSubsystemResponse)},
+  { 1169, -1, sizeof(::grpc_cli::DeleteSubsystemRequest_Param)},
+  { 1175, -1, sizeof(::grpc_cli::DeleteSubsystemRequest)},
+  { 1184, -1, sizeof(::grpc_cli::DeleteSubsystemResponse_Result)},
+  { 1190, -1, sizeof(::grpc_cli::DeleteSubsystemResponse)},
+  { 1199, -1, sizeof(::grpc_cli::AddListenerRequest_Param)},
+  { 1208, -1, sizeof(::grpc_cli::AddListenerRequest)},
+  { 1217, -1, sizeof(::grpc_cli::AddListenerResponse_Result)},
+  { 1223, -1, sizeof(::grpc_cli::AddListenerResponse)},
+  { 1232, -1, sizeof(::grpc_cli::Subsystem_AddressInfo)},
+  { 1241, -1, sizeof(::grpc_cli::Subsystem_Host)},
+  { 1247, -1, sizeof(::grpc_cli::Subsystem_Namespace)},
+  { 1255, -1, sizeof(::grpc_cli::Subsystem)},
+  { 1269, -1, sizeof(::grpc_cli::ListSubsystemRequest)},
+  { 1277, -1, sizeof(::grpc_cli::ListSubsystemResponse_Result_SubsystemList)},
+  { 1283, -1, sizeof(::grpc_cli::ListSubsystemResponse_Result)},
+  { 1290, -1, sizeof(::grpc_cli::ListSubsystemResponse)},
+  { 1299, -1, sizeof(::grpc_cli::SubsystemInfoRequest_Param)},
+  { 1305, -1, sizeof(::grpc_cli::SubsystemInfoRequest)},
+  { 1314, -1, sizeof(::grpc_cli::SubsystemInfoResponse_Result_SubsystemList)},
+  { 1320, -1, sizeof(::grpc_cli::SubsystemInfoResponse_Result)},
+  { 1327, -1, sizeof(::grpc_cli::SubsystemInfoResponse)},
+  { 1336, -1, sizeof(::grpc_cli::CreateTransportRequest_Param)},
+  { 1344, -1, sizeof(::grpc_cli::CreateTransportRequest)},
+  { 1353, -1, sizeof(::grpc_cli::CreateTransportResponse_Result)},
+  { 1359, -1, sizeof(::grpc_cli::CreateTransportResponse)},
+  { 1368, -1, sizeof(::grpc_cli::CreateVolumeRequest_Param)},
+  { 1380, -1, sizeof(::grpc_cli::CreateVolumeRequest)},
+  { 1389, -1, sizeof(::grpc_cli::CreateVolumeResponse_Result)},
+  { 1395, -1, sizeof(::grpc_cli::CreateVolumeResponse)},
+  { 1404, -1, sizeof(::grpc_cli::SetVolumePropertyRequest_Param)},
+  { 1417, -1, sizeof(::grpc_cli::SetVolumePropertyRequest)},
+  { 1426, -1, sizeof(::grpc_cli::SetVolumePropertyResponse_Result)},
+  { 1432, -1, sizeof(::grpc_cli::SetVolumePropertyResponse)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -4056,6 +4144,10 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_StopTelemetryRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_StopTelemetryResponse_Result_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_StopTelemetryResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_SetTelemetryPropertyRequest_Param_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_SetTelemetryPropertyRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_SetTelemetryPropertyResponse_Result_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_SetTelemetryPropertyResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ResetEventWrrRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ResetEventWrrResponse_Result_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::grpc_cli::_ResetEventWrrResponse_default_instance_),
@@ -4267,493 +4359,506 @@ const char descriptor_table_protodef_cli_2eproto[] PROTOBUF_SECTION_VARIABLE(pro
   "\001(\t\022\013\n\003rid\030\002 \001(\t\0226\n\006result\030\003 \001(\0132&.grpc_"
   "cli.StopTelemetryResponse.Result\022\037\n\004info"
   "\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006s"
-  "tatus\030\001 \001(\0132\020.grpc_cli.Status\"G\n\024ResetEv"
-  "entWrrRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 "
-  "\001(\t\022\021\n\trequestor\030\003 \001(\t\"\272\001\n\025ResetEventWrr"
-  "Response\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0226"
-  "\n\006result\030\003 \001(\0132&.grpc_cli.ResetEventWrrR"
+  "tatus\030\001 \001(\0132\020.grpc_cli.Status\"\260\001\n\033SetTel"
+  "emetryPropertyRequest\022\017\n\007command\030\001 \001(\t\022\013"
+  "\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022:\n\005param\030"
+  "\004 \001(\0132+.grpc_cli.SetTelemetryPropertyReq"
+  "uest.Param\032$\n\005Param\022\033\n\023publicationListPa"
+  "th\030\001 \001(\t\"\310\001\n\034SetTelemetryPropertyRespons"
+  "e\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022=\n\006resul"
+  "t\030\003 \001(\0132-.grpc_cli.SetTelemetryPropertyR"
   "esponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli."
   "PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc"
-  "_cli.Status\"B\n\017ResetMbrRequest\022\017\n\007comman"
-  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\""
-  "\260\001\n\020ResetMbrResponse\022\017\n\007command\030\001 \001(\t\022\013\n"
-  "\003rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cli.Re"
-  "setMbrResponse.Result\022\037\n\004info\030\004 \001(\0132\021.gr"
-  "pc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\013"
-  "2\020.grpc_cli.Status\"\225\001\n\025StopRebuildingReq"
-  "uest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tre"
-  "questor\030\003 \001(\t\0224\n\005param\030\004 \001(\0132%.grpc_cli."
-  "StopRebuildingRequest.Param\032\025\n\005Param\022\014\n\004"
-  "name\030\001 \001(\t\"\274\001\n\026StopRebuildingResponse\022\017\n"
-  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 "
-  "\001(\0132\'.grpc_cli.StopRebuildingResponse.Re"
-  "sult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n"
-  "\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Statu"
-  "s\"\245\001\n\025UpdateEventWrrRequest\022\017\n\007command\030\001"
-  " \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0224\n\005"
-  "param\030\004 \001(\0132%.grpc_cli.UpdateEventWrrReq"
-  "uest.Param\032%\n\005Param\022\014\n\004name\030\001 \001(\t\022\016\n\006wei"
-  "ght\030\002 \001(\003\"\274\001\n\026UpdateEventWrrResponse\022\017\n\007"
-  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001"
-  "(\0132\'.grpc_cli.UpdateEventWrrResponse.Res"
+  "_cli.Status\"G\n\024ResetEventWrrRequest\022\017\n\007c"
+  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003"
+  " \001(\t\"\272\001\n\025ResetEventWrrResponse\022\017\n\007comman"
+  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0226\n\006result\030\003 \001(\0132&.g"
+  "rpc_cli.ResetEventWrrResponse.Result\022\037\n\004"
+  "info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022"
+  " \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"B\n\017Res"
+  "etMbrRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001"
+  "(\t\022\021\n\trequestor\030\003 \001(\t\"\260\001\n\020ResetMbrRespon"
+  "se\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006resu"
+  "lt\030\003 \001(\0132!.grpc_cli.ResetMbrResponse.Res"
   "ult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006"
   "Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status"
-  "\"\353\001\n\017AddSpareRequest\022\017\n\007command\030\001 \001(\t\022\013\n"
-  "\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022.\n\005param\030\004"
-  " \001(\0132\037.grpc_cli.AddSpareRequest.Param\032%\n"
-  "\017SpareDeviceName\022\022\n\ndeviceName\030\001 \001(\t\032P\n\005"
-  "Param\022\r\n\005array\030\001 \001(\t\0228\n\005spare\030\003 \003(\0132).gr"
-  "pc_cli.AddSpareRequest.SpareDeviceName\"\260"
-  "\001\n\020AddSpareResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003"
-  "rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc_cli.Add"
-  "SpareResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grp"
-  "c_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132"
-  "\020.grpc_cli.Status\"$\n\016DeviceNameList\022\022\n\nd"
-  "eviceName\030\001 \001(\t\"\364\001\n\022RemoveSpareRequest\022\017"
-  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequesto"
-  "r\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.Remove"
-  "SpareRequest.Param\032%\n\017SpareDeviceName\022\022\n"
-  "\ndeviceName\030\001 \001(\t\032S\n\005Param\022\r\n\005array\030\001 \001("
-  "\t\022;\n\005spare\030\002 \003(\0132,.grpc_cli.RemoveSpareR"
-  "equest.SpareDeviceName\"\266\001\n\023RemoveSpareRe"
-  "sponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006"
-  "result\030\003 \001(\0132$.grpc_cli.RemoveSpareRespo"
-  "nse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosI"
-  "nfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli"
-  ".Status\"\256\001\n\031ReplaceArrayDeviceRequest\022\017\n"
-  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor"
-  "\030\003 \001(\t\0228\n\005param\030\004 \001(\0132).grpc_cli.Replace"
-  "ArrayDeviceRequest.Param\032&\n\005Param\022\r\n\005arr"
-  "ay\030\001 \001(\t\022\016\n\006device\030\002 \001(\t\"\304\001\n\032ReplaceArra"
-  "yDeviceResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\022;\n\006result\030\003 \001(\0132+.grpc_cli.Replace"
-  "ArrayDeviceResponse.Result\022\037\n\004info\030\004 \001(\013"
+  "\"\225\001\n\025StopRebuildingRequest\022\017\n\007command\030\001 "
+  "\001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0224\n\005p"
+  "aram\030\004 \001(\0132%.grpc_cli.StopRebuildingRequ"
+  "est.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\274\001\n\026Sto"
+  "pRebuildingResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003"
+  "rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'.grpc_cli.Sto"
+  "pRebuildingResponse.Result\022\037\n\004info\030\004 \001(\013"
   "2\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030"
-  "\001 \001(\0132\020.grpc_cli.Status\"\235\002\n\022CreateArrayR"
-  "equest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\t"
-  "requestor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cl"
-  "i.CreateArrayRequest.Param\032\242\001\n\005Param\022\014\n\004"
-  "name\030\001 \001(\t\022(\n\006buffer\030\002 \003(\0132\030.grpc_cli.De"
-  "viceNameList\022&\n\004data\030\003 \003(\0132\030.grpc_cli.De"
-  "viceNameList\022\'\n\005spare\030\004 \003(\0132\030.grpc_cli.D"
-  "eviceNameList\022\020\n\010raidtype\030\005 \001(\t\"\266\001\n\023Crea"
-  "teArrayResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.CreateA"
-  "rrayResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc"
-  "_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020"
-  ".grpc_cli.Status\"\366\001\n\026AutocreateArrayRequ"
-  "est\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treq"
-  "uestor\030\003 \001(\t\0225\n\005param\030\004 \001(\0132&.grpc_cli.A"
-  "utocreateArrayRequest.Param\032t\n\005Param\022\014\n\004"
-  "name\030\001 \001(\t\022(\n\006buffer\030\002 \003(\0132\030.grpc_cli.De"
-  "viceNameList\022\017\n\007numData\030\003 \001(\005\022\020\n\010numSpar"
-  "e\030\004 \001(\005\022\020\n\010raidtype\030\005 \001(\t\"\276\001\n\027Autocreate"
-  "ArrayResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 "
-  "\001(\t\0228\n\006result\030\003 \001(\0132(.grpc_cli.Autocreat"
-  "eArrayResponse.Result\022\037\n\004info\030\004 \001(\0132\021.gr"
-  "pc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\013"
-  "2\020.grpc_cli.Status\"\217\001\n\022DeleteArrayReques"
-  "t\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treque"
-  "stor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.Del"
-  "eteArrayRequest.Param\032\025\n\005Param\022\014\n\004name\030\001"
-  " \001(\t\"\266\001\n\023DeleteArrayResponse\022\017\n\007command\030"
+  "\001 \001(\0132\020.grpc_cli.Status\"\245\001\n\025UpdateEventW"
+  "rrRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022"
+  "\021\n\trequestor\030\003 \001(\t\0224\n\005param\030\004 \001(\0132%.grpc"
+  "_cli.UpdateEventWrrRequest.Param\032%\n\005Para"
+  "m\022\014\n\004name\030\001 \001(\t\022\016\n\006weight\030\002 \001(\003\"\274\001\n\026Upda"
+  "teEventWrrResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003r"
+  "id\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'.grpc_cli.Upda"
+  "teEventWrrResponse.Result\022\037\n\004info\030\004 \001(\0132"
+  "\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001"
+  " \001(\0132\020.grpc_cli.Status\"\353\001\n\017AddSpareReque"
+  "st\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequ"
+  "estor\030\003 \001(\t\022.\n\005param\030\004 \001(\0132\037.grpc_cli.Ad"
+  "dSpareRequest.Param\032%\n\017SpareDeviceName\022\022"
+  "\n\ndeviceName\030\001 \001(\t\032P\n\005Param\022\r\n\005array\030\001 \001"
+  "(\t\0228\n\005spare\030\003 \003(\0132).grpc_cli.AddSpareReq"
+  "uest.SpareDeviceName\"\260\001\n\020AddSpareRespons"
+  "e\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006resul"
+  "t\030\003 \001(\0132!.grpc_cli.AddSpareResponse.Resu"
+  "lt\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006R"
+  "esult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\""
+  "$\n\016DeviceNameList\022\022\n\ndeviceName\030\001 \001(\t\"\364\001"
+  "\n\022RemoveSpareRequest\022\017\n\007command\030\001 \001(\t\022\013\n"
+  "\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005param\030\004"
+  " \001(\0132\".grpc_cli.RemoveSpareRequest.Param"
+  "\032%\n\017SpareDeviceName\022\022\n\ndeviceName\030\001 \001(\t\032"
+  "S\n\005Param\022\r\n\005array\030\001 \001(\t\022;\n\005spare\030\002 \003(\0132,"
+  ".grpc_cli.RemoveSpareRequest.SpareDevice"
+  "Name\"\266\001\n\023RemoveSpareResponse\022\017\n\007command\030"
   "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grp"
-  "c_cli.DeleteArrayResponse.Result\022\037\n\004info"
+  "c_cli.RemoveSpareResponse.Result\022\037\n\004info"
   "\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006s"
-  "tatus\030\001 \001(\0132\020.grpc_cli.Status\"\305\001\n\021MountA"
-  "rrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001("
-  "\t\022\021\n\trequestor\030\003 \001(\t\0220\n\005param\030\004 \001(\0132!.gr"
-  "pc_cli.MountArrayRequest.Param\032M\n\005Param\022"
-  "\014\n\004name\030\001 \001(\t\022\037\n\022enableWriteThrough\030\002 \001("
-  "\010H\000\210\001\001B\025\n\023_enableWriteThrough\"\264\001\n\022MountA"
-  "rrayResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001"
-  "(\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.MountArray"
-  "Response.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli"
-  ".PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grp"
-  "c_cli.Status\"\221\001\n\023UnmountArrayRequest\022\017\n\007"
-  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030"
-  "\003 \001(\t\0222\n\005param\030\004 \001(\0132#.grpc_cli.UnmountA"
-  "rrayRequest.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t"
-  "\"\270\001\n\024UnmountArrayResponse\022\017\n\007command\030\001 \001"
-  "(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001(\0132%.grpc_c"
-  "li.UnmountArrayResponse.Result\022\037\n\004info\030\004"
-  " \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006sta"
-  "tus\030\001 \001(\0132\020.grpc_cli.Status\"\314\002\n\005Array\022\r\n"
-  "\005index\030\001 \001(\005\022\021\n\tunique_id\030\002 \001(\005\022\014\n\004name\030"
-  "\003 \001(\t\022\016\n\006status\030\004 \001(\t\022\r\n\005state\030\005 \001(\t\022\021\n\t"
-  "situation\030\006 \001(\t\022\026\n\016createDatetime\030\007 \001(\t\022"
-  "\026\n\016updateDatetime\030\010 \001(\t\022\032\n\022rebuildingPro"
-  "gress\030\t \001(\t\022\020\n\010capacity\030\n \001(\004\022\014\n\004used\030\013 "
-  "\001(\004\022\016\n\006gcMode\030\014 \001(\t\022\020\n\010metaRaid\030\r \001(\t\022\020\n"
-  "\010dataRaid\030\016 \001(\t\022\033\n\023writeThroughEnabled\030\017"
-  " \001(\010\022$\n\ndevicelist\030\020 \003(\0132\020.grpc_cli.Devi"
-  "ce\"C\n\020ListArrayRequest\022\017\n\007command\030\001 \001(\t\022"
-  "\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\240\002\n\021List"
-  "ArrayResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 "
-  "\001(\t\0222\n\006result\030\003 \001(\0132\".grpc_cli.ListArray"
-  "Response.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli"
-  ".PosInfo\032\227\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.gr"
-  "pc_cli.Status\022:\n\004data\030\002 \001(\0132,.grpc_cli.L"
-  "istArrayResponse.Result.ArrayList\032/\n\tArr"
-  "ayList\022\"\n\tarrayList\030\001 \003(\0132\017.grpc_cli.Arr"
-  "ay\"\213\001\n\020ArrayInfoRequest\022\017\n\007command\030\001 \001(\t"
-  "\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022/\n\005para"
-  "m\030\004 \001(\0132 .grpc_cli.ArrayInfoRequest.Para"
-  "m\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\321\001\n\021ArrayInfoRe"
-  "sponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006"
-  "result\030\003 \001(\0132\".grpc_cli.ArrayInfoRespons"
+  "tatus\030\001 \001(\0132\020.grpc_cli.Status\"\256\001\n\031Replac"
+  "eArrayDeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003"
+  "rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0228\n\005param\030\004 "
+  "\001(\0132).grpc_cli.ReplaceArrayDeviceRequest"
+  ".Param\032&\n\005Param\022\r\n\005array\030\001 \001(\t\022\016\n\006device"
+  "\030\002 \001(\t\"\304\001\n\032ReplaceArrayDeviceResponse\022\017\n"
+  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022;\n\006result\030\003 "
+  "\001(\0132+.grpc_cli.ReplaceArrayDeviceRespons"
   "e.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInf"
-  "o\032I\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.S"
-  "tatus\022\035\n\004data\030\002 \001(\0132\017.grpc_cli.Array\"B\n\017"
-  "ListNodeRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\233\002\n\020ListNodeRes"
-  "ponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006r"
-  "esult\030\003 \001(\0132!.grpc_cli.ListNodeResponse."
-  "Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032"
-  "\224\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.St"
-  "atus\0224\n\004data\030\002 \003(\0132&.grpc_cli.ListNodeRe"
-  "sponse.Result.Node\0322\n\004Node\022\014\n\004name\030\001 \001(\t"
-  "\022\n\n\002ip\030\002 \001(\t\022\020\n\010lastseen\030\003 \001(\t\"F\n\023ListHa"
-  "VolumeRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 "
-  "\001(\t\022\021\n\trequestor\030\003 \001(\t\"\336\002\n\024ListHaVolumeR"
-  "esponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n"
-  "\006result\030\003 \001(\0132%.grpc_cli.ListHaVolumeRes"
-  "ponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Po"
-  "sInfo\032\317\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_"
-  "cli.Status\022:\n\004data\030\002 \003(\0132,.grpc_cli.List"
-  "HaVolumeResponse.Result.Volume\032g\n\006Volume"
-  "\022\n\n\002id\030\001 \001(\005\022\014\n\004name\030\002 \001(\t\022\020\n\010nodeName\030\003"
-  " \001(\t\022\021\n\tarrayName\030\004 \001(\t\022\014\n\004size\030\005 \001(\003\022\020\n"
-  "\010lastseen\030\006 \001(\t\"K\n\030ListHaReplicationRequ"
-  "est\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treq"
-  "uestor\030\003 \001(\t\"\226\003\n\031ListHaReplicationRespon"
-  "se\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022:\n\006resu"
-  "lt\030\003 \001(\0132*.grpc_cli.ListHaReplicationRes"
-  "ponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Po"
-  "sInfo\032\375\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_"
-  "cli.Status\022D\n\004data\030\002 \003(\01326.grpc_cli.List"
-  "HaReplicationResponse.Result.Replication"
-  "\032\212\001\n\013Replication\022\n\n\002id\030\001 \001(\005\022\026\n\016sourceVo"
-  "lumeId\030\002 \001(\005\022\032\n\022sourceWalVolume_id\030\003 \001(\005"
-  "\022\033\n\023destinationVolumeId\030\004 \001(\005\022\036\n\026destina"
-  "tionWalVolumeId\030\005 \001(\005\"\223\003\n\031StartHaReplica"
-  "tionRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001("
-  "\t\022\021\n\trequestor\030\003 \001(\t\0228\n\005param\030\004 \001(\0132).gr"
-  "pc_cli.StartHaReplicationRequest.Param\032\212"
-  "\002\n\005Param\022\027\n\017primaryNodeName\030\001 \001(\t\022\030\n\020pri"
-  "maryArrayName\030\002 \001(\t\022\031\n\021primaryVolumeName"
-  "\030\003 \001(\t\022\034\n\024primaryWalVolumeName\030\004 \001(\t\022\031\n\021"
-  "secondaryNodeName\030\005 \001(\t\022\032\n\022secondaryArra"
-  "yName\030\006 \001(\t\022\033\n\023secondaryVolumeName\030\007 \001(\t"
-  "\022\036\n\026secondaryWalVolumeName\030\010 \001(\t\022\016\n\006stua"
-  "ts\030\t \001(\t\022\021\n\ttimestamp\030\n \001(\t\"\304\001\n\032StartHaR"
-  "eplicationResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003r"
-  "id\030\002 \001(\t\022;\n\006result\030\003 \001(\0132+.grpc_cli.Star"
-  "tHaReplicationResponse.Result\022\037\n\004info\030\004 "
-  "\001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006stat"
-  "us\030\001 \001(\0132\020.grpc_cli.Status\"\220\001\n\022SetLogLev"
-  "elRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022"
-  "\021\n\trequestor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc"
-  "_cli.SetLogLevelRequest.Param\032\026\n\005Param\022\r"
-  "\n\005level\030\001 \001(\t\"\266\001\n\023SetLogLevelResponse\022\017\n"
+  "o\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.S"
+  "tatus\"\235\002\n\022CreateArrayRequest\022\017\n\007command\030"
+  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n"
+  "\005param\030\004 \001(\0132\".grpc_cli.CreateArrayReque"
+  "st.Param\032\242\001\n\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006buff"
+  "er\030\002 \003(\0132\030.grpc_cli.DeviceNameList\022&\n\004da"
+  "ta\030\003 \003(\0132\030.grpc_cli.DeviceNameList\022\'\n\005sp"
+  "are\030\004 \003(\0132\030.grpc_cli.DeviceNameList\022\020\n\010r"
+  "aidtype\030\005 \001(\t\"\266\001\n\023CreateArrayResponse\022\017\n"
   "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 "
-  "\001(\0132$.grpc_cli.SetLogLevelResponse.Resul"
+  "\001(\0132$.grpc_cli.CreateArrayResponse.Resul"
   "t\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Re"
-  "sult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\246"
-  "\001\n\027SetLogPreferenceRequest\022\017\n\007command\030\001 "
-  "\001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0226\n\005p"
-  "aram\030\004 \001(\0132\'.grpc_cli.SetLogPreferenceRe"
-  "quest.Param\032\"\n\005Param\022\031\n\021structuredLoggin"
-  "g\030\001 \001(\t\"\300\001\n\030SetLogPreferenceResponse\022\017\n\007"
-  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0229\n\006result\030\003 \001"
-  "(\0132).grpc_cli.SetLogPreferenceResponse.R"
-  "esult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*"
-  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
-  "us\"D\n\021LoggerInfoRequest\022\017\n\007command\030\001 \001(\t"
-  "\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\345\003\n\022Log"
-  "gerInfoResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cli.LoggerI"
-  "nfoResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_"
-  "cli.PosInfo\032\332\002\n\006Result\022 \n\006status\030\001 \001(\0132\020"
-  ".grpc_cli.Status\022<\n\004data\030\002 \001(\0132..grpc_cl"
-  "i.LoggerInfoResponse.Result.LoggerInfo\032\357"
-  "\001\n\nLoggerInfo\022\024\n\014minorLogPath\030\001 \001(\t\022\024\n\014m"
-  "ajorLogPath\030\002 \001(\t\022\027\n\017logfileSizeInMb\030\003 \001"
-  "(\t\022\034\n\024logfileRotationCount\030\004 \001(\005\022\034\n\024minA"
-  "llowableLogLevel\030\005 \001(\t\022\025\n\rfilterEnabled\030"
-  "\006 \001(\005\022\026\n\016filterIncluded\030\007 \001(\t\022\026\n\016filterE"
-  "xcluded\030\010 \001(\t\022\031\n\021structuredLogging\030\t \001(\010"
-  "\"E\n\022GetLogLevelRequest\022\017\n\007command\030\001 \001(\t\022"
-  "\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\217\002\n\023GetL"
-  "ogLevelResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.GetLogL"
-  "evelResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc"
-  "_cli.PosInfo\032\202\001\n\006Result\022 \n\006status\030\001 \001(\0132"
-  "\020.grpc_cli.Status\022;\n\004data\030\002 \001(\0132-.grpc_c"
-  "li.GetLogLevelResponse.Result.LogLevel\032\031"
-  "\n\010LogLevel\022\r\n\005level\030\001 \001(\t\"H\n\025ApplyLogFil"
-  "terRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t"
-  "\022\021\n\trequestor\030\003 \001(\t\"\274\001\n\026ApplyLogFilterRe"
-  "sponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006"
-  "result\030\003 \001(\0132\'.grpc_cli.ApplyLogFilterRe"
-  "sponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.P"
-  "osInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_"
-  "cli.Status\"\326\001\n\023CreateDeviceRequest\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 "
-  "\001(\t\0222\n\005param\030\004 \001(\0132#.grpc_cli.CreateDevi"
-  "ceRequest.Param\032Z\n\005Param\022\014\n\004name\030\001 \001(\t\022\021"
-  "\n\tnumBlocks\030\002 \001(\r\022\021\n\tblockSize\030\003 \001(\r\022\017\n\007"
-  "devType\030\004 \001(\t\022\014\n\004numa\030\005 \001(\r\"\270\001\n\024CreateDe"
-  "viceResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001"
-  "(\t\0225\n\006result\030\003 \001(\0132%.grpc_cli.CreateDevi"
-  "ceResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_c"
-  "li.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.g"
-  "rpc_cli.Status\"D\n\021ScanDeviceRequest\022\017\n\007c"
-  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003"
-  " \001(\t\"\264\001\n\022ScanDeviceResponse\022\017\n\007command\030\001"
-  " \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grpc"
-  "_cli.ScanDeviceResponse.Result\022\037\n\004info\030\004"
-  " \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006sta"
-  "tus\030\001 \001(\0132\020.grpc_cli.Status\"\213\001\n\006Device\022\014"
-  "\n\004name\030\001 \001(\t\022\014\n\004type\030\002 \001(\t\022\017\n\007address\030\003 "
-  "\001(\t\022\r\n\005class\030\004 \001(\t\022\023\n\013modelNumber\030\005 \001(\t\022"
-  "\014\n\004numa\030\006 \001(\t\022\014\n\004size\030\007 \001(\004\022\024\n\014serialNum"
-  "ber\030\010 \001(\t\"D\n\021ListDeviceRequest\022\017\n\007comman"
-  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\""
-  "\247\002\n\022ListDeviceResponse\022\017\n\007command\030\001 \001(\t\022"
-  "\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\0132#.grpc_cli."
-  "ListDeviceResponse.Result\022\037\n\004info\030\004 \001(\0132"
-  "\021.grpc_cli.PosInfo\032\234\001\n\006Result\022 \n\006status\030"
-  "\001 \001(\0132\020.grpc_cli.Status\022<\n\004data\030\002 \001(\0132.."
-  "grpc_cli.ListDeviceResponse.Result.Devic"
-  "eList\0322\n\nDeviceList\022$\n\ndevicelist\030\001 \003(\0132"
-  "\020.grpc_cli.Device\"\335\004\n\010SmartLog\022\033\n\023availa"
-  "bleSpareSpace\030\001 \001(\t\022\023\n\013temperature\030\002 \001(\t"
-  "\022\031\n\021deviceReliability\030\003 \001(\t\022\020\n\010readOnly\030"
-  "\004 \001(\t\022\034\n\024volatileMemoryBackup\030\005 \001(\t\022\032\n\022c"
-  "urrentTemperature\030\006 \001(\t\022\026\n\016availableSpar"
-  "e\030\007 \001(\t\022\037\n\027availableSpareThreshold\030\010 \001(\t"
-  "\022\032\n\022lifePercentageUsed\030\t \001(\t\022\025\n\rdataUnit"
-  "sRead\030\n \001(\t\022\030\n\020dataUnitsWritten\030\013 \001(\t\022\030\n"
-  "\020hostReadCommands\030\014 \001(\t\022\031\n\021hostWriteComm"
-  "ands\030\r \001(\t\022\032\n\022controllerBusyTime\030\016 \001(\t\022\023"
-  "\n\013powerCycles\030\017 \001(\t\022\024\n\014powerOnHours\030\020 \001("
-  "\t\022\027\n\017unsafeShutdowns\030\021 \001(\t\022 \n\030unrecovera"
-  "bleMediaErrors\030\022 \001(\t\022\037\n\027lifetimeErrorLog"
-  "Entries\030\023 \001(\t\022\036\n\026warningTemperatureTime\030"
-  "\024 \001(\t\022\037\n\027criticalTemperatureTime\030\025 \001(\t\022\031"
-  "\n\021temperatureSensor\030\026 \003(\t\"\217\001\n\022GetSmartLo"
-  "gRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021"
-  "\n\trequestor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_"
-  "cli.GetSmartLogRequest.Param\032\025\n\005Param\022\014\n"
-  "\004name\030\001 \001(\t\"\330\001\n\023GetSmartLogResponse\022\017\n\007c"
-  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001("
-  "\0132$.grpc_cli.GetSmartLogResponse.Result\022"
-  "\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032L\n\006Resu"
-  "lt\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022 \n\004"
-  "data\030\002 \001(\0132\022.grpc_cli.SmartLog\"\205\002\n\026Creat"
-  "eSubsystemRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
-  "d\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0225\n\005param\030\004 \001("
-  "\0132&.grpc_cli.CreateSubsystemRequest.Para"
-  "m\032\202\001\n\005Param\022\013\n\003nqn\030\001 \001(\t\022\024\n\014serialNumber"
-  "\030\002 \001(\t\022\023\n\013modelNumber\030\003 \001(\t\022\025\n\rmaxNamesp"
-  "aces\030\004 \001(\r\022\024\n\014allowAnyHost\030\005 \001(\010\022\024\n\014anaR"
-  "eporting\030\006 \001(\010\"\276\001\n\027CreateSubsystemRespon"
-  "se\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0228\n\006resu"
-  "lt\030\003 \001(\0132(.grpc_cli.CreateSubsystemRespo"
-  "nse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosI"
-  "nfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli"
-  ".Status\"\231\001\n\026DeleteSubsystemRequest\022\017\n\007co"
-  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 "
-  "\001(\t\0225\n\005param\030\004 \001(\0132&.grpc_cli.DeleteSubs"
-  "ystemRequest.Param\032\027\n\005Param\022\016\n\006subnqn\030\001 "
-  "\001(\t\"\276\001\n\027DeleteSubsystemResponse\022\017\n\007comma"
-  "nd\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0228\n\006result\030\003 \001(\0132(."
-  "grpc_cli.DeleteSubsystemResponse.Result\022"
-  "\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Resu"
-  "lt\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\333\001\n"
-  "\022AddListenerRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003"
-  "rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005param\030\004 "
-  "\001(\0132\".grpc_cli.AddListenerRequest.Param\032"
-  "a\n\005Param\022\016\n\006subnqn\030\001 \001(\t\022\025\n\rtransportTyp"
-  "e\030\002 \001(\t\022\025\n\rtargetAddress\030\003 \001(\t\022\032\n\022transp"
-  "ortServiceId\030\004 \001(\t\"\266\001\n\023AddListenerRespon"
-  "se\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006resu"
-  "lt\030\003 \001(\0132$.grpc_cli.AddListenerResponse."
-  "Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032"
-  "*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Sta"
-  "tus\"\327\003\n\tSubsystem\022\013\n\003nqn\030\001 \001(\t\022\017\n\007subtyp"
-  "e\030\002 \001(\t\0228\n\017listenAddresses\030\003 \003(\0132\037.grpc_"
-  "cli.Subsystem.AddressInfo\022\024\n\014allowAnyHos"
-  "t\030\004 \001(\005\022\'\n\005hosts\030\005 \003(\0132\030.grpc_cli.Subsys"
-  "tem.Host\022\024\n\014serialNumber\030\006 \001(\t\022\023\n\013modelN"
-  "umber\030\007 \001(\t\022\025\n\rmaxNamespaces\030\010 \001(\005\0221\n\nna"
-  "mespaces\030\t \003(\0132\035.grpc_cli.Subsystem.Name"
-  "space\032n\n\013AddressInfo\022\025\n\rtransportType\030\001 "
-  "\001(\t\022\025\n\raddressFamily\030\002 \001(\t\022\025\n\rtargetAddr"
-  "ess\030\003 \001(\t\022\032\n\022transportServiceId\030\004 \001(\t\032\023\n"
-  "\004Host\022\013\n\003nqn\030\001 \001(\t\0329\n\tNamespace\022\014\n\004nsid\030"
-  "\001 \001(\005\022\020\n\010bdevName\030\002 \001(\t\022\014\n\004uuid\030\003 \001(\t\"G\n"
-  "\024ListSubsystemRequest\022\017\n\007command\030\001 \001(\t\022\013"
-  "\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\274\002\n\025ListS"
-  "ubsystemResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
-  "\030\002 \001(\t\0226\n\006result\030\003 \001(\0132&.grpc_cli.ListSu"
-  "bsystemResponse.Result\022\037\n\004info\030\004 \001(\0132\021.g"
-  "rpc_cli.PosInfo\032\253\001\n\006Result\022 \n\006status\030\001 \001"
-  "(\0132\020.grpc_cli.Status\022B\n\004data\030\002 \001(\01324.grp"
-  "c_cli.ListSubsystemResponse.Result.Subsy"
-  "stemList\032;\n\rSubsystemList\022*\n\rsubsystemli"
-  "st\030\001 \003(\0132\023.grpc_cli.Subsystem\"\225\001\n\024Subsys"
-  "temInfoRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002"
-  " \001(\t\022\021\n\trequestor\030\003 \001(\t\0223\n\005param\030\004 \001(\0132$"
-  ".grpc_cli.SubsystemInfoRequest.Param\032\027\n\005"
-  "Param\022\016\n\006subnqn\030\001 \001(\t\"\274\002\n\025SubsystemInfoR"
-  "esponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0226\n"
-  "\006result\030\003 \001(\0132&.grpc_cli.SubsystemInfoRe"
-  "sponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.P"
-  "osInfo\032\253\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc"
-  "_cli.Status\022B\n\004data\030\002 \001(\01324.grpc_cli.Sub"
-  "systemInfoResponse.Result.SubsystemList\032"
-  ";\n\rSubsystemList\022*\n\rsubsystemlist\030\001 \003(\0132"
-  "\023.grpc_cli.Subsystem\"\314\001\n\026CreateTransport"
-  "Request\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n"
-  "\trequestor\030\003 \001(\t\0225\n\005param\030\004 \001(\0132&.grpc_c"
-  "li.CreateTransportRequest.Param\032J\n\005Param"
-  "\022\025\n\rtransportType\030\001 \001(\t\022\024\n\014bufCacheSize\030"
-  "\002 \001(\005\022\024\n\014numSharedBuf\030\003 \001(\005\"\276\001\n\027CreateTr"
-  "ansportResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030"
-  "\002 \001(\t\0228\n\006result\030\003 \001(\0132(.grpc_cli.CreateT"
-  "ransportResponse.Result\022\037\n\004info\030\004 \001(\0132\021."
-  "grpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001"
-  "(\0132\020.grpc_cli.Status\"\356\001\n\023CreateVolumeReq"
+  "sult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\366"
+  "\001\n\026AutocreateArrayRequest\022\017\n\007command\030\001 \001"
+  "(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0225\n\005pa"
+  "ram\030\004 \001(\0132&.grpc_cli.AutocreateArrayRequ"
+  "est.Param\032t\n\005Param\022\014\n\004name\030\001 \001(\t\022(\n\006buff"
+  "er\030\002 \003(\0132\030.grpc_cli.DeviceNameList\022\017\n\007nu"
+  "mData\030\003 \001(\005\022\020\n\010numSpare\030\004 \001(\005\022\020\n\010raidtyp"
+  "e\030\005 \001(\t\"\276\001\n\027AutocreateArrayResponse\022\017\n\007c"
+  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0228\n\006result\030\003 \001("
+  "\0132(.grpc_cli.AutocreateArrayResponse.Res"
+  "ult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006"
+  "Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status"
+  "\"\217\001\n\022DeleteArrayRequest\022\017\n\007command\030\001 \001(\t"
+  "\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0221\n\005para"
+  "m\030\004 \001(\0132\".grpc_cli.DeleteArrayRequest.Pa"
+  "ram\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\266\001\n\023DeleteArr"
+  "ayResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t"
+  "\0224\n\006result\030\003 \001(\0132$.grpc_cli.DeleteArrayR"
+  "esponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli."
+  "PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc"
+  "_cli.Status\"\305\001\n\021MountArrayRequest\022\017\n\007com"
+  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001"
+  "(\t\0220\n\005param\030\004 \001(\0132!.grpc_cli.MountArrayR"
+  "equest.Param\032M\n\005Param\022\014\n\004name\030\001 \001(\t\022\037\n\022e"
+  "nableWriteThrough\030\002 \001(\010H\000\210\001\001B\025\n\023_enableW"
+  "riteThrough\"\264\001\n\022MountArrayResponse\022\017\n\007co"
+  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 \001(\013"
+  "2#.grpc_cli.MountArrayResponse.Result\022\037\n"
+  "\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result"
+  "\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\221\001\n\023U"
+  "nmountArrayRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003r"
+  "id\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005param\030\004 \001"
+  "(\0132#.grpc_cli.UnmountArrayRequest.Param\032"
+  "\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\270\001\n\024UnmountArrayR"
+  "esponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n"
+  "\006result\030\003 \001(\0132%.grpc_cli.UnmountArrayRes"
+  "ponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Po"
+  "sInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_c"
+  "li.Status\"\314\002\n\005Array\022\r\n\005index\030\001 \001(\005\022\021\n\tun"
+  "ique_id\030\002 \001(\005\022\014\n\004name\030\003 \001(\t\022\016\n\006status\030\004 "
+  "\001(\t\022\r\n\005state\030\005 \001(\t\022\021\n\tsituation\030\006 \001(\t\022\026\n"
+  "\016createDatetime\030\007 \001(\t\022\026\n\016updateDatetime\030"
+  "\010 \001(\t\022\032\n\022rebuildingProgress\030\t \001(\t\022\020\n\010cap"
+  "acity\030\n \001(\004\022\014\n\004used\030\013 \001(\004\022\016\n\006gcMode\030\014 \001("
+  "\t\022\020\n\010metaRaid\030\r \001(\t\022\020\n\010dataRaid\030\016 \001(\t\022\033\n"
+  "\023writeThroughEnabled\030\017 \001(\010\022$\n\ndevicelist"
+  "\030\020 \003(\0132\020.grpc_cli.Device\"C\n\020ListArrayReq"
   "uest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tre"
-  "questor\030\003 \001(\t\0222\n\005param\030\004 \001(\0132#.grpc_cli."
-  "CreateVolumeRequest.Param\032r\n\005Param\022\014\n\004na"
-  "me\030\001 \001(\t\022\r\n\005array\030\002 \001(\t\022\014\n\004size\030\003 \001(\004\022\017\n"
-  "\007maxiops\030\004 \001(\004\022\r\n\005maxbw\030\005 \001(\004\022\020\n\010iswalvo"
-  "l\030\006 \001(\010\022\014\n\004uuid\030\007 \001(\t\"\270\001\n\024CreateVolumeRe"
-  "sponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006"
-  "result\030\003 \001(\0132%.grpc_cli.CreateVolumeResp"
+  "questor\030\003 \001(\t\"\240\002\n\021ListArrayResponse\022\017\n\007c"
+  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003 \001("
+  "\0132\".grpc_cli.ListArrayResponse.Result\022\037\n"
+  "\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\227\001\n\006Resul"
+  "t\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022:\n\004d"
+  "ata\030\002 \001(\0132,.grpc_cli.ListArrayResponse.R"
+  "esult.ArrayList\032/\n\tArrayList\022\"\n\tarrayLis"
+  "t\030\001 \003(\0132\017.grpc_cli.Array\"\213\001\n\020ArrayInfoRe"
+  "quest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tr"
+  "equestor\030\003 \001(\t\022/\n\005param\030\004 \001(\0132 .grpc_cli"
+  ".ArrayInfoRequest.Param\032\025\n\005Param\022\014\n\004name"
+  "\030\001 \001(\t\"\321\001\n\021ArrayInfoResponse\022\017\n\007command\030"
+  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0222\n\006result\030\003 \001(\0132\".grp"
+  "c_cli.ArrayInfoResponse.Result\022\037\n\004info\030\004"
+  " \001(\0132\021.grpc_cli.PosInfo\032I\n\006Result\022 \n\006sta"
+  "tus\030\001 \001(\0132\020.grpc_cli.Status\022\035\n\004data\030\002 \001("
+  "\0132\017.grpc_cli.Array\"B\n\017ListNodeRequest\022\017\n"
+  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor"
+  "\030\003 \001(\t\"\233\002\n\020ListNodeResponse\022\017\n\007command\030\001"
+  " \001(\t\022\013\n\003rid\030\002 \001(\t\0221\n\006result\030\003 \001(\0132!.grpc"
+  "_cli.ListNodeResponse.Result\022\037\n\004info\030\004 \001"
+  "(\0132\021.grpc_cli.PosInfo\032\224\001\n\006Result\022 \n\006stat"
+  "us\030\001 \001(\0132\020.grpc_cli.Status\0224\n\004data\030\002 \003(\013"
+  "2&.grpc_cli.ListNodeResponse.Result.Node"
+  "\0322\n\004Node\022\014\n\004name\030\001 \001(\t\022\n\n\002ip\030\002 \001(\t\022\020\n\010la"
+  "stseen\030\003 \001(\t\"F\n\023ListHaVolumeRequest\022\017\n\007c"
+  "ommand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003"
+  " \001(\t\"\336\002\n\024ListHaVolumeResponse\022\017\n\007command"
+  "\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001(\0132%.gr"
+  "pc_cli.ListHaVolumeResponse.Result\022\037\n\004in"
+  "fo\030\004 \001(\0132\021.grpc_cli.PosInfo\032\317\001\n\006Result\022 "
+  "\n\006status\030\001 \001(\0132\020.grpc_cli.Status\022:\n\004data"
+  "\030\002 \003(\0132,.grpc_cli.ListHaVolumeResponse.R"
+  "esult.Volume\032g\n\006Volume\022\n\n\002id\030\001 \001(\005\022\014\n\004na"
+  "me\030\002 \001(\t\022\020\n\010nodeName\030\003 \001(\t\022\021\n\tarrayName\030"
+  "\004 \001(\t\022\014\n\004size\030\005 \001(\003\022\020\n\010lastseen\030\006 \001(\t\"K\n"
+  "\030ListHaReplicationRequest\022\017\n\007command\030\001 \001"
+  "(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\226\003\n\031L"
+  "istHaReplicationResponse\022\017\n\007command\030\001 \001("
+  "\t\022\013\n\003rid\030\002 \001(\t\022:\n\006result\030\003 \001(\0132*.grpc_cl"
+  "i.ListHaReplicationResponse.Result\022\037\n\004in"
+  "fo\030\004 \001(\0132\021.grpc_cli.PosInfo\032\375\001\n\006Result\022 "
+  "\n\006status\030\001 \001(\0132\020.grpc_cli.Status\022D\n\004data"
+  "\030\002 \003(\01326.grpc_cli.ListHaReplicationRespo"
+  "nse.Result.Replication\032\212\001\n\013Replication\022\n"
+  "\n\002id\030\001 \001(\005\022\026\n\016sourceVolumeId\030\002 \001(\005\022\032\n\022so"
+  "urceWalVolume_id\030\003 \001(\005\022\033\n\023destinationVol"
+  "umeId\030\004 \001(\005\022\036\n\026destinationWalVolumeId\030\005 "
+  "\001(\005\"\223\003\n\031StartHaReplicationRequest\022\017\n\007com"
+  "mand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001"
+  "(\t\0228\n\005param\030\004 \001(\0132).grpc_cli.StartHaRepl"
+  "icationRequest.Param\032\212\002\n\005Param\022\027\n\017primar"
+  "yNodeName\030\001 \001(\t\022\030\n\020primaryArrayName\030\002 \001("
+  "\t\022\031\n\021primaryVolumeName\030\003 \001(\t\022\034\n\024primaryW"
+  "alVolumeName\030\004 \001(\t\022\031\n\021secondaryNodeName\030"
+  "\005 \001(\t\022\032\n\022secondaryArrayName\030\006 \001(\t\022\033\n\023sec"
+  "ondaryVolumeName\030\007 \001(\t\022\036\n\026secondaryWalVo"
+  "lumeName\030\010 \001(\t\022\016\n\006stuats\030\t \001(\t\022\021\n\ttimest"
+  "amp\030\n \001(\t\"\304\001\n\032StartHaReplicationResponse"
+  "\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022;\n\006result"
+  "\030\003 \001(\0132+.grpc_cli.StartHaReplicationResp"
   "onse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Pos"
   "Info\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cl"
-  "i.Status\"\240\002\n\030SetVolumePropertyRequest\022\017\n"
-  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor"
-  "\030\003 \001(\t\0227\n\005param\030\004 \001(\0132(.grpc_cli.SetVolu"
-  "mePropertyRequest.Param\032\231\001\n\005Param\022\014\n\004nam"
-  "e\030\001 \001(\t\022\r\n\005array\030\002 \001(\t\022\025\n\rnewVolumeName\030"
-  "\003 \001(\t\022\014\n\004size\030\004 \001(\004\022\017\n\007maxiops\030\005 \001(\004\022\r\n\005"
-  "maxbw\030\006 \001(\004\022\030\n\020updateprimaryvol\030\007 \001(\010\022\024\n"
-  "\014isprimaryvol\030\010 \001(\010\"\302\001\n\031SetVolumePropert"
-  "yResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022"
-  ":\n\006result\030\003 \001(\0132*.grpc_cli.SetVolumeProp"
-  "ertyResponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc"
-  "_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020"
-  ".grpc_cli.Status2\217\036\n\006PosCli\022_\n\nSystemInf"
-  "o\022\033.grpc_cli.SystemInfoRequest\032\034.grpc_cl"
-  "i.SystemInfoResponse\"\026\202\323\344\223\002\020\022\016/v1/system"
-  "info\022_\n\nStopSystem\022\033.grpc_cli.StopSystem"
-  "Request\032\034.grpc_cli.StopSystemResponse\"\026\202"
-  "\323\344\223\002\020\022\016/v1/stopsystem\022}\n\021GetSystemProper"
-  "ty\022\".grpc_cli.GetSystemPropertyRequest\032#"
-  ".grpc_cli.GetSystemPropertyResponse\"\037\202\323\344"
-  "\223\002\031\022\027/v1/get_system_property\022\205\001\n\021SetSyst"
-  "emProperty\022\".grpc_cli.SetSystemPropertyR"
-  "equest\032#.grpc_cli.SetSystemPropertyRespo"
-  "nse\"\'\202\323\344\223\002!\022\037/v1/set_system_property/{le"
-  "vel}\022p\n\016StartTelemetry\022\037.grpc_cli.StartT"
-  "elemetryRequest\032 .grpc_cli.StartTelemetr"
-  "yResponse\"\033\202\323\344\223\002\025\022\023/v1/start_telemetry\022l"
-  "\n\rStopTelemetry\022\036.grpc_cli.StopTelemetry"
-  "Request\032\037.grpc_cli.StopTelemetryResponse"
-  "\"\032\202\323\344\223\002\024\022\022/v1/stop_telemetry\022P\n\rResetEve"
-  "ntWrr\022\036.grpc_cli.ResetEventWrrRequest\032\037."
-  "grpc_cli.ResetEventWrrResponse\022A\n\010ResetM"
-  "br\022\031.grpc_cli.ResetMbrRequest\032\032.grpc_cli"
-  ".ResetMbrResponse\022S\n\016StopRebuilding\022\037.gr"
-  "pc_cli.StopRebuildingRequest\032 .grpc_cli."
-  "StopRebuildingResponse\022S\n\016UpdateEventWrr"
-  "\022\037.grpc_cli.UpdateEventWrrRequest\032 .grpc"
-  "_cli.UpdateEventWrrResponse\022W\n\010AddSpare\022"
-  "\031.grpc_cli.AddSpareRequest\032\032.grpc_cli.Ad"
-  "dSpareResponse\"\024\202\323\344\223\002\016\"\014/v1/addspare\022c\n\013"
-  "RemoveSpare\022\034.grpc_cli.RemoveSpareReques"
-  "t\032\035.grpc_cli.RemoveSpareResponse\"\027\202\323\344\223\002\021"
-  "\"\017/v1/removespare\022x\n\022ReplaceArrayDevice\022"
-  "#.grpc_cli.ReplaceArrayDeviceRequest\032$.g"
-  "rpc_cli.ReplaceArrayDeviceResponse\"\027\202\323\344\223"
-  "\002\021\"\017/v1/removespare\022c\n\013CreateArray\022\034.grp"
-  "c_cli.CreateArrayRequest\032\035.grpc_cli.Crea"
-  "teArrayResponse\"\027\202\323\344\223\002\021\"\017/v1/createarray"
-  "\022s\n\017AutocreateArray\022 .grpc_cli.Autocreat"
-  "eArrayRequest\032!.grpc_cli.AutocreateArray"
-  "Response\"\033\202\323\344\223\002\025\"\023/v1/autocreatearray\022d\n"
-  "\013DeleteArray\022\034.grpc_cli.DeleteArrayReque"
-  "st\032\035.grpc_cli.DeleteArrayResponse\"\030\202\323\344\223\002"
-  "\022\"\020/v1/deletearray/\022_\n\nMountArray\022\033.grpc"
-  "_cli.MountArrayRequest\032\034.grpc_cli.MountA"
-  "rrayResponse\"\026\202\323\344\223\002\020\"\016/v1/mountarray\022g\n\014"
-  "UnmountArray\022\035.grpc_cli.UnmountArrayRequ"
-  "est\032\036.grpc_cli.UnmountArrayResponse\"\030\202\323\344"
-  "\223\002\022\"\020/v1/unmountarray\022[\n\tListArray\022\032.grp"
-  "c_cli.ListArrayRequest\032\033.grpc_cli.ListAr"
-  "rayResponse\"\025\202\323\344\223\002\017\"\r/v1/listarray\022[\n\tAr"
-  "rayInfo\022\032.grpc_cli.ArrayInfoRequest\032\033.gr"
-  "pc_cli.ArrayInfoResponse\"\025\202\323\344\223\002\017\"\r/v1/ar"
-  "rayinfo\022w\n\020SetLogPreference\022!.grpc_cli.S"
-  "etLogPreferenceRequest\032\".grpc_cli.SetLog"
-  "PreferenceResponse\"\034\202\323\344\223\002\026\"\024/v1/setlogpr"
-  "eference\022c\n\013SetLogLevel\022\034.grpc_cli.SetLo"
-  "gLevelRequest\032\035.grpc_cli.SetLogLevelResp"
-  "onse\"\027\202\323\344\223\002\021\"\017/v1/setloglevel\022_\n\nLoggerI"
-  "nfo\022\033.grpc_cli.LoggerInfoRequest\032\034.grpc_"
-  "cli.LoggerInfoResponse\"\026\202\323\344\223\002\020\"\016/v1/logg"
-  "erinfo\022c\n\013GetLogLevel\022\034.grpc_cli.GetLogL"
-  "evelRequest\032\035.grpc_cli.GetLogLevelRespon"
-  "se\"\027\202\323\344\223\002\021\"\017/v1/getloglevel\022l\n\016ApplyLogF"
-  "ilter\022\037.grpc_cli.ApplyLogFilterRequest\032 "
-  ".grpc_cli.ApplyLogFilterResponse\"\027\202\323\344\223\002\021"
-  "\"\017/v1/applyfilter\022g\n\014CreateDevice\022\035.grpc"
-  "_cli.CreateDeviceRequest\032\036.grpc_cli.Crea"
-  "teDeviceResponse\"\030\202\323\344\223\002\022\"\020/v1/createdevi"
-  "ce\022_\n\nScanDevice\022\033.grpc_cli.ScanDeviceRe"
-  "quest\032\034.grpc_cli.ScanDeviceResponse\"\026\202\323\344"
-  "\223\002\020\"\016/v1/scandevice\022_\n\nListDevice\022\033.grpc"
-  "_cli.ListDeviceRequest\032\034.grpc_cli.ListDe"
-  "viceResponse\"\026\202\323\344\223\002\020\"\016/v1/listdevice\022`\n\013"
-  "GetSmartLog\022\034.grpc_cli.GetSmartLogReques"
-  "t\032\035.grpc_cli.GetSmartLogResponse\"\024\202\323\344\223\002\016"
-  "\"\014/v1/smartlog\022s\n\017CreateSubsystem\022 .grpc"
-  "_cli.CreateSubsystemRequest\032!.grpc_cli.C"
-  "reateSubsystemResponse\"\033\202\323\344\223\002\025\"\023/v1/crea"
-  "tesubsystem\022s\n\017DeleteSubsystem\022 .grpc_cl"
-  "i.DeleteSubsystemRequest\032!.grpc_cli.Dele"
-  "teSubsystemResponse\"\033\202\323\344\223\002\025\"\023/v1/deletes"
-  "ubsystem\022c\n\013AddListener\022\034.grpc_cli.AddLi"
-  "stenerRequest\032\035.grpc_cli.AddListenerResp"
-  "onse\"\027\202\323\344\223\002\021\"\017/v1/addlistener\022k\n\rListSub"
-  "system\022\036.grpc_cli.ListSubsystemRequest\032\037"
-  ".grpc_cli.ListSubsystemResponse\"\031\202\323\344\223\002\023\""
-  "\021/v1/listsubsystem\022k\n\rSubsystemInfo\022\036.gr"
-  "pc_cli.SubsystemInfoRequest\032\037.grpc_cli.S"
-  "ubsystemInfoResponse\"\031\202\323\344\223\002\023\"\021/v1/subsys"
-  "teminfo\022s\n\017CreateTransport\022 .grpc_cli.Cr"
-  "eateTransportRequest\032!.grpc_cli.CreateTr"
-  "ansportResponse\"\033\202\323\344\223\002\025\"\023/v1/createtrans"
-  "port\022g\n\014CreateVolume\022\035.grpc_cli.CreateVo"
-  "lumeRequest\032\036.grpc_cli.CreateVolumeRespo"
-  "nse\"\030\202\323\344\223\002\022\"\020/v1/createvolume\022{\n\021SetVolu"
-  "meProperty\022\".grpc_cli.SetVolumePropertyR"
-  "equest\032#.grpc_cli.SetVolumePropertyRespo"
-  "nse\"\035\202\323\344\223\002\027\"\025/v1/setvolumepropertyB\tZ\007cl"
-  "i/apib\006proto3"
+  "i.Status\"\220\001\n\022SetLogLevelRequest\022\017\n\007comma"
+  "nd\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t"
+  "\0221\n\005param\030\004 \001(\0132\".grpc_cli.SetLogLevelRe"
+  "quest.Param\032\026\n\005Param\022\r\n\005level\030\001 \001(\t\"\266\001\n\023"
+  "SetLogLevelResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003"
+  "rid\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.Set"
+  "LogLevelResponse.Result\022\037\n\004info\030\004 \001(\0132\021."
+  "grpc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001"
+  "(\0132\020.grpc_cli.Status\"\246\001\n\027SetLogPreferenc"
+  "eRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021"
+  "\n\trequestor\030\003 \001(\t\0226\n\005param\030\004 \001(\0132\'.grpc_"
+  "cli.SetLogPreferenceRequest.Param\032\"\n\005Par"
+  "am\022\031\n\021structuredLogging\030\001 \001(\t\"\300\001\n\030SetLog"
+  "PreferenceResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003r"
+  "id\030\002 \001(\t\0229\n\006result\030\003 \001(\0132).grpc_cli.SetL"
+  "ogPreferenceResponse.Result\022\037\n\004info\030\004 \001("
+  "\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006status"
+  "\030\001 \001(\0132\020.grpc_cli.Status\"D\n\021LoggerInfoRe"
+  "quest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tr"
+  "equestor\030\003 \001(\t\"\345\003\n\022LoggerInfoResponse\022\017\n"
+  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006result\030\003 "
+  "\001(\0132#.grpc_cli.LoggerInfoResponse.Result"
+  "\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\332\002\n\006Re"
+  "sult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022<"
+  "\n\004data\030\002 \001(\0132..grpc_cli.LoggerInfoRespon"
+  "se.Result.LoggerInfo\032\357\001\n\nLoggerInfo\022\024\n\014m"
+  "inorLogPath\030\001 \001(\t\022\024\n\014majorLogPath\030\002 \001(\t\022"
+  "\027\n\017logfileSizeInMb\030\003 \001(\t\022\034\n\024logfileRotat"
+  "ionCount\030\004 \001(\005\022\034\n\024minAllowableLogLevel\030\005"
+  " \001(\t\022\025\n\rfilterEnabled\030\006 \001(\005\022\026\n\016filterInc"
+  "luded\030\007 \001(\t\022\026\n\016filterExcluded\030\010 \001(\t\022\031\n\021s"
+  "tructuredLogging\030\t \001(\010\"E\n\022GetLogLevelReq"
+  "uest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\tre"
+  "questor\030\003 \001(\t\"\217\002\n\023GetLogLevelResponse\022\017\n"
+  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 "
+  "\001(\0132$.grpc_cli.GetLogLevelResponse.Resul"
+  "t\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\202\001\n\006R"
+  "esult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022"
+  ";\n\004data\030\002 \001(\0132-.grpc_cli.GetLogLevelResp"
+  "onse.Result.LogLevel\032\031\n\010LogLevel\022\r\n\005leve"
+  "l\030\001 \001(\t\"H\n\025ApplyLogFilterRequest\022\017\n\007comm"
+  "and\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001("
+  "\t\"\274\001\n\026ApplyLogFilterResponse\022\017\n\007command\030"
+  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0227\n\006result\030\003 \001(\0132\'.grp"
+  "c_cli.ApplyLogFilterResponse.Result\022\037\n\004i"
+  "nfo\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 "
+  "\n\006status\030\001 \001(\0132\020.grpc_cli.Status\"\326\001\n\023Cre"
+  "ateDeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
+  "\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005param\030\004 \001(\013"
+  "2#.grpc_cli.CreateDeviceRequest.Param\032Z\n"
+  "\005Param\022\014\n\004name\030\001 \001(\t\022\021\n\tnumBlocks\030\002 \001(\r\022"
+  "\021\n\tblockSize\030\003 \001(\r\022\017\n\007devType\030\004 \001(\t\022\014\n\004n"
+  "uma\030\005 \001(\r\"\270\001\n\024CreateDeviceResponse\022\017\n\007co"
+  "mmand\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001(\013"
+  "2%.grpc_cli.CreateDeviceResponse.Result\022"
+  "\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Resu"
+  "lt\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status\"D\n\021"
+  "ScanDeviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
+  "d\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\"\264\001\n\022ScanDevic"
+  "eResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022"
+  "3\n\006result\030\003 \001(\0132#.grpc_cli.ScanDeviceRes"
+  "ponse.Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.Po"
+  "sInfo\032*\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_c"
+  "li.Status\"\213\001\n\006Device\022\014\n\004name\030\001 \001(\t\022\014\n\004ty"
+  "pe\030\002 \001(\t\022\017\n\007address\030\003 \001(\t\022\r\n\005class\030\004 \001(\t"
+  "\022\023\n\013modelNumber\030\005 \001(\t\022\014\n\004numa\030\006 \001(\t\022\014\n\004s"
+  "ize\030\007 \001(\004\022\024\n\014serialNumber\030\010 \001(\t\"D\n\021ListD"
+  "eviceRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001"
+  "(\t\022\021\n\trequestor\030\003 \001(\t\"\247\002\n\022ListDeviceResp"
+  "onse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0223\n\006re"
+  "sult\030\003 \001(\0132#.grpc_cli.ListDeviceResponse"
+  ".Result\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo"
+  "\032\234\001\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.S"
+  "tatus\022<\n\004data\030\002 \001(\0132..grpc_cli.ListDevic"
+  "eResponse.Result.DeviceList\0322\n\nDeviceLis"
+  "t\022$\n\ndevicelist\030\001 \003(\0132\020.grpc_cli.Device\""
+  "\335\004\n\010SmartLog\022\033\n\023availableSpareSpace\030\001 \001("
+  "\t\022\023\n\013temperature\030\002 \001(\t\022\031\n\021deviceReliabil"
+  "ity\030\003 \001(\t\022\020\n\010readOnly\030\004 \001(\t\022\034\n\024volatileM"
+  "emoryBackup\030\005 \001(\t\022\032\n\022currentTemperature\030"
+  "\006 \001(\t\022\026\n\016availableSpare\030\007 \001(\t\022\037\n\027availab"
+  "leSpareThreshold\030\010 \001(\t\022\032\n\022lifePercentage"
+  "Used\030\t \001(\t\022\025\n\rdataUnitsRead\030\n \001(\t\022\030\n\020dat"
+  "aUnitsWritten\030\013 \001(\t\022\030\n\020hostReadCommands\030"
+  "\014 \001(\t\022\031\n\021hostWriteCommands\030\r \001(\t\022\032\n\022cont"
+  "rollerBusyTime\030\016 \001(\t\022\023\n\013powerCycles\030\017 \001("
+  "\t\022\024\n\014powerOnHours\030\020 \001(\t\022\027\n\017unsafeShutdow"
+  "ns\030\021 \001(\t\022 \n\030unrecoverableMediaErrors\030\022 \001"
+  "(\t\022\037\n\027lifetimeErrorLogEntries\030\023 \001(\t\022\036\n\026w"
+  "arningTemperatureTime\030\024 \001(\t\022\037\n\027criticalT"
+  "emperatureTime\030\025 \001(\t\022\031\n\021temperatureSenso"
+  "r\030\026 \003(\t\"\217\001\n\022GetSmartLogRequest\022\017\n\007comman"
+  "d\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\022"
+  "1\n\005param\030\004 \001(\0132\".grpc_cli.GetSmartLogReq"
+  "uest.Param\032\025\n\005Param\022\014\n\004name\030\001 \001(\t\"\330\001\n\023Ge"
+  "tSmartLogResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003ri"
+  "d\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cli.GetSm"
+  "artLogResponse.Result\022\037\n\004info\030\004 \001(\0132\021.gr"
+  "pc_cli.PosInfo\032L\n\006Result\022 \n\006status\030\001 \001(\013"
+  "2\020.grpc_cli.Status\022 \n\004data\030\002 \001(\0132\022.grpc_"
+  "cli.SmartLog\"\205\002\n\026CreateSubsystemRequest\022"
+  "\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequest"
+  "or\030\003 \001(\t\0225\n\005param\030\004 \001(\0132&.grpc_cli.Creat"
+  "eSubsystemRequest.Param\032\202\001\n\005Param\022\013\n\003nqn"
+  "\030\001 \001(\t\022\024\n\014serialNumber\030\002 \001(\t\022\023\n\013modelNum"
+  "ber\030\003 \001(\t\022\025\n\rmaxNamespaces\030\004 \001(\r\022\024\n\014allo"
+  "wAnyHost\030\005 \001(\010\022\024\n\014anaReporting\030\006 \001(\010\"\276\001\n"
+  "\027CreateSubsystemResponse\022\017\n\007command\030\001 \001("
+  "\t\022\013\n\003rid\030\002 \001(\t\0228\n\006result\030\003 \001(\0132(.grpc_cl"
+  "i.CreateSubsystemResponse.Result\022\037\n\004info"
+  "\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006s"
+  "tatus\030\001 \001(\0132\020.grpc_cli.Status\"\231\001\n\026Delete"
+  "SubsystemRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003rid"
+  "\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0225\n\005param\030\004 \001(\013"
+  "2&.grpc_cli.DeleteSubsystemRequest.Param"
+  "\032\027\n\005Param\022\016\n\006subnqn\030\001 \001(\t\"\276\001\n\027DeleteSubs"
+  "ystemResponse\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 "
+  "\001(\t\0228\n\006result\030\003 \001(\0132(.grpc_cli.DeleteSub"
+  "systemResponse.Result\022\037\n\004info\030\004 \001(\0132\021.gr"
+  "pc_cli.PosInfo\032*\n\006Result\022 \n\006status\030\001 \001(\013"
+  "2\020.grpc_cli.Status\"\333\001\n\022AddListenerReques"
+  "t\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treque"
+  "stor\030\003 \001(\t\0221\n\005param\030\004 \001(\0132\".grpc_cli.Add"
+  "ListenerRequest.Param\032a\n\005Param\022\016\n\006subnqn"
+  "\030\001 \001(\t\022\025\n\rtransportType\030\002 \001(\t\022\025\n\rtargetA"
+  "ddress\030\003 \001(\t\022\032\n\022transportServiceId\030\004 \001(\t"
+  "\"\266\001\n\023AddListenerResponse\022\017\n\007command\030\001 \001("
+  "\t\022\013\n\003rid\030\002 \001(\t\0224\n\006result\030\003 \001(\0132$.grpc_cl"
+  "i.AddListenerResponse.Result\022\037\n\004info\030\004 \001"
+  "(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006statu"
+  "s\030\001 \001(\0132\020.grpc_cli.Status\"\327\003\n\tSubsystem\022"
+  "\013\n\003nqn\030\001 \001(\t\022\017\n\007subtype\030\002 \001(\t\0228\n\017listenA"
+  "ddresses\030\003 \003(\0132\037.grpc_cli.Subsystem.Addr"
+  "essInfo\022\024\n\014allowAnyHost\030\004 \001(\005\022\'\n\005hosts\030\005"
+  " \003(\0132\030.grpc_cli.Subsystem.Host\022\024\n\014serial"
+  "Number\030\006 \001(\t\022\023\n\013modelNumber\030\007 \001(\t\022\025\n\rmax"
+  "Namespaces\030\010 \001(\005\0221\n\nnamespaces\030\t \003(\0132\035.g"
+  "rpc_cli.Subsystem.Namespace\032n\n\013AddressIn"
+  "fo\022\025\n\rtransportType\030\001 \001(\t\022\025\n\raddressFami"
+  "ly\030\002 \001(\t\022\025\n\rtargetAddress\030\003 \001(\t\022\032\n\022trans"
+  "portServiceId\030\004 \001(\t\032\023\n\004Host\022\013\n\003nqn\030\001 \001(\t"
+  "\0329\n\tNamespace\022\014\n\004nsid\030\001 \001(\005\022\020\n\010bdevName\030"
+  "\002 \001(\t\022\014\n\004uuid\030\003 \001(\t\"G\n\024ListSubsystemRequ"
+  "est\022\017\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\treq"
+  "uestor\030\003 \001(\t\"\274\002\n\025ListSubsystemResponse\022\017"
+  "\n\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0226\n\006result\030\003"
+  " \001(\0132&.grpc_cli.ListSubsystemResponse.Re"
+  "sult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032\253\001"
+  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
+  "us\022B\n\004data\030\002 \001(\01324.grpc_cli.ListSubsyste"
+  "mResponse.Result.SubsystemList\032;\n\rSubsys"
+  "temList\022*\n\rsubsystemlist\030\001 \003(\0132\023.grpc_cl"
+  "i.Subsystem\"\225\001\n\024SubsystemInfoRequest\022\017\n\007"
+  "command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030"
+  "\003 \001(\t\0223\n\005param\030\004 \001(\0132$.grpc_cli.Subsyste"
+  "mInfoRequest.Param\032\027\n\005Param\022\016\n\006subnqn\030\001 "
+  "\001(\t\"\274\002\n\025SubsystemInfoResponse\022\017\n\007command"
+  "\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0226\n\006result\030\003 \001(\0132&.gr"
+  "pc_cli.SubsystemInfoResponse.Result\022\037\n\004i"
+  "nfo\030\004 \001(\0132\021.grpc_cli.PosInfo\032\253\001\n\006Result\022"
+  " \n\006status\030\001 \001(\0132\020.grpc_cli.Status\022B\n\004dat"
+  "a\030\002 \001(\01324.grpc_cli.SubsystemInfoResponse"
+  ".Result.SubsystemList\032;\n\rSubsystemList\022*"
+  "\n\rsubsystemlist\030\001 \003(\0132\023.grpc_cli.Subsyst"
+  "em\"\314\001\n\026CreateTransportRequest\022\017\n\007command"
+  "\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0225"
+  "\n\005param\030\004 \001(\0132&.grpc_cli.CreateTransport"
+  "Request.Param\032J\n\005Param\022\025\n\rtransportType\030"
+  "\001 \001(\t\022\024\n\014bufCacheSize\030\002 \001(\005\022\024\n\014numShared"
+  "Buf\030\003 \001(\005\"\276\001\n\027CreateTransportResponse\022\017\n"
+  "\007command\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0228\n\006result\030\003 "
+  "\001(\0132(.grpc_cli.CreateTransportResponse.R"
+  "esult\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*"
+  "\n\006Result\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Stat"
+  "us\"\356\001\n\023CreateVolumeRequest\022\017\n\007command\030\001 "
+  "\001(\t\022\013\n\003rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0222\n\005p"
+  "aram\030\004 \001(\0132#.grpc_cli.CreateVolumeReques"
+  "t.Param\032r\n\005Param\022\014\n\004name\030\001 \001(\t\022\r\n\005array\030"
+  "\002 \001(\t\022\014\n\004size\030\003 \001(\004\022\017\n\007maxiops\030\004 \001(\004\022\r\n\005"
+  "maxbw\030\005 \001(\004\022\020\n\010iswalvol\030\006 \001(\010\022\014\n\004uuid\030\007 "
+  "\001(\t\"\270\001\n\024CreateVolumeResponse\022\017\n\007command\030"
+  "\001 \001(\t\022\013\n\003rid\030\002 \001(\t\0225\n\006result\030\003 \001(\0132%.grp"
+  "c_cli.CreateVolumeResponse.Result\022\037\n\004inf"
+  "o\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Result\022 \n\006"
+  "status\030\001 \001(\0132\020.grpc_cli.Status\"\240\002\n\030SetVo"
+  "lumePropertyRequest\022\017\n\007command\030\001 \001(\t\022\013\n\003"
+  "rid\030\002 \001(\t\022\021\n\trequestor\030\003 \001(\t\0227\n\005param\030\004 "
+  "\001(\0132(.grpc_cli.SetVolumePropertyRequest."
+  "Param\032\231\001\n\005Param\022\014\n\004name\030\001 \001(\t\022\r\n\005array\030\002"
+  " \001(\t\022\025\n\rnewVolumeName\030\003 \001(\t\022\014\n\004size\030\004 \001("
+  "\004\022\017\n\007maxiops\030\005 \001(\004\022\r\n\005maxbw\030\006 \001(\004\022\030\n\020upd"
+  "ateprimaryvol\030\007 \001(\010\022\024\n\014isprimaryvol\030\010 \001("
+  "\010\"\302\001\n\031SetVolumePropertyResponse\022\017\n\007comma"
+  "nd\030\001 \001(\t\022\013\n\003rid\030\002 \001(\t\022:\n\006result\030\003 \001(\0132*."
+  "grpc_cli.SetVolumePropertyResponse.Resul"
+  "t\022\037\n\004info\030\004 \001(\0132\021.grpc_cli.PosInfo\032*\n\006Re"
+  "sult\022 \n\006status\030\001 \001(\0132\020.grpc_cli.Status2\233"
+  "\037\n\006PosCli\022_\n\nSystemInfo\022\033.grpc_cli.Syste"
+  "mInfoRequest\032\034.grpc_cli.SystemInfoRespon"
+  "se\"\026\202\323\344\223\002\020\022\016/v1/systeminfo\022_\n\nStopSystem"
+  "\022\033.grpc_cli.StopSystemRequest\032\034.grpc_cli"
+  ".StopSystemResponse\"\026\202\323\344\223\002\020\022\016/v1/stopsys"
+  "tem\022}\n\021GetSystemProperty\022\".grpc_cli.GetS"
+  "ystemPropertyRequest\032#.grpc_cli.GetSyste"
+  "mPropertyResponse\"\037\202\323\344\223\002\031\022\027/v1/get_syste"
+  "m_property\022\205\001\n\021SetSystemProperty\022\".grpc_"
+  "cli.SetSystemPropertyRequest\032#.grpc_cli."
+  "SetSystemPropertyResponse\"\'\202\323\344\223\002!\022\037/v1/s"
+  "et_system_property/{level}\022p\n\016StartTelem"
+  "etry\022\037.grpc_cli.StartTelemetryRequest\032 ."
+  "grpc_cli.StartTelemetryResponse\"\033\202\323\344\223\002\025\022"
+  "\023/v1/start_telemetry\022l\n\rStopTelemetry\022\036."
+  "grpc_cli.StopTelemetryRequest\032\037.grpc_cli"
+  ".StopTelemetryResponse\"\032\202\323\344\223\002\024\022\022/v1/stop"
+  "_telemetry\022\211\001\n\024SetTelemetryProperty\022%.gr"
+  "pc_cli.SetTelemetryPropertyRequest\032&.grp"
+  "c_cli.SetTelemetryPropertyResponse\"\"\202\323\344\223"
+  "\002\034\022\032/v1/set_telemetry_property\022P\n\rResetE"
+  "ventWrr\022\036.grpc_cli.ResetEventWrrRequest\032"
+  "\037.grpc_cli.ResetEventWrrResponse\022A\n\010Rese"
+  "tMbr\022\031.grpc_cli.ResetMbrRequest\032\032.grpc_c"
+  "li.ResetMbrResponse\022S\n\016StopRebuilding\022\037."
+  "grpc_cli.StopRebuildingRequest\032 .grpc_cl"
+  "i.StopRebuildingResponse\022S\n\016UpdateEventW"
+  "rr\022\037.grpc_cli.UpdateEventWrrRequest\032 .gr"
+  "pc_cli.UpdateEventWrrResponse\022W\n\010AddSpar"
+  "e\022\031.grpc_cli.AddSpareRequest\032\032.grpc_cli."
+  "AddSpareResponse\"\024\202\323\344\223\002\016\"\014/v1/addspare\022c"
+  "\n\013RemoveSpare\022\034.grpc_cli.RemoveSpareRequ"
+  "est\032\035.grpc_cli.RemoveSpareResponse\"\027\202\323\344\223"
+  "\002\021\"\017/v1/removespare\022x\n\022ReplaceArrayDevic"
+  "e\022#.grpc_cli.ReplaceArrayDeviceRequest\032$"
+  ".grpc_cli.ReplaceArrayDeviceResponse\"\027\202\323"
+  "\344\223\002\021\"\017/v1/removespare\022c\n\013CreateArray\022\034.g"
+  "rpc_cli.CreateArrayRequest\032\035.grpc_cli.Cr"
+  "eateArrayResponse\"\027\202\323\344\223\002\021\"\017/v1/createarr"
+  "ay\022s\n\017AutocreateArray\022 .grpc_cli.Autocre"
+  "ateArrayRequest\032!.grpc_cli.AutocreateArr"
+  "ayResponse\"\033\202\323\344\223\002\025\"\023/v1/autocreatearray\022"
+  "d\n\013DeleteArray\022\034.grpc_cli.DeleteArrayReq"
+  "uest\032\035.grpc_cli.DeleteArrayResponse\"\030\202\323\344"
+  "\223\002\022\"\020/v1/deletearray/\022_\n\nMountArray\022\033.gr"
+  "pc_cli.MountArrayRequest\032\034.grpc_cli.Moun"
+  "tArrayResponse\"\026\202\323\344\223\002\020\"\016/v1/mountarray\022g"
+  "\n\014UnmountArray\022\035.grpc_cli.UnmountArrayRe"
+  "quest\032\036.grpc_cli.UnmountArrayResponse\"\030\202"
+  "\323\344\223\002\022\"\020/v1/unmountarray\022[\n\tListArray\022\032.g"
+  "rpc_cli.ListArrayRequest\032\033.grpc_cli.List"
+  "ArrayResponse\"\025\202\323\344\223\002\017\"\r/v1/listarray\022[\n\t"
+  "ArrayInfo\022\032.grpc_cli.ArrayInfoRequest\032\033."
+  "grpc_cli.ArrayInfoResponse\"\025\202\323\344\223\002\017\"\r/v1/"
+  "arrayinfo\022w\n\020SetLogPreference\022!.grpc_cli"
+  ".SetLogPreferenceRequest\032\".grpc_cli.SetL"
+  "ogPreferenceResponse\"\034\202\323\344\223\002\026\"\024/v1/setlog"
+  "preference\022c\n\013SetLogLevel\022\034.grpc_cli.Set"
+  "LogLevelRequest\032\035.grpc_cli.SetLogLevelRe"
+  "sponse\"\027\202\323\344\223\002\021\"\017/v1/setloglevel\022_\n\nLogge"
+  "rInfo\022\033.grpc_cli.LoggerInfoRequest\032\034.grp"
+  "c_cli.LoggerInfoResponse\"\026\202\323\344\223\002\020\"\016/v1/lo"
+  "ggerinfo\022c\n\013GetLogLevel\022\034.grpc_cli.GetLo"
+  "gLevelRequest\032\035.grpc_cli.GetLogLevelResp"
+  "onse\"\027\202\323\344\223\002\021\"\017/v1/getloglevel\022l\n\016ApplyLo"
+  "gFilter\022\037.grpc_cli.ApplyLogFilterRequest"
+  "\032 .grpc_cli.ApplyLogFilterResponse\"\027\202\323\344\223"
+  "\002\021\"\017/v1/applyfilter\022g\n\014CreateDevice\022\035.gr"
+  "pc_cli.CreateDeviceRequest\032\036.grpc_cli.Cr"
+  "eateDeviceResponse\"\030\202\323\344\223\002\022\"\020/v1/createde"
+  "vice\022_\n\nScanDevice\022\033.grpc_cli.ScanDevice"
+  "Request\032\034.grpc_cli.ScanDeviceResponse\"\026\202"
+  "\323\344\223\002\020\"\016/v1/scandevice\022_\n\nListDevice\022\033.gr"
+  "pc_cli.ListDeviceRequest\032\034.grpc_cli.List"
+  "DeviceResponse\"\026\202\323\344\223\002\020\"\016/v1/listdevice\022`"
+  "\n\013GetSmartLog\022\034.grpc_cli.GetSmartLogRequ"
+  "est\032\035.grpc_cli.GetSmartLogResponse\"\024\202\323\344\223"
+  "\002\016\"\014/v1/smartlog\022s\n\017CreateSubsystem\022 .gr"
+  "pc_cli.CreateSubsystemRequest\032!.grpc_cli"
+  ".CreateSubsystemResponse\"\033\202\323\344\223\002\025\"\023/v1/cr"
+  "eatesubsystem\022s\n\017DeleteSubsystem\022 .grpc_"
+  "cli.DeleteSubsystemRequest\032!.grpc_cli.De"
+  "leteSubsystemResponse\"\033\202\323\344\223\002\025\"\023/v1/delet"
+  "esubsystem\022c\n\013AddListener\022\034.grpc_cli.Add"
+  "ListenerRequest\032\035.grpc_cli.AddListenerRe"
+  "sponse\"\027\202\323\344\223\002\021\"\017/v1/addlistener\022k\n\rListS"
+  "ubsystem\022\036.grpc_cli.ListSubsystemRequest"
+  "\032\037.grpc_cli.ListSubsystemResponse\"\031\202\323\344\223\002"
+  "\023\"\021/v1/listsubsystem\022k\n\rSubsystemInfo\022\036."
+  "grpc_cli.SubsystemInfoRequest\032\037.grpc_cli"
+  ".SubsystemInfoResponse\"\031\202\323\344\223\002\023\"\021/v1/subs"
+  "ysteminfo\022s\n\017CreateTransport\022 .grpc_cli."
+  "CreateTransportRequest\032!.grpc_cli.Create"
+  "TransportResponse\"\033\202\323\344\223\002\025\"\023/v1/createtra"
+  "nsport\022g\n\014CreateVolume\022\035.grpc_cli.Create"
+  "VolumeRequest\032\036.grpc_cli.CreateVolumeRes"
+  "ponse\"\030\202\323\344\223\002\022\"\020/v1/createvolume\022{\n\021SetVo"
+  "lumeProperty\022\".grpc_cli.SetVolumePropert"
+  "yRequest\032#.grpc_cli.SetVolumePropertyRes"
+  "ponse\"\035\202\323\344\223\002\027\"\025/v1/setvolumepropertyB\tZ\007"
+  "cli/apib\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_cli_2eproto_deps[1] = {
   &::descriptor_table_annotations_2eproto,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_cli_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_cli_2eproto = {
-  false, false, 21573, descriptor_table_protodef_cli_2eproto, "cli.proto", 
-  &descriptor_table_cli_2eproto_once, descriptor_table_cli_2eproto_deps, 1, 170,
+  false, false, 22095, descriptor_table_protodef_cli_2eproto, "cli.proto", 
+  &descriptor_table_cli_2eproto_once, descriptor_table_cli_2eproto_deps, 1, 174,
   schemas, file_default_instances, TableStruct_cli_2eproto::offsets,
   file_level_metadata_cli_2eproto, file_level_enum_descriptors_cli_2eproto, file_level_service_descriptors_cli_2eproto,
 };
@@ -11462,6 +11567,1056 @@ void StopTelemetryResponse::InternalSwap(StopTelemetryResponse* other) {
 }
 
 ::PROTOBUF_NAMESPACE_ID::Metadata StopTelemetryResponse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class SetTelemetryPropertyRequest_Param::_Internal {
+ public:
+};
+
+SetTelemetryPropertyRequest_Param::SetTelemetryPropertyRequest_Param(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.SetTelemetryPropertyRequest.Param)
+}
+SetTelemetryPropertyRequest_Param::SetTelemetryPropertyRequest_Param(const SetTelemetryPropertyRequest_Param& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  publicationlistpath_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_publicationlistpath().empty()) {
+    publicationlistpath_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_publicationlistpath(), 
+      GetArena());
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.SetTelemetryPropertyRequest.Param)
+}
+
+void SetTelemetryPropertyRequest_Param::SharedCtor() {
+publicationlistpath_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+SetTelemetryPropertyRequest_Param::~SetTelemetryPropertyRequest_Param() {
+  // @@protoc_insertion_point(destructor:grpc_cli.SetTelemetryPropertyRequest.Param)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void SetTelemetryPropertyRequest_Param::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  publicationlistpath_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+void SetTelemetryPropertyRequest_Param::ArenaDtor(void* object) {
+  SetTelemetryPropertyRequest_Param* _this = reinterpret_cast< SetTelemetryPropertyRequest_Param* >(object);
+  (void)_this;
+}
+void SetTelemetryPropertyRequest_Param::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void SetTelemetryPropertyRequest_Param::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void SetTelemetryPropertyRequest_Param::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.SetTelemetryPropertyRequest.Param)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  publicationlistpath_.ClearToEmpty();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SetTelemetryPropertyRequest_Param::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // string publicationListPath = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          auto str = _internal_mutable_publicationlistpath();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SetTelemetryPropertyRequest.Param.publicationListPath"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* SetTelemetryPropertyRequest_Param::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.SetTelemetryPropertyRequest.Param)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string publicationListPath = 1;
+  if (this->publicationlistpath().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_publicationlistpath().data(), static_cast<int>(this->_internal_publicationlistpath().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SetTelemetryPropertyRequest.Param.publicationListPath");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_publicationlistpath(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.SetTelemetryPropertyRequest.Param)
+  return target;
+}
+
+size_t SetTelemetryPropertyRequest_Param::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.SetTelemetryPropertyRequest.Param)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string publicationListPath = 1;
+  if (this->publicationlistpath().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_publicationlistpath());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void SetTelemetryPropertyRequest_Param::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.SetTelemetryPropertyRequest.Param)
+  GOOGLE_DCHECK_NE(&from, this);
+  const SetTelemetryPropertyRequest_Param* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<SetTelemetryPropertyRequest_Param>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.SetTelemetryPropertyRequest.Param)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.SetTelemetryPropertyRequest.Param)
+    MergeFrom(*source);
+  }
+}
+
+void SetTelemetryPropertyRequest_Param::MergeFrom(const SetTelemetryPropertyRequest_Param& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.SetTelemetryPropertyRequest.Param)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.publicationlistpath().size() > 0) {
+    _internal_set_publicationlistpath(from._internal_publicationlistpath());
+  }
+}
+
+void SetTelemetryPropertyRequest_Param::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.SetTelemetryPropertyRequest.Param)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SetTelemetryPropertyRequest_Param::CopyFrom(const SetTelemetryPropertyRequest_Param& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.SetTelemetryPropertyRequest.Param)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SetTelemetryPropertyRequest_Param::IsInitialized() const {
+  return true;
+}
+
+void SetTelemetryPropertyRequest_Param::InternalSwap(SetTelemetryPropertyRequest_Param* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  publicationlistpath_.Swap(&other->publicationlistpath_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SetTelemetryPropertyRequest_Param::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class SetTelemetryPropertyRequest::_Internal {
+ public:
+  static const ::grpc_cli::SetTelemetryPropertyRequest_Param& param(const SetTelemetryPropertyRequest* msg);
+};
+
+const ::grpc_cli::SetTelemetryPropertyRequest_Param&
+SetTelemetryPropertyRequest::_Internal::param(const SetTelemetryPropertyRequest* msg) {
+  return *msg->param_;
+}
+SetTelemetryPropertyRequest::SetTelemetryPropertyRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.SetTelemetryPropertyRequest)
+}
+SetTelemetryPropertyRequest::SetTelemetryPropertyRequest(const SetTelemetryPropertyRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_command().empty()) {
+    command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_command(), 
+      GetArena());
+  }
+  rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_rid().empty()) {
+    rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_rid(), 
+      GetArena());
+  }
+  requestor_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_requestor().empty()) {
+    requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_requestor(), 
+      GetArena());
+  }
+  if (from._internal_has_param()) {
+    param_ = new ::grpc_cli::SetTelemetryPropertyRequest_Param(*from.param_);
+  } else {
+    param_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.SetTelemetryPropertyRequest)
+}
+
+void SetTelemetryPropertyRequest::SharedCtor() {
+command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+requestor_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+param_ = nullptr;
+}
+
+SetTelemetryPropertyRequest::~SetTelemetryPropertyRequest() {
+  // @@protoc_insertion_point(destructor:grpc_cli.SetTelemetryPropertyRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void SetTelemetryPropertyRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  command_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  rid_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  requestor_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (this != internal_default_instance()) delete param_;
+}
+
+void SetTelemetryPropertyRequest::ArenaDtor(void* object) {
+  SetTelemetryPropertyRequest* _this = reinterpret_cast< SetTelemetryPropertyRequest* >(object);
+  (void)_this;
+}
+void SetTelemetryPropertyRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void SetTelemetryPropertyRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void SetTelemetryPropertyRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.SetTelemetryPropertyRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  command_.ClearToEmpty();
+  rid_.ClearToEmpty();
+  requestor_.ClearToEmpty();
+  if (GetArena() == nullptr && param_ != nullptr) {
+    delete param_;
+  }
+  param_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SetTelemetryPropertyRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // string command = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          auto str = _internal_mutable_command();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SetTelemetryPropertyRequest.command"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string rid = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_rid();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SetTelemetryPropertyRequest.rid"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string requestor = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          auto str = _internal_mutable_requestor();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SetTelemetryPropertyRequest.requestor"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .grpc_cli.SetTelemetryPropertyRequest.Param param = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 34)) {
+          ptr = ctx->ParseMessage(_internal_mutable_param(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* SetTelemetryPropertyRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.SetTelemetryPropertyRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_command().data(), static_cast<int>(this->_internal_command().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SetTelemetryPropertyRequest.command");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_command(), target);
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_rid().data(), static_cast<int>(this->_internal_rid().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SetTelemetryPropertyRequest.rid");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_rid(), target);
+  }
+
+  // string requestor = 3;
+  if (this->requestor().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_requestor().data(), static_cast<int>(this->_internal_requestor().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SetTelemetryPropertyRequest.requestor");
+    target = stream->WriteStringMaybeAliased(
+        3, this->_internal_requestor(), target);
+  }
+
+  // .grpc_cli.SetTelemetryPropertyRequest.Param param = 4;
+  if (this->has_param()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        4, _Internal::param(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.SetTelemetryPropertyRequest)
+  return target;
+}
+
+size_t SetTelemetryPropertyRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.SetTelemetryPropertyRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_command());
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_rid());
+  }
+
+  // string requestor = 3;
+  if (this->requestor().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_requestor());
+  }
+
+  // .grpc_cli.SetTelemetryPropertyRequest.Param param = 4;
+  if (this->has_param()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *param_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void SetTelemetryPropertyRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.SetTelemetryPropertyRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const SetTelemetryPropertyRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<SetTelemetryPropertyRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.SetTelemetryPropertyRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.SetTelemetryPropertyRequest)
+    MergeFrom(*source);
+  }
+}
+
+void SetTelemetryPropertyRequest::MergeFrom(const SetTelemetryPropertyRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.SetTelemetryPropertyRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.command().size() > 0) {
+    _internal_set_command(from._internal_command());
+  }
+  if (from.rid().size() > 0) {
+    _internal_set_rid(from._internal_rid());
+  }
+  if (from.requestor().size() > 0) {
+    _internal_set_requestor(from._internal_requestor());
+  }
+  if (from.has_param()) {
+    _internal_mutable_param()->::grpc_cli::SetTelemetryPropertyRequest_Param::MergeFrom(from._internal_param());
+  }
+}
+
+void SetTelemetryPropertyRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.SetTelemetryPropertyRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SetTelemetryPropertyRequest::CopyFrom(const SetTelemetryPropertyRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.SetTelemetryPropertyRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SetTelemetryPropertyRequest::IsInitialized() const {
+  return true;
+}
+
+void SetTelemetryPropertyRequest::InternalSwap(SetTelemetryPropertyRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  command_.Swap(&other->command_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  rid_.Swap(&other->rid_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  requestor_.Swap(&other->requestor_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  swap(param_, other->param_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SetTelemetryPropertyRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class SetTelemetryPropertyResponse_Result::_Internal {
+ public:
+  static const ::grpc_cli::Status& status(const SetTelemetryPropertyResponse_Result* msg);
+};
+
+const ::grpc_cli::Status&
+SetTelemetryPropertyResponse_Result::_Internal::status(const SetTelemetryPropertyResponse_Result* msg) {
+  return *msg->status_;
+}
+SetTelemetryPropertyResponse_Result::SetTelemetryPropertyResponse_Result(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.SetTelemetryPropertyResponse.Result)
+}
+SetTelemetryPropertyResponse_Result::SetTelemetryPropertyResponse_Result(const SetTelemetryPropertyResponse_Result& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  if (from._internal_has_status()) {
+    status_ = new ::grpc_cli::Status(*from.status_);
+  } else {
+    status_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.SetTelemetryPropertyResponse.Result)
+}
+
+void SetTelemetryPropertyResponse_Result::SharedCtor() {
+status_ = nullptr;
+}
+
+SetTelemetryPropertyResponse_Result::~SetTelemetryPropertyResponse_Result() {
+  // @@protoc_insertion_point(destructor:grpc_cli.SetTelemetryPropertyResponse.Result)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void SetTelemetryPropertyResponse_Result::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  if (this != internal_default_instance()) delete status_;
+}
+
+void SetTelemetryPropertyResponse_Result::ArenaDtor(void* object) {
+  SetTelemetryPropertyResponse_Result* _this = reinterpret_cast< SetTelemetryPropertyResponse_Result* >(object);
+  (void)_this;
+}
+void SetTelemetryPropertyResponse_Result::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void SetTelemetryPropertyResponse_Result::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void SetTelemetryPropertyResponse_Result::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.SetTelemetryPropertyResponse.Result)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  if (GetArena() == nullptr && status_ != nullptr) {
+    delete status_;
+  }
+  status_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SetTelemetryPropertyResponse_Result::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // .grpc_cli.Status status = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr = ctx->ParseMessage(_internal_mutable_status(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* SetTelemetryPropertyResponse_Result::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.SetTelemetryPropertyResponse.Result)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // .grpc_cli.Status status = 1;
+  if (this->has_status()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        1, _Internal::status(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.SetTelemetryPropertyResponse.Result)
+  return target;
+}
+
+size_t SetTelemetryPropertyResponse_Result::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.SetTelemetryPropertyResponse.Result)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // .grpc_cli.Status status = 1;
+  if (this->has_status()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *status_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void SetTelemetryPropertyResponse_Result::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.SetTelemetryPropertyResponse.Result)
+  GOOGLE_DCHECK_NE(&from, this);
+  const SetTelemetryPropertyResponse_Result* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<SetTelemetryPropertyResponse_Result>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.SetTelemetryPropertyResponse.Result)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.SetTelemetryPropertyResponse.Result)
+    MergeFrom(*source);
+  }
+}
+
+void SetTelemetryPropertyResponse_Result::MergeFrom(const SetTelemetryPropertyResponse_Result& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.SetTelemetryPropertyResponse.Result)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.has_status()) {
+    _internal_mutable_status()->::grpc_cli::Status::MergeFrom(from._internal_status());
+  }
+}
+
+void SetTelemetryPropertyResponse_Result::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.SetTelemetryPropertyResponse.Result)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SetTelemetryPropertyResponse_Result::CopyFrom(const SetTelemetryPropertyResponse_Result& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.SetTelemetryPropertyResponse.Result)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SetTelemetryPropertyResponse_Result::IsInitialized() const {
+  return true;
+}
+
+void SetTelemetryPropertyResponse_Result::InternalSwap(SetTelemetryPropertyResponse_Result* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  swap(status_, other->status_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SetTelemetryPropertyResponse_Result::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+class SetTelemetryPropertyResponse::_Internal {
+ public:
+  static const ::grpc_cli::SetTelemetryPropertyResponse_Result& result(const SetTelemetryPropertyResponse* msg);
+  static const ::grpc_cli::PosInfo& info(const SetTelemetryPropertyResponse* msg);
+};
+
+const ::grpc_cli::SetTelemetryPropertyResponse_Result&
+SetTelemetryPropertyResponse::_Internal::result(const SetTelemetryPropertyResponse* msg) {
+  return *msg->result_;
+}
+const ::grpc_cli::PosInfo&
+SetTelemetryPropertyResponse::_Internal::info(const SetTelemetryPropertyResponse* msg) {
+  return *msg->info_;
+}
+SetTelemetryPropertyResponse::SetTelemetryPropertyResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:grpc_cli.SetTelemetryPropertyResponse)
+}
+SetTelemetryPropertyResponse::SetTelemetryPropertyResponse(const SetTelemetryPropertyResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_command().empty()) {
+    command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_command(), 
+      GetArena());
+  }
+  rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_rid().empty()) {
+    rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, from._internal_rid(), 
+      GetArena());
+  }
+  if (from._internal_has_result()) {
+    result_ = new ::grpc_cli::SetTelemetryPropertyResponse_Result(*from.result_);
+  } else {
+    result_ = nullptr;
+  }
+  if (from._internal_has_info()) {
+    info_ = new ::grpc_cli::PosInfo(*from.info_);
+  } else {
+    info_ = nullptr;
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_cli.SetTelemetryPropertyResponse)
+}
+
+void SetTelemetryPropertyResponse::SharedCtor() {
+command_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+rid_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+::memset(reinterpret_cast<char*>(this) + static_cast<size_t>(
+    reinterpret_cast<char*>(&result_) - reinterpret_cast<char*>(this)),
+    0, static_cast<size_t>(reinterpret_cast<char*>(&info_) -
+    reinterpret_cast<char*>(&result_)) + sizeof(info_));
+}
+
+SetTelemetryPropertyResponse::~SetTelemetryPropertyResponse() {
+  // @@protoc_insertion_point(destructor:grpc_cli.SetTelemetryPropertyResponse)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void SetTelemetryPropertyResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  command_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  rid_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (this != internal_default_instance()) delete result_;
+  if (this != internal_default_instance()) delete info_;
+}
+
+void SetTelemetryPropertyResponse::ArenaDtor(void* object) {
+  SetTelemetryPropertyResponse* _this = reinterpret_cast< SetTelemetryPropertyResponse* >(object);
+  (void)_this;
+}
+void SetTelemetryPropertyResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void SetTelemetryPropertyResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+
+void SetTelemetryPropertyResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_cli.SetTelemetryPropertyResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  command_.ClearToEmpty();
+  rid_.ClearToEmpty();
+  if (GetArena() == nullptr && result_ != nullptr) {
+    delete result_;
+  }
+  result_ = nullptr;
+  if (GetArena() == nullptr && info_ != nullptr) {
+    delete info_;
+  }
+  info_ = nullptr;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* SetTelemetryPropertyResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // string command = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          auto str = _internal_mutable_command();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SetTelemetryPropertyResponse.command"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string rid = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_rid();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "grpc_cli.SetTelemetryPropertyResponse.rid"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .grpc_cli.SetTelemetryPropertyResponse.Result result = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 26)) {
+          ptr = ctx->ParseMessage(_internal_mutable_result(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // .grpc_cli.PosInfo info = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 34)) {
+          ptr = ctx->ParseMessage(_internal_mutable_info(), ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* SetTelemetryPropertyResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_cli.SetTelemetryPropertyResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_command().data(), static_cast<int>(this->_internal_command().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SetTelemetryPropertyResponse.command");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_command(), target);
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_rid().data(), static_cast<int>(this->_internal_rid().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpc_cli.SetTelemetryPropertyResponse.rid");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_rid(), target);
+  }
+
+  // .grpc_cli.SetTelemetryPropertyResponse.Result result = 3;
+  if (this->has_result()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        3, _Internal::result(this), target, stream);
+  }
+
+  // .grpc_cli.PosInfo info = 4;
+  if (this->has_info()) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(
+        4, _Internal::info(this), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_cli.SetTelemetryPropertyResponse)
+  return target;
+}
+
+size_t SetTelemetryPropertyResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_cli.SetTelemetryPropertyResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string command = 1;
+  if (this->command().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_command());
+  }
+
+  // string rid = 2;
+  if (this->rid().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_rid());
+  }
+
+  // .grpc_cli.SetTelemetryPropertyResponse.Result result = 3;
+  if (this->has_result()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *result_);
+  }
+
+  // .grpc_cli.PosInfo info = 4;
+  if (this->has_info()) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(
+        *info_);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void SetTelemetryPropertyResponse::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_cli.SetTelemetryPropertyResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const SetTelemetryPropertyResponse* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<SetTelemetryPropertyResponse>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_cli.SetTelemetryPropertyResponse)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_cli.SetTelemetryPropertyResponse)
+    MergeFrom(*source);
+  }
+}
+
+void SetTelemetryPropertyResponse::MergeFrom(const SetTelemetryPropertyResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_cli.SetTelemetryPropertyResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.command().size() > 0) {
+    _internal_set_command(from._internal_command());
+  }
+  if (from.rid().size() > 0) {
+    _internal_set_rid(from._internal_rid());
+  }
+  if (from.has_result()) {
+    _internal_mutable_result()->::grpc_cli::SetTelemetryPropertyResponse_Result::MergeFrom(from._internal_result());
+  }
+  if (from.has_info()) {
+    _internal_mutable_info()->::grpc_cli::PosInfo::MergeFrom(from._internal_info());
+  }
+}
+
+void SetTelemetryPropertyResponse::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_cli.SetTelemetryPropertyResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void SetTelemetryPropertyResponse::CopyFrom(const SetTelemetryPropertyResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_cli.SetTelemetryPropertyResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool SetTelemetryPropertyResponse::IsInitialized() const {
+  return true;
+}
+
+void SetTelemetryPropertyResponse::InternalSwap(SetTelemetryPropertyResponse* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  command_.Swap(&other->command_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  rid_.Swap(&other->rid_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(SetTelemetryPropertyResponse, info_)
+      + sizeof(SetTelemetryPropertyResponse::info_)
+      - PROTOBUF_FIELD_OFFSET(SetTelemetryPropertyResponse, result_)>(
+          reinterpret_cast<char*>(&result_),
+          reinterpret_cast<char*>(&other->result_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata SetTelemetryPropertyResponse::GetMetadata() const {
   return GetMetadataStatic();
 }
 
@@ -53877,6 +55032,18 @@ template<> PROTOBUF_NOINLINE ::grpc_cli::StopTelemetryResponse_Result* Arena::Cr
 }
 template<> PROTOBUF_NOINLINE ::grpc_cli::StopTelemetryResponse* Arena::CreateMaybeMessage< ::grpc_cli::StopTelemetryResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::grpc_cli::StopTelemetryResponse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::SetTelemetryPropertyRequest_Param* Arena::CreateMaybeMessage< ::grpc_cli::SetTelemetryPropertyRequest_Param >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::SetTelemetryPropertyRequest_Param >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::SetTelemetryPropertyRequest* Arena::CreateMaybeMessage< ::grpc_cli::SetTelemetryPropertyRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::SetTelemetryPropertyRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::SetTelemetryPropertyResponse_Result* Arena::CreateMaybeMessage< ::grpc_cli::SetTelemetryPropertyResponse_Result >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::SetTelemetryPropertyResponse_Result >(arena);
+}
+template<> PROTOBUF_NOINLINE ::grpc_cli::SetTelemetryPropertyResponse* Arena::CreateMaybeMessage< ::grpc_cli::SetTelemetryPropertyResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::grpc_cli::SetTelemetryPropertyResponse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::grpc_cli::ResetEventWrrRequest* Arena::CreateMaybeMessage< ::grpc_cli::ResetEventWrrRequest >(Arena* arena) {
   return Arena::CreateMessageInternal< ::grpc_cli::ResetEventWrrRequest >(arena);

--- a/proto/generated/cpp/cli.pb.h
+++ b/proto/generated/cpp/cli.pb.h
@@ -47,7 +47,7 @@ struct TableStruct_cli_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxiliaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[170]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[174]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -434,6 +434,18 @@ extern SetSystemPropertyResponseDefaultTypeInternal _SetSystemPropertyResponse_d
 class SetSystemPropertyResponse_Result;
 struct SetSystemPropertyResponse_ResultDefaultTypeInternal;
 extern SetSystemPropertyResponse_ResultDefaultTypeInternal _SetSystemPropertyResponse_Result_default_instance_;
+class SetTelemetryPropertyRequest;
+struct SetTelemetryPropertyRequestDefaultTypeInternal;
+extern SetTelemetryPropertyRequestDefaultTypeInternal _SetTelemetryPropertyRequest_default_instance_;
+class SetTelemetryPropertyRequest_Param;
+struct SetTelemetryPropertyRequest_ParamDefaultTypeInternal;
+extern SetTelemetryPropertyRequest_ParamDefaultTypeInternal _SetTelemetryPropertyRequest_Param_default_instance_;
+class SetTelemetryPropertyResponse;
+struct SetTelemetryPropertyResponseDefaultTypeInternal;
+extern SetTelemetryPropertyResponseDefaultTypeInternal _SetTelemetryPropertyResponse_default_instance_;
+class SetTelemetryPropertyResponse_Result;
+struct SetTelemetryPropertyResponse_ResultDefaultTypeInternal;
+extern SetTelemetryPropertyResponse_ResultDefaultTypeInternal _SetTelemetryPropertyResponse_Result_default_instance_;
 class SetVolumePropertyRequest;
 struct SetVolumePropertyRequestDefaultTypeInternal;
 extern SetVolumePropertyRequestDefaultTypeInternal _SetVolumePropertyRequest_default_instance_;
@@ -694,6 +706,10 @@ template<> ::grpc_cli::SetSystemPropertyRequest* Arena::CreateMaybeMessage<::grp
 template<> ::grpc_cli::SetSystemPropertyRequest_Param* Arena::CreateMaybeMessage<::grpc_cli::SetSystemPropertyRequest_Param>(Arena*);
 template<> ::grpc_cli::SetSystemPropertyResponse* Arena::CreateMaybeMessage<::grpc_cli::SetSystemPropertyResponse>(Arena*);
 template<> ::grpc_cli::SetSystemPropertyResponse_Result* Arena::CreateMaybeMessage<::grpc_cli::SetSystemPropertyResponse_Result>(Arena*);
+template<> ::grpc_cli::SetTelemetryPropertyRequest* Arena::CreateMaybeMessage<::grpc_cli::SetTelemetryPropertyRequest>(Arena*);
+template<> ::grpc_cli::SetTelemetryPropertyRequest_Param* Arena::CreateMaybeMessage<::grpc_cli::SetTelemetryPropertyRequest_Param>(Arena*);
+template<> ::grpc_cli::SetTelemetryPropertyResponse* Arena::CreateMaybeMessage<::grpc_cli::SetTelemetryPropertyResponse>(Arena*);
+template<> ::grpc_cli::SetTelemetryPropertyResponse_Result* Arena::CreateMaybeMessage<::grpc_cli::SetTelemetryPropertyResponse_Result>(Arena*);
 template<> ::grpc_cli::SetVolumePropertyRequest* Arena::CreateMaybeMessage<::grpc_cli::SetVolumePropertyRequest>(Arena*);
 template<> ::grpc_cli::SetVolumePropertyRequest_Param* Arena::CreateMaybeMessage<::grpc_cli::SetVolumePropertyRequest_Param>(Arena*);
 template<> ::grpc_cli::SetVolumePropertyResponse* Arena::CreateMaybeMessage<::grpc_cli::SetVolumePropertyResponse>(Arena*);
@@ -5047,6 +5063,702 @@ class StopTelemetryResponse PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class SetTelemetryPropertyRequest_Param PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.SetTelemetryPropertyRequest.Param) */ {
+ public:
+  inline SetTelemetryPropertyRequest_Param() : SetTelemetryPropertyRequest_Param(nullptr) {}
+  virtual ~SetTelemetryPropertyRequest_Param();
+  explicit constexpr SetTelemetryPropertyRequest_Param(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  SetTelemetryPropertyRequest_Param(const SetTelemetryPropertyRequest_Param& from);
+  SetTelemetryPropertyRequest_Param(SetTelemetryPropertyRequest_Param&& from) noexcept
+    : SetTelemetryPropertyRequest_Param() {
+    *this = ::std::move(from);
+  }
+
+  inline SetTelemetryPropertyRequest_Param& operator=(const SetTelemetryPropertyRequest_Param& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetTelemetryPropertyRequest_Param& operator=(SetTelemetryPropertyRequest_Param&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const SetTelemetryPropertyRequest_Param& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetTelemetryPropertyRequest_Param* internal_default_instance() {
+    return reinterpret_cast<const SetTelemetryPropertyRequest_Param*>(
+               &_SetTelemetryPropertyRequest_Param_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    23;
+
+  friend void swap(SetTelemetryPropertyRequest_Param& a, SetTelemetryPropertyRequest_Param& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SetTelemetryPropertyRequest_Param* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetTelemetryPropertyRequest_Param* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SetTelemetryPropertyRequest_Param* New() const final {
+    return CreateMaybeMessage<SetTelemetryPropertyRequest_Param>(nullptr);
+  }
+
+  SetTelemetryPropertyRequest_Param* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SetTelemetryPropertyRequest_Param>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const SetTelemetryPropertyRequest_Param& from);
+  void MergeFrom(const SetTelemetryPropertyRequest_Param& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SetTelemetryPropertyRequest_Param* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.SetTelemetryPropertyRequest.Param";
+  }
+  protected:
+  explicit SetTelemetryPropertyRequest_Param(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kPublicationListPathFieldNumber = 1,
+  };
+  // string publicationListPath = 1;
+  void clear_publicationlistpath();
+  const std::string& publicationlistpath() const;
+  void set_publicationlistpath(const std::string& value);
+  void set_publicationlistpath(std::string&& value);
+  void set_publicationlistpath(const char* value);
+  void set_publicationlistpath(const char* value, size_t size);
+  std::string* mutable_publicationlistpath();
+  std::string* release_publicationlistpath();
+  void set_allocated_publicationlistpath(std::string* publicationlistpath);
+  private:
+  const std::string& _internal_publicationlistpath() const;
+  void _internal_set_publicationlistpath(const std::string& value);
+  std::string* _internal_mutable_publicationlistpath();
+  public:
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.SetTelemetryPropertyRequest.Param)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr publicationlistpath_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetTelemetryPropertyRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.SetTelemetryPropertyRequest) */ {
+ public:
+  inline SetTelemetryPropertyRequest() : SetTelemetryPropertyRequest(nullptr) {}
+  virtual ~SetTelemetryPropertyRequest();
+  explicit constexpr SetTelemetryPropertyRequest(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  SetTelemetryPropertyRequest(const SetTelemetryPropertyRequest& from);
+  SetTelemetryPropertyRequest(SetTelemetryPropertyRequest&& from) noexcept
+    : SetTelemetryPropertyRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline SetTelemetryPropertyRequest& operator=(const SetTelemetryPropertyRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetTelemetryPropertyRequest& operator=(SetTelemetryPropertyRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const SetTelemetryPropertyRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetTelemetryPropertyRequest* internal_default_instance() {
+    return reinterpret_cast<const SetTelemetryPropertyRequest*>(
+               &_SetTelemetryPropertyRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    24;
+
+  friend void swap(SetTelemetryPropertyRequest& a, SetTelemetryPropertyRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SetTelemetryPropertyRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetTelemetryPropertyRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SetTelemetryPropertyRequest* New() const final {
+    return CreateMaybeMessage<SetTelemetryPropertyRequest>(nullptr);
+  }
+
+  SetTelemetryPropertyRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SetTelemetryPropertyRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const SetTelemetryPropertyRequest& from);
+  void MergeFrom(const SetTelemetryPropertyRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SetTelemetryPropertyRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.SetTelemetryPropertyRequest";
+  }
+  protected:
+  explicit SetTelemetryPropertyRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  typedef SetTelemetryPropertyRequest_Param Param;
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kCommandFieldNumber = 1,
+    kRidFieldNumber = 2,
+    kRequestorFieldNumber = 3,
+    kParamFieldNumber = 4,
+  };
+  // string command = 1;
+  void clear_command();
+  const std::string& command() const;
+  void set_command(const std::string& value);
+  void set_command(std::string&& value);
+  void set_command(const char* value);
+  void set_command(const char* value, size_t size);
+  std::string* mutable_command();
+  std::string* release_command();
+  void set_allocated_command(std::string* command);
+  private:
+  const std::string& _internal_command() const;
+  void _internal_set_command(const std::string& value);
+  std::string* _internal_mutable_command();
+  public:
+
+  // string rid = 2;
+  void clear_rid();
+  const std::string& rid() const;
+  void set_rid(const std::string& value);
+  void set_rid(std::string&& value);
+  void set_rid(const char* value);
+  void set_rid(const char* value, size_t size);
+  std::string* mutable_rid();
+  std::string* release_rid();
+  void set_allocated_rid(std::string* rid);
+  private:
+  const std::string& _internal_rid() const;
+  void _internal_set_rid(const std::string& value);
+  std::string* _internal_mutable_rid();
+  public:
+
+  // string requestor = 3;
+  void clear_requestor();
+  const std::string& requestor() const;
+  void set_requestor(const std::string& value);
+  void set_requestor(std::string&& value);
+  void set_requestor(const char* value);
+  void set_requestor(const char* value, size_t size);
+  std::string* mutable_requestor();
+  std::string* release_requestor();
+  void set_allocated_requestor(std::string* requestor);
+  private:
+  const std::string& _internal_requestor() const;
+  void _internal_set_requestor(const std::string& value);
+  std::string* _internal_mutable_requestor();
+  public:
+
+  // .grpc_cli.SetTelemetryPropertyRequest.Param param = 4;
+  bool has_param() const;
+  private:
+  bool _internal_has_param() const;
+  public:
+  void clear_param();
+  const ::grpc_cli::SetTelemetryPropertyRequest_Param& param() const;
+  ::grpc_cli::SetTelemetryPropertyRequest_Param* release_param();
+  ::grpc_cli::SetTelemetryPropertyRequest_Param* mutable_param();
+  void set_allocated_param(::grpc_cli::SetTelemetryPropertyRequest_Param* param);
+  private:
+  const ::grpc_cli::SetTelemetryPropertyRequest_Param& _internal_param() const;
+  ::grpc_cli::SetTelemetryPropertyRequest_Param* _internal_mutable_param();
+  public:
+  void unsafe_arena_set_allocated_param(
+      ::grpc_cli::SetTelemetryPropertyRequest_Param* param);
+  ::grpc_cli::SetTelemetryPropertyRequest_Param* unsafe_arena_release_param();
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.SetTelemetryPropertyRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr command_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr rid_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr requestor_;
+  ::grpc_cli::SetTelemetryPropertyRequest_Param* param_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetTelemetryPropertyResponse_Result PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.SetTelemetryPropertyResponse.Result) */ {
+ public:
+  inline SetTelemetryPropertyResponse_Result() : SetTelemetryPropertyResponse_Result(nullptr) {}
+  virtual ~SetTelemetryPropertyResponse_Result();
+  explicit constexpr SetTelemetryPropertyResponse_Result(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  SetTelemetryPropertyResponse_Result(const SetTelemetryPropertyResponse_Result& from);
+  SetTelemetryPropertyResponse_Result(SetTelemetryPropertyResponse_Result&& from) noexcept
+    : SetTelemetryPropertyResponse_Result() {
+    *this = ::std::move(from);
+  }
+
+  inline SetTelemetryPropertyResponse_Result& operator=(const SetTelemetryPropertyResponse_Result& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetTelemetryPropertyResponse_Result& operator=(SetTelemetryPropertyResponse_Result&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const SetTelemetryPropertyResponse_Result& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetTelemetryPropertyResponse_Result* internal_default_instance() {
+    return reinterpret_cast<const SetTelemetryPropertyResponse_Result*>(
+               &_SetTelemetryPropertyResponse_Result_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    25;
+
+  friend void swap(SetTelemetryPropertyResponse_Result& a, SetTelemetryPropertyResponse_Result& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SetTelemetryPropertyResponse_Result* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetTelemetryPropertyResponse_Result* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SetTelemetryPropertyResponse_Result* New() const final {
+    return CreateMaybeMessage<SetTelemetryPropertyResponse_Result>(nullptr);
+  }
+
+  SetTelemetryPropertyResponse_Result* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SetTelemetryPropertyResponse_Result>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const SetTelemetryPropertyResponse_Result& from);
+  void MergeFrom(const SetTelemetryPropertyResponse_Result& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SetTelemetryPropertyResponse_Result* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.SetTelemetryPropertyResponse.Result";
+  }
+  protected:
+  explicit SetTelemetryPropertyResponse_Result(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kStatusFieldNumber = 1,
+  };
+  // .grpc_cli.Status status = 1;
+  bool has_status() const;
+  private:
+  bool _internal_has_status() const;
+  public:
+  void clear_status();
+  const ::grpc_cli::Status& status() const;
+  ::grpc_cli::Status* release_status();
+  ::grpc_cli::Status* mutable_status();
+  void set_allocated_status(::grpc_cli::Status* status);
+  private:
+  const ::grpc_cli::Status& _internal_status() const;
+  ::grpc_cli::Status* _internal_mutable_status();
+  public:
+  void unsafe_arena_set_allocated_status(
+      ::grpc_cli::Status* status);
+  ::grpc_cli::Status* unsafe_arena_release_status();
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.SetTelemetryPropertyResponse.Result)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::grpc_cli::Status* status_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
+class SetTelemetryPropertyResponse PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.SetTelemetryPropertyResponse) */ {
+ public:
+  inline SetTelemetryPropertyResponse() : SetTelemetryPropertyResponse(nullptr) {}
+  virtual ~SetTelemetryPropertyResponse();
+  explicit constexpr SetTelemetryPropertyResponse(::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized);
+
+  SetTelemetryPropertyResponse(const SetTelemetryPropertyResponse& from);
+  SetTelemetryPropertyResponse(SetTelemetryPropertyResponse&& from) noexcept
+    : SetTelemetryPropertyResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline SetTelemetryPropertyResponse& operator=(const SetTelemetryPropertyResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline SetTelemetryPropertyResponse& operator=(SetTelemetryPropertyResponse&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const SetTelemetryPropertyResponse& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const SetTelemetryPropertyResponse* internal_default_instance() {
+    return reinterpret_cast<const SetTelemetryPropertyResponse*>(
+               &_SetTelemetryPropertyResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    26;
+
+  friend void swap(SetTelemetryPropertyResponse& a, SetTelemetryPropertyResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(SetTelemetryPropertyResponse* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(SetTelemetryPropertyResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline SetTelemetryPropertyResponse* New() const final {
+    return CreateMaybeMessage<SetTelemetryPropertyResponse>(nullptr);
+  }
+
+  SetTelemetryPropertyResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<SetTelemetryPropertyResponse>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const SetTelemetryPropertyResponse& from);
+  void MergeFrom(const SetTelemetryPropertyResponse& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(SetTelemetryPropertyResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "grpc_cli.SetTelemetryPropertyResponse";
+  }
+  protected:
+  explicit SetTelemetryPropertyResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    return ::descriptor_table_cli_2eproto_metadata_getter(kIndexInFileMessages);
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  typedef SetTelemetryPropertyResponse_Result Result;
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kCommandFieldNumber = 1,
+    kRidFieldNumber = 2,
+    kResultFieldNumber = 3,
+    kInfoFieldNumber = 4,
+  };
+  // string command = 1;
+  void clear_command();
+  const std::string& command() const;
+  void set_command(const std::string& value);
+  void set_command(std::string&& value);
+  void set_command(const char* value);
+  void set_command(const char* value, size_t size);
+  std::string* mutable_command();
+  std::string* release_command();
+  void set_allocated_command(std::string* command);
+  private:
+  const std::string& _internal_command() const;
+  void _internal_set_command(const std::string& value);
+  std::string* _internal_mutable_command();
+  public:
+
+  // string rid = 2;
+  void clear_rid();
+  const std::string& rid() const;
+  void set_rid(const std::string& value);
+  void set_rid(std::string&& value);
+  void set_rid(const char* value);
+  void set_rid(const char* value, size_t size);
+  std::string* mutable_rid();
+  std::string* release_rid();
+  void set_allocated_rid(std::string* rid);
+  private:
+  const std::string& _internal_rid() const;
+  void _internal_set_rid(const std::string& value);
+  std::string* _internal_mutable_rid();
+  public:
+
+  // .grpc_cli.SetTelemetryPropertyResponse.Result result = 3;
+  bool has_result() const;
+  private:
+  bool _internal_has_result() const;
+  public:
+  void clear_result();
+  const ::grpc_cli::SetTelemetryPropertyResponse_Result& result() const;
+  ::grpc_cli::SetTelemetryPropertyResponse_Result* release_result();
+  ::grpc_cli::SetTelemetryPropertyResponse_Result* mutable_result();
+  void set_allocated_result(::grpc_cli::SetTelemetryPropertyResponse_Result* result);
+  private:
+  const ::grpc_cli::SetTelemetryPropertyResponse_Result& _internal_result() const;
+  ::grpc_cli::SetTelemetryPropertyResponse_Result* _internal_mutable_result();
+  public:
+  void unsafe_arena_set_allocated_result(
+      ::grpc_cli::SetTelemetryPropertyResponse_Result* result);
+  ::grpc_cli::SetTelemetryPropertyResponse_Result* unsafe_arena_release_result();
+
+  // .grpc_cli.PosInfo info = 4;
+  bool has_info() const;
+  private:
+  bool _internal_has_info() const;
+  public:
+  void clear_info();
+  const ::grpc_cli::PosInfo& info() const;
+  ::grpc_cli::PosInfo* release_info();
+  ::grpc_cli::PosInfo* mutable_info();
+  void set_allocated_info(::grpc_cli::PosInfo* info);
+  private:
+  const ::grpc_cli::PosInfo& _internal_info() const;
+  ::grpc_cli::PosInfo* _internal_mutable_info();
+  public:
+  void unsafe_arena_set_allocated_info(
+      ::grpc_cli::PosInfo* info);
+  ::grpc_cli::PosInfo* unsafe_arena_release_info();
+
+  // @@protoc_insertion_point(class_scope:grpc_cli.SetTelemetryPropertyResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr command_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr rid_;
+  ::grpc_cli::SetTelemetryPropertyResponse_Result* result_;
+  ::grpc_cli::PosInfo* info_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_cli_2eproto;
+};
+// -------------------------------------------------------------------
+
 class ResetEventWrrRequest PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:grpc_cli.ResetEventWrrRequest) */ {
  public:
@@ -5090,7 +5802,7 @@ class ResetEventWrrRequest PROTOBUF_FINAL :
                &_ResetEventWrrRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    23;
+    27;
 
   friend void swap(ResetEventWrrRequest& a, ResetEventWrrRequest& b) {
     a.Swap(&b);
@@ -5270,7 +5982,7 @@ class ResetEventWrrResponse_Result PROTOBUF_FINAL :
                &_ResetEventWrrResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    24;
+    28;
 
   friend void swap(ResetEventWrrResponse_Result& a, ResetEventWrrResponse_Result& b) {
     a.Swap(&b);
@@ -5416,7 +6128,7 @@ class ResetEventWrrResponse PROTOBUF_FINAL :
                &_ResetEventWrrResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    25;
+    29;
 
   friend void swap(ResetEventWrrResponse& a, ResetEventWrrResponse& b) {
     a.Swap(&b);
@@ -5620,7 +6332,7 @@ class ResetMbrRequest PROTOBUF_FINAL :
                &_ResetMbrRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    26;
+    30;
 
   friend void swap(ResetMbrRequest& a, ResetMbrRequest& b) {
     a.Swap(&b);
@@ -5800,7 +6512,7 @@ class ResetMbrResponse_Result PROTOBUF_FINAL :
                &_ResetMbrResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    27;
+    31;
 
   friend void swap(ResetMbrResponse_Result& a, ResetMbrResponse_Result& b) {
     a.Swap(&b);
@@ -5946,7 +6658,7 @@ class ResetMbrResponse PROTOBUF_FINAL :
                &_ResetMbrResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    28;
+    32;
 
   friend void swap(ResetMbrResponse& a, ResetMbrResponse& b) {
     a.Swap(&b);
@@ -6150,7 +6862,7 @@ class StopRebuildingRequest_Param PROTOBUF_FINAL :
                &_StopRebuildingRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    29;
+    33;
 
   friend void swap(StopRebuildingRequest_Param& a, StopRebuildingRequest_Param& b) {
     a.Swap(&b);
@@ -6294,7 +7006,7 @@ class StopRebuildingRequest PROTOBUF_FINAL :
                &_StopRebuildingRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    30;
+    34;
 
   friend void swap(StopRebuildingRequest& a, StopRebuildingRequest& b) {
     a.Swap(&b);
@@ -6496,7 +7208,7 @@ class StopRebuildingResponse_Result PROTOBUF_FINAL :
                &_StopRebuildingResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    31;
+    35;
 
   friend void swap(StopRebuildingResponse_Result& a, StopRebuildingResponse_Result& b) {
     a.Swap(&b);
@@ -6642,7 +7354,7 @@ class StopRebuildingResponse PROTOBUF_FINAL :
                &_StopRebuildingResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    32;
+    36;
 
   friend void swap(StopRebuildingResponse& a, StopRebuildingResponse& b) {
     a.Swap(&b);
@@ -6846,7 +7558,7 @@ class UpdateEventWrrRequest_Param PROTOBUF_FINAL :
                &_UpdateEventWrrRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    33;
+    37;
 
   friend void swap(UpdateEventWrrRequest_Param& a, UpdateEventWrrRequest_Param& b) {
     a.Swap(&b);
@@ -7001,7 +7713,7 @@ class UpdateEventWrrRequest PROTOBUF_FINAL :
                &_UpdateEventWrrRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    34;
+    38;
 
   friend void swap(UpdateEventWrrRequest& a, UpdateEventWrrRequest& b) {
     a.Swap(&b);
@@ -7203,7 +7915,7 @@ class UpdateEventWrrResponse_Result PROTOBUF_FINAL :
                &_UpdateEventWrrResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    35;
+    39;
 
   friend void swap(UpdateEventWrrResponse_Result& a, UpdateEventWrrResponse_Result& b) {
     a.Swap(&b);
@@ -7349,7 +8061,7 @@ class UpdateEventWrrResponse PROTOBUF_FINAL :
                &_UpdateEventWrrResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    36;
+    40;
 
   friend void swap(UpdateEventWrrResponse& a, UpdateEventWrrResponse& b) {
     a.Swap(&b);
@@ -7553,7 +8265,7 @@ class AddSpareRequest_SpareDeviceName PROTOBUF_FINAL :
                &_AddSpareRequest_SpareDeviceName_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    37;
+    41;
 
   friend void swap(AddSpareRequest_SpareDeviceName& a, AddSpareRequest_SpareDeviceName& b) {
     a.Swap(&b);
@@ -7697,7 +8409,7 @@ class AddSpareRequest_Param PROTOBUF_FINAL :
                &_AddSpareRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    38;
+    42;
 
   friend void swap(AddSpareRequest_Param& a, AddSpareRequest_Param& b) {
     a.Swap(&b);
@@ -7861,7 +8573,7 @@ class AddSpareRequest PROTOBUF_FINAL :
                &_AddSpareRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    39;
+    43;
 
   friend void swap(AddSpareRequest& a, AddSpareRequest& b) {
     a.Swap(&b);
@@ -8064,7 +8776,7 @@ class AddSpareResponse_Result PROTOBUF_FINAL :
                &_AddSpareResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    40;
+    44;
 
   friend void swap(AddSpareResponse_Result& a, AddSpareResponse_Result& b) {
     a.Swap(&b);
@@ -8210,7 +8922,7 @@ class AddSpareResponse PROTOBUF_FINAL :
                &_AddSpareResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    41;
+    45;
 
   friend void swap(AddSpareResponse& a, AddSpareResponse& b) {
     a.Swap(&b);
@@ -8414,7 +9126,7 @@ class DeviceNameList PROTOBUF_FINAL :
                &_DeviceNameList_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    42;
+    46;
 
   friend void swap(DeviceNameList& a, DeviceNameList& b) {
     a.Swap(&b);
@@ -8558,7 +9270,7 @@ class RemoveSpareRequest_SpareDeviceName PROTOBUF_FINAL :
                &_RemoveSpareRequest_SpareDeviceName_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    43;
+    47;
 
   friend void swap(RemoveSpareRequest_SpareDeviceName& a, RemoveSpareRequest_SpareDeviceName& b) {
     a.Swap(&b);
@@ -8702,7 +9414,7 @@ class RemoveSpareRequest_Param PROTOBUF_FINAL :
                &_RemoveSpareRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    44;
+    48;
 
   friend void swap(RemoveSpareRequest_Param& a, RemoveSpareRequest_Param& b) {
     a.Swap(&b);
@@ -8866,7 +9578,7 @@ class RemoveSpareRequest PROTOBUF_FINAL :
                &_RemoveSpareRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    45;
+    49;
 
   friend void swap(RemoveSpareRequest& a, RemoveSpareRequest& b) {
     a.Swap(&b);
@@ -9069,7 +9781,7 @@ class RemoveSpareResponse_Result PROTOBUF_FINAL :
                &_RemoveSpareResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    46;
+    50;
 
   friend void swap(RemoveSpareResponse_Result& a, RemoveSpareResponse_Result& b) {
     a.Swap(&b);
@@ -9215,7 +9927,7 @@ class RemoveSpareResponse PROTOBUF_FINAL :
                &_RemoveSpareResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    47;
+    51;
 
   friend void swap(RemoveSpareResponse& a, RemoveSpareResponse& b) {
     a.Swap(&b);
@@ -9419,7 +10131,7 @@ class ReplaceArrayDeviceRequest_Param PROTOBUF_FINAL :
                &_ReplaceArrayDeviceRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    48;
+    52;
 
   friend void swap(ReplaceArrayDeviceRequest_Param& a, ReplaceArrayDeviceRequest_Param& b) {
     a.Swap(&b);
@@ -9581,7 +10293,7 @@ class ReplaceArrayDeviceRequest PROTOBUF_FINAL :
                &_ReplaceArrayDeviceRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    49;
+    53;
 
   friend void swap(ReplaceArrayDeviceRequest& a, ReplaceArrayDeviceRequest& b) {
     a.Swap(&b);
@@ -9783,7 +10495,7 @@ class ReplaceArrayDeviceResponse_Result PROTOBUF_FINAL :
                &_ReplaceArrayDeviceResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    50;
+    54;
 
   friend void swap(ReplaceArrayDeviceResponse_Result& a, ReplaceArrayDeviceResponse_Result& b) {
     a.Swap(&b);
@@ -9929,7 +10641,7 @@ class ReplaceArrayDeviceResponse PROTOBUF_FINAL :
                &_ReplaceArrayDeviceResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    51;
+    55;
 
   friend void swap(ReplaceArrayDeviceResponse& a, ReplaceArrayDeviceResponse& b) {
     a.Swap(&b);
@@ -10133,7 +10845,7 @@ class CreateArrayRequest_Param PROTOBUF_FINAL :
                &_CreateArrayRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    52;
+    56;
 
   friend void swap(CreateArrayRequest_Param& a, CreateArrayRequest_Param& b) {
     a.Swap(&b);
@@ -10355,7 +11067,7 @@ class CreateArrayRequest PROTOBUF_FINAL :
                &_CreateArrayRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    53;
+    57;
 
   friend void swap(CreateArrayRequest& a, CreateArrayRequest& b) {
     a.Swap(&b);
@@ -10557,7 +11269,7 @@ class CreateArrayResponse_Result PROTOBUF_FINAL :
                &_CreateArrayResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    54;
+    58;
 
   friend void swap(CreateArrayResponse_Result& a, CreateArrayResponse_Result& b) {
     a.Swap(&b);
@@ -10703,7 +11415,7 @@ class CreateArrayResponse PROTOBUF_FINAL :
                &_CreateArrayResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    55;
+    59;
 
   friend void swap(CreateArrayResponse& a, CreateArrayResponse& b) {
     a.Swap(&b);
@@ -10907,7 +11619,7 @@ class AutocreateArrayRequest_Param PROTOBUF_FINAL :
                &_AutocreateArrayRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    56;
+    60;
 
   friend void swap(AutocreateArrayRequest_Param& a, AutocreateArrayRequest_Param& b) {
     a.Swap(&b);
@@ -11111,7 +11823,7 @@ class AutocreateArrayRequest PROTOBUF_FINAL :
                &_AutocreateArrayRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    57;
+    61;
 
   friend void swap(AutocreateArrayRequest& a, AutocreateArrayRequest& b) {
     a.Swap(&b);
@@ -11313,7 +12025,7 @@ class AutocreateArrayResponse_Result PROTOBUF_FINAL :
                &_AutocreateArrayResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    58;
+    62;
 
   friend void swap(AutocreateArrayResponse_Result& a, AutocreateArrayResponse_Result& b) {
     a.Swap(&b);
@@ -11459,7 +12171,7 @@ class AutocreateArrayResponse PROTOBUF_FINAL :
                &_AutocreateArrayResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    59;
+    63;
 
   friend void swap(AutocreateArrayResponse& a, AutocreateArrayResponse& b) {
     a.Swap(&b);
@@ -11663,7 +12375,7 @@ class DeleteArrayRequest_Param PROTOBUF_FINAL :
                &_DeleteArrayRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    60;
+    64;
 
   friend void swap(DeleteArrayRequest_Param& a, DeleteArrayRequest_Param& b) {
     a.Swap(&b);
@@ -11807,7 +12519,7 @@ class DeleteArrayRequest PROTOBUF_FINAL :
                &_DeleteArrayRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    61;
+    65;
 
   friend void swap(DeleteArrayRequest& a, DeleteArrayRequest& b) {
     a.Swap(&b);
@@ -12009,7 +12721,7 @@ class DeleteArrayResponse_Result PROTOBUF_FINAL :
                &_DeleteArrayResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    62;
+    66;
 
   friend void swap(DeleteArrayResponse_Result& a, DeleteArrayResponse_Result& b) {
     a.Swap(&b);
@@ -12155,7 +12867,7 @@ class DeleteArrayResponse PROTOBUF_FINAL :
                &_DeleteArrayResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    63;
+    67;
 
   friend void swap(DeleteArrayResponse& a, DeleteArrayResponse& b) {
     a.Swap(&b);
@@ -12359,7 +13071,7 @@ class MountArrayRequest_Param PROTOBUF_FINAL :
                &_MountArrayRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    64;
+    68;
 
   friend void swap(MountArrayRequest_Param& a, MountArrayRequest_Param& b) {
     a.Swap(&b);
@@ -12519,7 +13231,7 @@ class MountArrayRequest PROTOBUF_FINAL :
                &_MountArrayRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    65;
+    69;
 
   friend void swap(MountArrayRequest& a, MountArrayRequest& b) {
     a.Swap(&b);
@@ -12721,7 +13433,7 @@ class MountArrayResponse_Result PROTOBUF_FINAL :
                &_MountArrayResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    66;
+    70;
 
   friend void swap(MountArrayResponse_Result& a, MountArrayResponse_Result& b) {
     a.Swap(&b);
@@ -12867,7 +13579,7 @@ class MountArrayResponse PROTOBUF_FINAL :
                &_MountArrayResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    67;
+    71;
 
   friend void swap(MountArrayResponse& a, MountArrayResponse& b) {
     a.Swap(&b);
@@ -13071,7 +13783,7 @@ class UnmountArrayRequest_Param PROTOBUF_FINAL :
                &_UnmountArrayRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    68;
+    72;
 
   friend void swap(UnmountArrayRequest_Param& a, UnmountArrayRequest_Param& b) {
     a.Swap(&b);
@@ -13215,7 +13927,7 @@ class UnmountArrayRequest PROTOBUF_FINAL :
                &_UnmountArrayRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    69;
+    73;
 
   friend void swap(UnmountArrayRequest& a, UnmountArrayRequest& b) {
     a.Swap(&b);
@@ -13417,7 +14129,7 @@ class UnmountArrayResponse_Result PROTOBUF_FINAL :
                &_UnmountArrayResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    70;
+    74;
 
   friend void swap(UnmountArrayResponse_Result& a, UnmountArrayResponse_Result& b) {
     a.Swap(&b);
@@ -13563,7 +14275,7 @@ class UnmountArrayResponse PROTOBUF_FINAL :
                &_UnmountArrayResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    71;
+    75;
 
   friend void swap(UnmountArrayResponse& a, UnmountArrayResponse& b) {
     a.Swap(&b);
@@ -13767,7 +14479,7 @@ class Array PROTOBUF_FINAL :
                &_Array_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    72;
+    76;
 
   friend void swap(Array& a, Array& b) {
     a.Swap(&b);
@@ -14148,7 +14860,7 @@ class ListArrayRequest PROTOBUF_FINAL :
                &_ListArrayRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    73;
+    77;
 
   friend void swap(ListArrayRequest& a, ListArrayRequest& b) {
     a.Swap(&b);
@@ -14328,7 +15040,7 @@ class ListArrayResponse_Result_ArrayList PROTOBUF_FINAL :
                &_ListArrayResponse_Result_ArrayList_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    74;
+    78;
 
   friend void swap(ListArrayResponse_Result_ArrayList& a, ListArrayResponse_Result_ArrayList& b) {
     a.Swap(&b);
@@ -14474,7 +15186,7 @@ class ListArrayResponse_Result PROTOBUF_FINAL :
                &_ListArrayResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    75;
+    79;
 
   friend void swap(ListArrayResponse_Result& a, ListArrayResponse_Result& b) {
     a.Swap(&b);
@@ -14642,7 +15354,7 @@ class ListArrayResponse PROTOBUF_FINAL :
                &_ListArrayResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    76;
+    80;
 
   friend void swap(ListArrayResponse& a, ListArrayResponse& b) {
     a.Swap(&b);
@@ -14846,7 +15558,7 @@ class ArrayInfoRequest_Param PROTOBUF_FINAL :
                &_ArrayInfoRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    77;
+    81;
 
   friend void swap(ArrayInfoRequest_Param& a, ArrayInfoRequest_Param& b) {
     a.Swap(&b);
@@ -14990,7 +15702,7 @@ class ArrayInfoRequest PROTOBUF_FINAL :
                &_ArrayInfoRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    78;
+    82;
 
   friend void swap(ArrayInfoRequest& a, ArrayInfoRequest& b) {
     a.Swap(&b);
@@ -15192,7 +15904,7 @@ class ArrayInfoResponse_Result PROTOBUF_FINAL :
                &_ArrayInfoResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    79;
+    83;
 
   friend void swap(ArrayInfoResponse_Result& a, ArrayInfoResponse_Result& b) {
     a.Swap(&b);
@@ -15358,7 +16070,7 @@ class ArrayInfoResponse PROTOBUF_FINAL :
                &_ArrayInfoResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    80;
+    84;
 
   friend void swap(ArrayInfoResponse& a, ArrayInfoResponse& b) {
     a.Swap(&b);
@@ -15562,7 +16274,7 @@ class ListNodeRequest PROTOBUF_FINAL :
                &_ListNodeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    81;
+    85;
 
   friend void swap(ListNodeRequest& a, ListNodeRequest& b) {
     a.Swap(&b);
@@ -15742,7 +16454,7 @@ class ListNodeResponse_Result_Node PROTOBUF_FINAL :
                &_ListNodeResponse_Result_Node_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    82;
+    86;
 
   friend void swap(ListNodeResponse_Result_Node& a, ListNodeResponse_Result_Node& b) {
     a.Swap(&b);
@@ -15922,7 +16634,7 @@ class ListNodeResponse_Result PROTOBUF_FINAL :
                &_ListNodeResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    83;
+    87;
 
   friend void swap(ListNodeResponse_Result& a, ListNodeResponse_Result& b) {
     a.Swap(&b);
@@ -16090,7 +16802,7 @@ class ListNodeResponse PROTOBUF_FINAL :
                &_ListNodeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    84;
+    88;
 
   friend void swap(ListNodeResponse& a, ListNodeResponse& b) {
     a.Swap(&b);
@@ -16294,7 +17006,7 @@ class ListHaVolumeRequest PROTOBUF_FINAL :
                &_ListHaVolumeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    85;
+    89;
 
   friend void swap(ListHaVolumeRequest& a, ListHaVolumeRequest& b) {
     a.Swap(&b);
@@ -16474,7 +17186,7 @@ class ListHaVolumeResponse_Result_Volume PROTOBUF_FINAL :
                &_ListHaVolumeResponse_Result_Volume_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    86;
+    90;
 
   friend void swap(ListHaVolumeResponse_Result_Volume& a, ListHaVolumeResponse_Result_Volume& b) {
     a.Swap(&b);
@@ -16694,7 +17406,7 @@ class ListHaVolumeResponse_Result PROTOBUF_FINAL :
                &_ListHaVolumeResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    87;
+    91;
 
   friend void swap(ListHaVolumeResponse_Result& a, ListHaVolumeResponse_Result& b) {
     a.Swap(&b);
@@ -16862,7 +17574,7 @@ class ListHaVolumeResponse PROTOBUF_FINAL :
                &_ListHaVolumeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    88;
+    92;
 
   friend void swap(ListHaVolumeResponse& a, ListHaVolumeResponse& b) {
     a.Swap(&b);
@@ -17066,7 +17778,7 @@ class ListHaReplicationRequest PROTOBUF_FINAL :
                &_ListHaReplicationRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    89;
+    93;
 
   friend void swap(ListHaReplicationRequest& a, ListHaReplicationRequest& b) {
     a.Swap(&b);
@@ -17246,7 +17958,7 @@ class ListHaReplicationResponse_Result_Replication PROTOBUF_FINAL :
                &_ListHaReplicationResponse_Result_Replication_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    90;
+    94;
 
   friend void swap(ListHaReplicationResponse_Result_Replication& a, ListHaReplicationResponse_Result_Replication& b) {
     a.Swap(&b);
@@ -17427,7 +18139,7 @@ class ListHaReplicationResponse_Result PROTOBUF_FINAL :
                &_ListHaReplicationResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    91;
+    95;
 
   friend void swap(ListHaReplicationResponse_Result& a, ListHaReplicationResponse_Result& b) {
     a.Swap(&b);
@@ -17595,7 +18307,7 @@ class ListHaReplicationResponse PROTOBUF_FINAL :
                &_ListHaReplicationResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    92;
+    96;
 
   friend void swap(ListHaReplicationResponse& a, ListHaReplicationResponse& b) {
     a.Swap(&b);
@@ -17799,7 +18511,7 @@ class StartHaReplicationRequest_Param PROTOBUF_FINAL :
                &_StartHaReplicationRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    93;
+    97;
 
   friend void swap(StartHaReplicationRequest_Param& a, StartHaReplicationRequest_Param& b) {
     a.Swap(&b);
@@ -18105,7 +18817,7 @@ class StartHaReplicationRequest PROTOBUF_FINAL :
                &_StartHaReplicationRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    94;
+    98;
 
   friend void swap(StartHaReplicationRequest& a, StartHaReplicationRequest& b) {
     a.Swap(&b);
@@ -18307,7 +19019,7 @@ class StartHaReplicationResponse_Result PROTOBUF_FINAL :
                &_StartHaReplicationResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    95;
+    99;
 
   friend void swap(StartHaReplicationResponse_Result& a, StartHaReplicationResponse_Result& b) {
     a.Swap(&b);
@@ -18453,7 +19165,7 @@ class StartHaReplicationResponse PROTOBUF_FINAL :
                &_StartHaReplicationResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    96;
+    100;
 
   friend void swap(StartHaReplicationResponse& a, StartHaReplicationResponse& b) {
     a.Swap(&b);
@@ -18657,7 +19369,7 @@ class SetLogLevelRequest_Param PROTOBUF_FINAL :
                &_SetLogLevelRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    97;
+    101;
 
   friend void swap(SetLogLevelRequest_Param& a, SetLogLevelRequest_Param& b) {
     a.Swap(&b);
@@ -18801,7 +19513,7 @@ class SetLogLevelRequest PROTOBUF_FINAL :
                &_SetLogLevelRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    98;
+    102;
 
   friend void swap(SetLogLevelRequest& a, SetLogLevelRequest& b) {
     a.Swap(&b);
@@ -19003,7 +19715,7 @@ class SetLogLevelResponse_Result PROTOBUF_FINAL :
                &_SetLogLevelResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    99;
+    103;
 
   friend void swap(SetLogLevelResponse_Result& a, SetLogLevelResponse_Result& b) {
     a.Swap(&b);
@@ -19149,7 +19861,7 @@ class SetLogLevelResponse PROTOBUF_FINAL :
                &_SetLogLevelResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    100;
+    104;
 
   friend void swap(SetLogLevelResponse& a, SetLogLevelResponse& b) {
     a.Swap(&b);
@@ -19353,7 +20065,7 @@ class SetLogPreferenceRequest_Param PROTOBUF_FINAL :
                &_SetLogPreferenceRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    101;
+    105;
 
   friend void swap(SetLogPreferenceRequest_Param& a, SetLogPreferenceRequest_Param& b) {
     a.Swap(&b);
@@ -19497,7 +20209,7 @@ class SetLogPreferenceRequest PROTOBUF_FINAL :
                &_SetLogPreferenceRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    102;
+    106;
 
   friend void swap(SetLogPreferenceRequest& a, SetLogPreferenceRequest& b) {
     a.Swap(&b);
@@ -19699,7 +20411,7 @@ class SetLogPreferenceResponse_Result PROTOBUF_FINAL :
                &_SetLogPreferenceResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    103;
+    107;
 
   friend void swap(SetLogPreferenceResponse_Result& a, SetLogPreferenceResponse_Result& b) {
     a.Swap(&b);
@@ -19845,7 +20557,7 @@ class SetLogPreferenceResponse PROTOBUF_FINAL :
                &_SetLogPreferenceResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    104;
+    108;
 
   friend void swap(SetLogPreferenceResponse& a, SetLogPreferenceResponse& b) {
     a.Swap(&b);
@@ -20049,7 +20761,7 @@ class LoggerInfoRequest PROTOBUF_FINAL :
                &_LoggerInfoRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    105;
+    109;
 
   friend void swap(LoggerInfoRequest& a, LoggerInfoRequest& b) {
     a.Swap(&b);
@@ -20229,7 +20941,7 @@ class LoggerInfoResponse_Result_LoggerInfo PROTOBUF_FINAL :
                &_LoggerInfoResponse_Result_LoggerInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    106;
+    110;
 
   friend void swap(LoggerInfoResponse_Result_LoggerInfo& a, LoggerInfoResponse_Result_LoggerInfo& b) {
     a.Swap(&b);
@@ -20496,7 +21208,7 @@ class LoggerInfoResponse_Result PROTOBUF_FINAL :
                &_LoggerInfoResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    107;
+    111;
 
   friend void swap(LoggerInfoResponse_Result& a, LoggerInfoResponse_Result& b) {
     a.Swap(&b);
@@ -20664,7 +21376,7 @@ class LoggerInfoResponse PROTOBUF_FINAL :
                &_LoggerInfoResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    108;
+    112;
 
   friend void swap(LoggerInfoResponse& a, LoggerInfoResponse& b) {
     a.Swap(&b);
@@ -20868,7 +21580,7 @@ class GetLogLevelRequest PROTOBUF_FINAL :
                &_GetLogLevelRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    109;
+    113;
 
   friend void swap(GetLogLevelRequest& a, GetLogLevelRequest& b) {
     a.Swap(&b);
@@ -21048,7 +21760,7 @@ class GetLogLevelResponse_Result_LogLevel PROTOBUF_FINAL :
                &_GetLogLevelResponse_Result_LogLevel_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    110;
+    114;
 
   friend void swap(GetLogLevelResponse_Result_LogLevel& a, GetLogLevelResponse_Result_LogLevel& b) {
     a.Swap(&b);
@@ -21192,7 +21904,7 @@ class GetLogLevelResponse_Result PROTOBUF_FINAL :
                &_GetLogLevelResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    111;
+    115;
 
   friend void swap(GetLogLevelResponse_Result& a, GetLogLevelResponse_Result& b) {
     a.Swap(&b);
@@ -21360,7 +22072,7 @@ class GetLogLevelResponse PROTOBUF_FINAL :
                &_GetLogLevelResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    112;
+    116;
 
   friend void swap(GetLogLevelResponse& a, GetLogLevelResponse& b) {
     a.Swap(&b);
@@ -21564,7 +22276,7 @@ class ApplyLogFilterRequest PROTOBUF_FINAL :
                &_ApplyLogFilterRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    113;
+    117;
 
   friend void swap(ApplyLogFilterRequest& a, ApplyLogFilterRequest& b) {
     a.Swap(&b);
@@ -21744,7 +22456,7 @@ class ApplyLogFilterResponse_Result PROTOBUF_FINAL :
                &_ApplyLogFilterResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    114;
+    118;
 
   friend void swap(ApplyLogFilterResponse_Result& a, ApplyLogFilterResponse_Result& b) {
     a.Swap(&b);
@@ -21890,7 +22602,7 @@ class ApplyLogFilterResponse PROTOBUF_FINAL :
                &_ApplyLogFilterResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    115;
+    119;
 
   friend void swap(ApplyLogFilterResponse& a, ApplyLogFilterResponse& b) {
     a.Swap(&b);
@@ -22094,7 +22806,7 @@ class CreateDeviceRequest_Param PROTOBUF_FINAL :
                &_CreateDeviceRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    116;
+    120;
 
   friend void swap(CreateDeviceRequest_Param& a, CreateDeviceRequest_Param& b) {
     a.Swap(&b);
@@ -22289,7 +23001,7 @@ class CreateDeviceRequest PROTOBUF_FINAL :
                &_CreateDeviceRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    117;
+    121;
 
   friend void swap(CreateDeviceRequest& a, CreateDeviceRequest& b) {
     a.Swap(&b);
@@ -22491,7 +23203,7 @@ class CreateDeviceResponse_Result PROTOBUF_FINAL :
                &_CreateDeviceResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    118;
+    122;
 
   friend void swap(CreateDeviceResponse_Result& a, CreateDeviceResponse_Result& b) {
     a.Swap(&b);
@@ -22637,7 +23349,7 @@ class CreateDeviceResponse PROTOBUF_FINAL :
                &_CreateDeviceResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    119;
+    123;
 
   friend void swap(CreateDeviceResponse& a, CreateDeviceResponse& b) {
     a.Swap(&b);
@@ -22841,7 +23553,7 @@ class ScanDeviceRequest PROTOBUF_FINAL :
                &_ScanDeviceRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    120;
+    124;
 
   friend void swap(ScanDeviceRequest& a, ScanDeviceRequest& b) {
     a.Swap(&b);
@@ -23021,7 +23733,7 @@ class ScanDeviceResponse_Result PROTOBUF_FINAL :
                &_ScanDeviceResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    121;
+    125;
 
   friend void swap(ScanDeviceResponse_Result& a, ScanDeviceResponse_Result& b) {
     a.Swap(&b);
@@ -23167,7 +23879,7 @@ class ScanDeviceResponse PROTOBUF_FINAL :
                &_ScanDeviceResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    122;
+    126;
 
   friend void swap(ScanDeviceResponse& a, ScanDeviceResponse& b) {
     a.Swap(&b);
@@ -23371,7 +24083,7 @@ class Device PROTOBUF_FINAL :
                &_Device_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    123;
+    127;
 
   friend void swap(Device& a, Device& b) {
     a.Swap(&b);
@@ -23634,7 +24346,7 @@ class ListDeviceRequest PROTOBUF_FINAL :
                &_ListDeviceRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    124;
+    128;
 
   friend void swap(ListDeviceRequest& a, ListDeviceRequest& b) {
     a.Swap(&b);
@@ -23814,7 +24526,7 @@ class ListDeviceResponse_Result_DeviceList PROTOBUF_FINAL :
                &_ListDeviceResponse_Result_DeviceList_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    125;
+    129;
 
   friend void swap(ListDeviceResponse_Result_DeviceList& a, ListDeviceResponse_Result_DeviceList& b) {
     a.Swap(&b);
@@ -23960,7 +24672,7 @@ class ListDeviceResponse_Result PROTOBUF_FINAL :
                &_ListDeviceResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    126;
+    130;
 
   friend void swap(ListDeviceResponse_Result& a, ListDeviceResponse_Result& b) {
     a.Swap(&b);
@@ -24128,7 +24840,7 @@ class ListDeviceResponse PROTOBUF_FINAL :
                &_ListDeviceResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    127;
+    131;
 
   friend void swap(ListDeviceResponse& a, ListDeviceResponse& b) {
     a.Swap(&b);
@@ -24332,7 +25044,7 @@ class SmartLog PROTOBUF_FINAL :
                &_SmartLog_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    128;
+    132;
 
   friend void swap(SmartLog& a, SmartLog& b) {
     a.Swap(&b);
@@ -24862,7 +25574,7 @@ class GetSmartLogRequest_Param PROTOBUF_FINAL :
                &_GetSmartLogRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    129;
+    133;
 
   friend void swap(GetSmartLogRequest_Param& a, GetSmartLogRequest_Param& b) {
     a.Swap(&b);
@@ -25006,7 +25718,7 @@ class GetSmartLogRequest PROTOBUF_FINAL :
                &_GetSmartLogRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    130;
+    134;
 
   friend void swap(GetSmartLogRequest& a, GetSmartLogRequest& b) {
     a.Swap(&b);
@@ -25208,7 +25920,7 @@ class GetSmartLogResponse_Result PROTOBUF_FINAL :
                &_GetSmartLogResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    131;
+    135;
 
   friend void swap(GetSmartLogResponse_Result& a, GetSmartLogResponse_Result& b) {
     a.Swap(&b);
@@ -25374,7 +26086,7 @@ class GetSmartLogResponse PROTOBUF_FINAL :
                &_GetSmartLogResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    132;
+    136;
 
   friend void swap(GetSmartLogResponse& a, GetSmartLogResponse& b) {
     a.Swap(&b);
@@ -25578,7 +26290,7 @@ class CreateSubsystemRequest_Param PROTOBUF_FINAL :
                &_CreateSubsystemRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    133;
+    137;
 
   friend void swap(CreateSubsystemRequest_Param& a, CreateSubsystemRequest_Param& b) {
     a.Swap(&b);
@@ -25791,7 +26503,7 @@ class CreateSubsystemRequest PROTOBUF_FINAL :
                &_CreateSubsystemRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    134;
+    138;
 
   friend void swap(CreateSubsystemRequest& a, CreateSubsystemRequest& b) {
     a.Swap(&b);
@@ -25993,7 +26705,7 @@ class CreateSubsystemResponse_Result PROTOBUF_FINAL :
                &_CreateSubsystemResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    135;
+    139;
 
   friend void swap(CreateSubsystemResponse_Result& a, CreateSubsystemResponse_Result& b) {
     a.Swap(&b);
@@ -26139,7 +26851,7 @@ class CreateSubsystemResponse PROTOBUF_FINAL :
                &_CreateSubsystemResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    136;
+    140;
 
   friend void swap(CreateSubsystemResponse& a, CreateSubsystemResponse& b) {
     a.Swap(&b);
@@ -26343,7 +27055,7 @@ class DeleteSubsystemRequest_Param PROTOBUF_FINAL :
                &_DeleteSubsystemRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    137;
+    141;
 
   friend void swap(DeleteSubsystemRequest_Param& a, DeleteSubsystemRequest_Param& b) {
     a.Swap(&b);
@@ -26487,7 +27199,7 @@ class DeleteSubsystemRequest PROTOBUF_FINAL :
                &_DeleteSubsystemRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    138;
+    142;
 
   friend void swap(DeleteSubsystemRequest& a, DeleteSubsystemRequest& b) {
     a.Swap(&b);
@@ -26689,7 +27401,7 @@ class DeleteSubsystemResponse_Result PROTOBUF_FINAL :
                &_DeleteSubsystemResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    139;
+    143;
 
   friend void swap(DeleteSubsystemResponse_Result& a, DeleteSubsystemResponse_Result& b) {
     a.Swap(&b);
@@ -26835,7 +27547,7 @@ class DeleteSubsystemResponse PROTOBUF_FINAL :
                &_DeleteSubsystemResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    140;
+    144;
 
   friend void swap(DeleteSubsystemResponse& a, DeleteSubsystemResponse& b) {
     a.Swap(&b);
@@ -27039,7 +27751,7 @@ class AddListenerRequest_Param PROTOBUF_FINAL :
                &_AddListenerRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    141;
+    145;
 
   friend void swap(AddListenerRequest_Param& a, AddListenerRequest_Param& b) {
     a.Swap(&b);
@@ -27237,7 +27949,7 @@ class AddListenerRequest PROTOBUF_FINAL :
                &_AddListenerRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    142;
+    146;
 
   friend void swap(AddListenerRequest& a, AddListenerRequest& b) {
     a.Swap(&b);
@@ -27439,7 +28151,7 @@ class AddListenerResponse_Result PROTOBUF_FINAL :
                &_AddListenerResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    143;
+    147;
 
   friend void swap(AddListenerResponse_Result& a, AddListenerResponse_Result& b) {
     a.Swap(&b);
@@ -27585,7 +28297,7 @@ class AddListenerResponse PROTOBUF_FINAL :
                &_AddListenerResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    144;
+    148;
 
   friend void swap(AddListenerResponse& a, AddListenerResponse& b) {
     a.Swap(&b);
@@ -27789,7 +28501,7 @@ class Subsystem_AddressInfo PROTOBUF_FINAL :
                &_Subsystem_AddressInfo_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    145;
+    149;
 
   friend void swap(Subsystem_AddressInfo& a, Subsystem_AddressInfo& b) {
     a.Swap(&b);
@@ -27987,7 +28699,7 @@ class Subsystem_Host PROTOBUF_FINAL :
                &_Subsystem_Host_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    146;
+    150;
 
   friend void swap(Subsystem_Host& a, Subsystem_Host& b) {
     a.Swap(&b);
@@ -28131,7 +28843,7 @@ class Subsystem_Namespace PROTOBUF_FINAL :
                &_Subsystem_Namespace_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    147;
+    151;
 
   friend void swap(Subsystem_Namespace& a, Subsystem_Namespace& b) {
     a.Swap(&b);
@@ -28304,7 +29016,7 @@ class Subsystem PROTOBUF_FINAL :
                &_Subsystem_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    148;
+    152;
 
   friend void swap(Subsystem& a, Subsystem& b) {
     a.Swap(&b);
@@ -28588,7 +29300,7 @@ class ListSubsystemRequest PROTOBUF_FINAL :
                &_ListSubsystemRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    149;
+    153;
 
   friend void swap(ListSubsystemRequest& a, ListSubsystemRequest& b) {
     a.Swap(&b);
@@ -28768,7 +29480,7 @@ class ListSubsystemResponse_Result_SubsystemList PROTOBUF_FINAL :
                &_ListSubsystemResponse_Result_SubsystemList_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    150;
+    154;
 
   friend void swap(ListSubsystemResponse_Result_SubsystemList& a, ListSubsystemResponse_Result_SubsystemList& b) {
     a.Swap(&b);
@@ -28914,7 +29626,7 @@ class ListSubsystemResponse_Result PROTOBUF_FINAL :
                &_ListSubsystemResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    151;
+    155;
 
   friend void swap(ListSubsystemResponse_Result& a, ListSubsystemResponse_Result& b) {
     a.Swap(&b);
@@ -29082,7 +29794,7 @@ class ListSubsystemResponse PROTOBUF_FINAL :
                &_ListSubsystemResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    152;
+    156;
 
   friend void swap(ListSubsystemResponse& a, ListSubsystemResponse& b) {
     a.Swap(&b);
@@ -29286,7 +29998,7 @@ class SubsystemInfoRequest_Param PROTOBUF_FINAL :
                &_SubsystemInfoRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    153;
+    157;
 
   friend void swap(SubsystemInfoRequest_Param& a, SubsystemInfoRequest_Param& b) {
     a.Swap(&b);
@@ -29430,7 +30142,7 @@ class SubsystemInfoRequest PROTOBUF_FINAL :
                &_SubsystemInfoRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    154;
+    158;
 
   friend void swap(SubsystemInfoRequest& a, SubsystemInfoRequest& b) {
     a.Swap(&b);
@@ -29632,7 +30344,7 @@ class SubsystemInfoResponse_Result_SubsystemList PROTOBUF_FINAL :
                &_SubsystemInfoResponse_Result_SubsystemList_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    155;
+    159;
 
   friend void swap(SubsystemInfoResponse_Result_SubsystemList& a, SubsystemInfoResponse_Result_SubsystemList& b) {
     a.Swap(&b);
@@ -29778,7 +30490,7 @@ class SubsystemInfoResponse_Result PROTOBUF_FINAL :
                &_SubsystemInfoResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    156;
+    160;
 
   friend void swap(SubsystemInfoResponse_Result& a, SubsystemInfoResponse_Result& b) {
     a.Swap(&b);
@@ -29946,7 +30658,7 @@ class SubsystemInfoResponse PROTOBUF_FINAL :
                &_SubsystemInfoResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    157;
+    161;
 
   friend void swap(SubsystemInfoResponse& a, SubsystemInfoResponse& b) {
     a.Swap(&b);
@@ -30150,7 +30862,7 @@ class CreateTransportRequest_Param PROTOBUF_FINAL :
                &_CreateTransportRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    158;
+    162;
 
   friend void swap(CreateTransportRequest_Param& a, CreateTransportRequest_Param& b) {
     a.Swap(&b);
@@ -30316,7 +31028,7 @@ class CreateTransportRequest PROTOBUF_FINAL :
                &_CreateTransportRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    159;
+    163;
 
   friend void swap(CreateTransportRequest& a, CreateTransportRequest& b) {
     a.Swap(&b);
@@ -30518,7 +31230,7 @@ class CreateTransportResponse_Result PROTOBUF_FINAL :
                &_CreateTransportResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    160;
+    164;
 
   friend void swap(CreateTransportResponse_Result& a, CreateTransportResponse_Result& b) {
     a.Swap(&b);
@@ -30664,7 +31376,7 @@ class CreateTransportResponse PROTOBUF_FINAL :
                &_CreateTransportResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    161;
+    165;
 
   friend void swap(CreateTransportResponse& a, CreateTransportResponse& b) {
     a.Swap(&b);
@@ -30868,7 +31580,7 @@ class CreateVolumeRequest_Param PROTOBUF_FINAL :
                &_CreateVolumeRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    162;
+    166;
 
   friend void swap(CreateVolumeRequest_Param& a, CreateVolumeRequest_Param& b) {
     a.Swap(&b);
@@ -31092,7 +31804,7 @@ class CreateVolumeRequest PROTOBUF_FINAL :
                &_CreateVolumeRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    163;
+    167;
 
   friend void swap(CreateVolumeRequest& a, CreateVolumeRequest& b) {
     a.Swap(&b);
@@ -31294,7 +32006,7 @@ class CreateVolumeResponse_Result PROTOBUF_FINAL :
                &_CreateVolumeResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    164;
+    168;
 
   friend void swap(CreateVolumeResponse_Result& a, CreateVolumeResponse_Result& b) {
     a.Swap(&b);
@@ -31440,7 +32152,7 @@ class CreateVolumeResponse PROTOBUF_FINAL :
                &_CreateVolumeResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    165;
+    169;
 
   friend void swap(CreateVolumeResponse& a, CreateVolumeResponse& b) {
     a.Swap(&b);
@@ -31644,7 +32356,7 @@ class SetVolumePropertyRequest_Param PROTOBUF_FINAL :
                &_SetVolumePropertyRequest_Param_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    166;
+    170;
 
   friend void swap(SetVolumePropertyRequest_Param& a, SetVolumePropertyRequest_Param& b) {
     a.Swap(&b);
@@ -31879,7 +32591,7 @@ class SetVolumePropertyRequest PROTOBUF_FINAL :
                &_SetVolumePropertyRequest_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    167;
+    171;
 
   friend void swap(SetVolumePropertyRequest& a, SetVolumePropertyRequest& b) {
     a.Swap(&b);
@@ -32081,7 +32793,7 @@ class SetVolumePropertyResponse_Result PROTOBUF_FINAL :
                &_SetVolumePropertyResponse_Result_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    168;
+    172;
 
   friend void swap(SetVolumePropertyResponse_Result& a, SetVolumePropertyResponse_Result& b) {
     a.Swap(&b);
@@ -32227,7 +32939,7 @@ class SetVolumePropertyResponse PROTOBUF_FINAL :
                &_SetVolumePropertyResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    169;
+    173;
 
   friend void swap(SetVolumePropertyResponse& a, SetVolumePropertyResponse& b) {
     a.Swap(&b);
@@ -37474,6 +38186,720 @@ inline void StopTelemetryResponse::set_allocated_info(::grpc_cli::PosInfo* info)
   }
   info_ = info;
   // @@protoc_insertion_point(field_set_allocated:grpc_cli.StopTelemetryResponse.info)
+}
+
+// -------------------------------------------------------------------
+
+// SetTelemetryPropertyRequest_Param
+
+// string publicationListPath = 1;
+inline void SetTelemetryPropertyRequest_Param::clear_publicationlistpath() {
+  publicationlistpath_.ClearToEmpty();
+}
+inline const std::string& SetTelemetryPropertyRequest_Param::publicationlistpath() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SetTelemetryPropertyRequest.Param.publicationListPath)
+  return _internal_publicationlistpath();
+}
+inline void SetTelemetryPropertyRequest_Param::set_publicationlistpath(const std::string& value) {
+  _internal_set_publicationlistpath(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SetTelemetryPropertyRequest.Param.publicationListPath)
+}
+inline std::string* SetTelemetryPropertyRequest_Param::mutable_publicationlistpath() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SetTelemetryPropertyRequest.Param.publicationListPath)
+  return _internal_mutable_publicationlistpath();
+}
+inline const std::string& SetTelemetryPropertyRequest_Param::_internal_publicationlistpath() const {
+  return publicationlistpath_.Get();
+}
+inline void SetTelemetryPropertyRequest_Param::_internal_set_publicationlistpath(const std::string& value) {
+  
+  publicationlistpath_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SetTelemetryPropertyRequest_Param::set_publicationlistpath(std::string&& value) {
+  
+  publicationlistpath_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SetTelemetryPropertyRequest.Param.publicationListPath)
+}
+inline void SetTelemetryPropertyRequest_Param::set_publicationlistpath(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  publicationlistpath_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SetTelemetryPropertyRequest.Param.publicationListPath)
+}
+inline void SetTelemetryPropertyRequest_Param::set_publicationlistpath(const char* value,
+    size_t size) {
+  
+  publicationlistpath_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SetTelemetryPropertyRequest.Param.publicationListPath)
+}
+inline std::string* SetTelemetryPropertyRequest_Param::_internal_mutable_publicationlistpath() {
+  
+  return publicationlistpath_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SetTelemetryPropertyRequest_Param::release_publicationlistpath() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SetTelemetryPropertyRequest.Param.publicationListPath)
+  return publicationlistpath_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SetTelemetryPropertyRequest_Param::set_allocated_publicationlistpath(std::string* publicationlistpath) {
+  if (publicationlistpath != nullptr) {
+    
+  } else {
+    
+  }
+  publicationlistpath_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), publicationlistpath,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SetTelemetryPropertyRequest.Param.publicationListPath)
+}
+
+// -------------------------------------------------------------------
+
+// SetTelemetryPropertyRequest
+
+// string command = 1;
+inline void SetTelemetryPropertyRequest::clear_command() {
+  command_.ClearToEmpty();
+}
+inline const std::string& SetTelemetryPropertyRequest::command() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SetTelemetryPropertyRequest.command)
+  return _internal_command();
+}
+inline void SetTelemetryPropertyRequest::set_command(const std::string& value) {
+  _internal_set_command(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SetTelemetryPropertyRequest.command)
+}
+inline std::string* SetTelemetryPropertyRequest::mutable_command() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SetTelemetryPropertyRequest.command)
+  return _internal_mutable_command();
+}
+inline const std::string& SetTelemetryPropertyRequest::_internal_command() const {
+  return command_.Get();
+}
+inline void SetTelemetryPropertyRequest::_internal_set_command(const std::string& value) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SetTelemetryPropertyRequest::set_command(std::string&& value) {
+  
+  command_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SetTelemetryPropertyRequest.command)
+}
+inline void SetTelemetryPropertyRequest::set_command(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SetTelemetryPropertyRequest.command)
+}
+inline void SetTelemetryPropertyRequest::set_command(const char* value,
+    size_t size) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SetTelemetryPropertyRequest.command)
+}
+inline std::string* SetTelemetryPropertyRequest::_internal_mutable_command() {
+  
+  return command_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SetTelemetryPropertyRequest::release_command() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SetTelemetryPropertyRequest.command)
+  return command_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SetTelemetryPropertyRequest::set_allocated_command(std::string* command) {
+  if (command != nullptr) {
+    
+  } else {
+    
+  }
+  command_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), command,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SetTelemetryPropertyRequest.command)
+}
+
+// string rid = 2;
+inline void SetTelemetryPropertyRequest::clear_rid() {
+  rid_.ClearToEmpty();
+}
+inline const std::string& SetTelemetryPropertyRequest::rid() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SetTelemetryPropertyRequest.rid)
+  return _internal_rid();
+}
+inline void SetTelemetryPropertyRequest::set_rid(const std::string& value) {
+  _internal_set_rid(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SetTelemetryPropertyRequest.rid)
+}
+inline std::string* SetTelemetryPropertyRequest::mutable_rid() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SetTelemetryPropertyRequest.rid)
+  return _internal_mutable_rid();
+}
+inline const std::string& SetTelemetryPropertyRequest::_internal_rid() const {
+  return rid_.Get();
+}
+inline void SetTelemetryPropertyRequest::_internal_set_rid(const std::string& value) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SetTelemetryPropertyRequest::set_rid(std::string&& value) {
+  
+  rid_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SetTelemetryPropertyRequest.rid)
+}
+inline void SetTelemetryPropertyRequest::set_rid(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SetTelemetryPropertyRequest.rid)
+}
+inline void SetTelemetryPropertyRequest::set_rid(const char* value,
+    size_t size) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SetTelemetryPropertyRequest.rid)
+}
+inline std::string* SetTelemetryPropertyRequest::_internal_mutable_rid() {
+  
+  return rid_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SetTelemetryPropertyRequest::release_rid() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SetTelemetryPropertyRequest.rid)
+  return rid_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SetTelemetryPropertyRequest::set_allocated_rid(std::string* rid) {
+  if (rid != nullptr) {
+    
+  } else {
+    
+  }
+  rid_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), rid,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SetTelemetryPropertyRequest.rid)
+}
+
+// string requestor = 3;
+inline void SetTelemetryPropertyRequest::clear_requestor() {
+  requestor_.ClearToEmpty();
+}
+inline const std::string& SetTelemetryPropertyRequest::requestor() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SetTelemetryPropertyRequest.requestor)
+  return _internal_requestor();
+}
+inline void SetTelemetryPropertyRequest::set_requestor(const std::string& value) {
+  _internal_set_requestor(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SetTelemetryPropertyRequest.requestor)
+}
+inline std::string* SetTelemetryPropertyRequest::mutable_requestor() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SetTelemetryPropertyRequest.requestor)
+  return _internal_mutable_requestor();
+}
+inline const std::string& SetTelemetryPropertyRequest::_internal_requestor() const {
+  return requestor_.Get();
+}
+inline void SetTelemetryPropertyRequest::_internal_set_requestor(const std::string& value) {
+  
+  requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SetTelemetryPropertyRequest::set_requestor(std::string&& value) {
+  
+  requestor_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SetTelemetryPropertyRequest.requestor)
+}
+inline void SetTelemetryPropertyRequest::set_requestor(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SetTelemetryPropertyRequest.requestor)
+}
+inline void SetTelemetryPropertyRequest::set_requestor(const char* value,
+    size_t size) {
+  
+  requestor_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SetTelemetryPropertyRequest.requestor)
+}
+inline std::string* SetTelemetryPropertyRequest::_internal_mutable_requestor() {
+  
+  return requestor_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SetTelemetryPropertyRequest::release_requestor() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SetTelemetryPropertyRequest.requestor)
+  return requestor_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SetTelemetryPropertyRequest::set_allocated_requestor(std::string* requestor) {
+  if (requestor != nullptr) {
+    
+  } else {
+    
+  }
+  requestor_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), requestor,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SetTelemetryPropertyRequest.requestor)
+}
+
+// .grpc_cli.SetTelemetryPropertyRequest.Param param = 4;
+inline bool SetTelemetryPropertyRequest::_internal_has_param() const {
+  return this != internal_default_instance() && param_ != nullptr;
+}
+inline bool SetTelemetryPropertyRequest::has_param() const {
+  return _internal_has_param();
+}
+inline void SetTelemetryPropertyRequest::clear_param() {
+  if (GetArena() == nullptr && param_ != nullptr) {
+    delete param_;
+  }
+  param_ = nullptr;
+}
+inline const ::grpc_cli::SetTelemetryPropertyRequest_Param& SetTelemetryPropertyRequest::_internal_param() const {
+  const ::grpc_cli::SetTelemetryPropertyRequest_Param* p = param_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::SetTelemetryPropertyRequest_Param&>(
+      ::grpc_cli::_SetTelemetryPropertyRequest_Param_default_instance_);
+}
+inline const ::grpc_cli::SetTelemetryPropertyRequest_Param& SetTelemetryPropertyRequest::param() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SetTelemetryPropertyRequest.param)
+  return _internal_param();
+}
+inline void SetTelemetryPropertyRequest::unsafe_arena_set_allocated_param(
+    ::grpc_cli::SetTelemetryPropertyRequest_Param* param) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(param_);
+  }
+  param_ = param;
+  if (param) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.SetTelemetryPropertyRequest.param)
+}
+inline ::grpc_cli::SetTelemetryPropertyRequest_Param* SetTelemetryPropertyRequest::release_param() {
+  
+  ::grpc_cli::SetTelemetryPropertyRequest_Param* temp = param_;
+  param_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::SetTelemetryPropertyRequest_Param* SetTelemetryPropertyRequest::unsafe_arena_release_param() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SetTelemetryPropertyRequest.param)
+  
+  ::grpc_cli::SetTelemetryPropertyRequest_Param* temp = param_;
+  param_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::SetTelemetryPropertyRequest_Param* SetTelemetryPropertyRequest::_internal_mutable_param() {
+  
+  if (param_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::SetTelemetryPropertyRequest_Param>(GetArena());
+    param_ = p;
+  }
+  return param_;
+}
+inline ::grpc_cli::SetTelemetryPropertyRequest_Param* SetTelemetryPropertyRequest::mutable_param() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SetTelemetryPropertyRequest.param)
+  return _internal_mutable_param();
+}
+inline void SetTelemetryPropertyRequest::set_allocated_param(::grpc_cli::SetTelemetryPropertyRequest_Param* param) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete param_;
+  }
+  if (param) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(param);
+    if (message_arena != submessage_arena) {
+      param = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, param, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  param_ = param;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SetTelemetryPropertyRequest.param)
+}
+
+// -------------------------------------------------------------------
+
+// SetTelemetryPropertyResponse_Result
+
+// .grpc_cli.Status status = 1;
+inline bool SetTelemetryPropertyResponse_Result::_internal_has_status() const {
+  return this != internal_default_instance() && status_ != nullptr;
+}
+inline bool SetTelemetryPropertyResponse_Result::has_status() const {
+  return _internal_has_status();
+}
+inline void SetTelemetryPropertyResponse_Result::clear_status() {
+  if (GetArena() == nullptr && status_ != nullptr) {
+    delete status_;
+  }
+  status_ = nullptr;
+}
+inline const ::grpc_cli::Status& SetTelemetryPropertyResponse_Result::_internal_status() const {
+  const ::grpc_cli::Status* p = status_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::Status&>(
+      ::grpc_cli::_Status_default_instance_);
+}
+inline const ::grpc_cli::Status& SetTelemetryPropertyResponse_Result::status() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SetTelemetryPropertyResponse.Result.status)
+  return _internal_status();
+}
+inline void SetTelemetryPropertyResponse_Result::unsafe_arena_set_allocated_status(
+    ::grpc_cli::Status* status) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(status_);
+  }
+  status_ = status;
+  if (status) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.SetTelemetryPropertyResponse.Result.status)
+}
+inline ::grpc_cli::Status* SetTelemetryPropertyResponse_Result::release_status() {
+  
+  ::grpc_cli::Status* temp = status_;
+  status_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::Status* SetTelemetryPropertyResponse_Result::unsafe_arena_release_status() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SetTelemetryPropertyResponse.Result.status)
+  
+  ::grpc_cli::Status* temp = status_;
+  status_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::Status* SetTelemetryPropertyResponse_Result::_internal_mutable_status() {
+  
+  if (status_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::Status>(GetArena());
+    status_ = p;
+  }
+  return status_;
+}
+inline ::grpc_cli::Status* SetTelemetryPropertyResponse_Result::mutable_status() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SetTelemetryPropertyResponse.Result.status)
+  return _internal_mutable_status();
+}
+inline void SetTelemetryPropertyResponse_Result::set_allocated_status(::grpc_cli::Status* status) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete status_;
+  }
+  if (status) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(status);
+    if (message_arena != submessage_arena) {
+      status = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, status, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  status_ = status;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SetTelemetryPropertyResponse.Result.status)
+}
+
+// -------------------------------------------------------------------
+
+// SetTelemetryPropertyResponse
+
+// string command = 1;
+inline void SetTelemetryPropertyResponse::clear_command() {
+  command_.ClearToEmpty();
+}
+inline const std::string& SetTelemetryPropertyResponse::command() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SetTelemetryPropertyResponse.command)
+  return _internal_command();
+}
+inline void SetTelemetryPropertyResponse::set_command(const std::string& value) {
+  _internal_set_command(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SetTelemetryPropertyResponse.command)
+}
+inline std::string* SetTelemetryPropertyResponse::mutable_command() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SetTelemetryPropertyResponse.command)
+  return _internal_mutable_command();
+}
+inline const std::string& SetTelemetryPropertyResponse::_internal_command() const {
+  return command_.Get();
+}
+inline void SetTelemetryPropertyResponse::_internal_set_command(const std::string& value) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SetTelemetryPropertyResponse::set_command(std::string&& value) {
+  
+  command_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SetTelemetryPropertyResponse.command)
+}
+inline void SetTelemetryPropertyResponse::set_command(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SetTelemetryPropertyResponse.command)
+}
+inline void SetTelemetryPropertyResponse::set_command(const char* value,
+    size_t size) {
+  
+  command_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SetTelemetryPropertyResponse.command)
+}
+inline std::string* SetTelemetryPropertyResponse::_internal_mutable_command() {
+  
+  return command_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SetTelemetryPropertyResponse::release_command() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SetTelemetryPropertyResponse.command)
+  return command_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SetTelemetryPropertyResponse::set_allocated_command(std::string* command) {
+  if (command != nullptr) {
+    
+  } else {
+    
+  }
+  command_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), command,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SetTelemetryPropertyResponse.command)
+}
+
+// string rid = 2;
+inline void SetTelemetryPropertyResponse::clear_rid() {
+  rid_.ClearToEmpty();
+}
+inline const std::string& SetTelemetryPropertyResponse::rid() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SetTelemetryPropertyResponse.rid)
+  return _internal_rid();
+}
+inline void SetTelemetryPropertyResponse::set_rid(const std::string& value) {
+  _internal_set_rid(value);
+  // @@protoc_insertion_point(field_set:grpc_cli.SetTelemetryPropertyResponse.rid)
+}
+inline std::string* SetTelemetryPropertyResponse::mutable_rid() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SetTelemetryPropertyResponse.rid)
+  return _internal_mutable_rid();
+}
+inline const std::string& SetTelemetryPropertyResponse::_internal_rid() const {
+  return rid_.Get();
+}
+inline void SetTelemetryPropertyResponse::_internal_set_rid(const std::string& value) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, value, GetArena());
+}
+inline void SetTelemetryPropertyResponse::set_rid(std::string&& value) {
+  
+  rid_.Set(
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:grpc_cli.SetTelemetryPropertyResponse.rid)
+}
+inline void SetTelemetryPropertyResponse::set_rid(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(value), GetArena());
+  // @@protoc_insertion_point(field_set_char:grpc_cli.SetTelemetryPropertyResponse.rid)
+}
+inline void SetTelemetryPropertyResponse::set_rid(const char* value,
+    size_t size) {
+  
+  rid_.Set(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:grpc_cli.SetTelemetryPropertyResponse.rid)
+}
+inline std::string* SetTelemetryPropertyResponse::_internal_mutable_rid() {
+  
+  return rid_.Mutable(::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::EmptyDefault{}, GetArena());
+}
+inline std::string* SetTelemetryPropertyResponse::release_rid() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SetTelemetryPropertyResponse.rid)
+  return rid_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void SetTelemetryPropertyResponse::set_allocated_rid(std::string* rid) {
+  if (rid != nullptr) {
+    
+  } else {
+    
+  }
+  rid_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), rid,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SetTelemetryPropertyResponse.rid)
+}
+
+// .grpc_cli.SetTelemetryPropertyResponse.Result result = 3;
+inline bool SetTelemetryPropertyResponse::_internal_has_result() const {
+  return this != internal_default_instance() && result_ != nullptr;
+}
+inline bool SetTelemetryPropertyResponse::has_result() const {
+  return _internal_has_result();
+}
+inline void SetTelemetryPropertyResponse::clear_result() {
+  if (GetArena() == nullptr && result_ != nullptr) {
+    delete result_;
+  }
+  result_ = nullptr;
+}
+inline const ::grpc_cli::SetTelemetryPropertyResponse_Result& SetTelemetryPropertyResponse::_internal_result() const {
+  const ::grpc_cli::SetTelemetryPropertyResponse_Result* p = result_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::SetTelemetryPropertyResponse_Result&>(
+      ::grpc_cli::_SetTelemetryPropertyResponse_Result_default_instance_);
+}
+inline const ::grpc_cli::SetTelemetryPropertyResponse_Result& SetTelemetryPropertyResponse::result() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SetTelemetryPropertyResponse.result)
+  return _internal_result();
+}
+inline void SetTelemetryPropertyResponse::unsafe_arena_set_allocated_result(
+    ::grpc_cli::SetTelemetryPropertyResponse_Result* result) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(result_);
+  }
+  result_ = result;
+  if (result) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.SetTelemetryPropertyResponse.result)
+}
+inline ::grpc_cli::SetTelemetryPropertyResponse_Result* SetTelemetryPropertyResponse::release_result() {
+  
+  ::grpc_cli::SetTelemetryPropertyResponse_Result* temp = result_;
+  result_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::SetTelemetryPropertyResponse_Result* SetTelemetryPropertyResponse::unsafe_arena_release_result() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SetTelemetryPropertyResponse.result)
+  
+  ::grpc_cli::SetTelemetryPropertyResponse_Result* temp = result_;
+  result_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::SetTelemetryPropertyResponse_Result* SetTelemetryPropertyResponse::_internal_mutable_result() {
+  
+  if (result_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::SetTelemetryPropertyResponse_Result>(GetArena());
+    result_ = p;
+  }
+  return result_;
+}
+inline ::grpc_cli::SetTelemetryPropertyResponse_Result* SetTelemetryPropertyResponse::mutable_result() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SetTelemetryPropertyResponse.result)
+  return _internal_mutable_result();
+}
+inline void SetTelemetryPropertyResponse::set_allocated_result(::grpc_cli::SetTelemetryPropertyResponse_Result* result) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete result_;
+  }
+  if (result) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(result);
+    if (message_arena != submessage_arena) {
+      result = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, result, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  result_ = result;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SetTelemetryPropertyResponse.result)
+}
+
+// .grpc_cli.PosInfo info = 4;
+inline bool SetTelemetryPropertyResponse::_internal_has_info() const {
+  return this != internal_default_instance() && info_ != nullptr;
+}
+inline bool SetTelemetryPropertyResponse::has_info() const {
+  return _internal_has_info();
+}
+inline void SetTelemetryPropertyResponse::clear_info() {
+  if (GetArena() == nullptr && info_ != nullptr) {
+    delete info_;
+  }
+  info_ = nullptr;
+}
+inline const ::grpc_cli::PosInfo& SetTelemetryPropertyResponse::_internal_info() const {
+  const ::grpc_cli::PosInfo* p = info_;
+  return p != nullptr ? *p : reinterpret_cast<const ::grpc_cli::PosInfo&>(
+      ::grpc_cli::_PosInfo_default_instance_);
+}
+inline const ::grpc_cli::PosInfo& SetTelemetryPropertyResponse::info() const {
+  // @@protoc_insertion_point(field_get:grpc_cli.SetTelemetryPropertyResponse.info)
+  return _internal_info();
+}
+inline void SetTelemetryPropertyResponse::unsafe_arena_set_allocated_info(
+    ::grpc_cli::PosInfo* info) {
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::PROTOBUF_NAMESPACE_ID::MessageLite*>(info_);
+  }
+  info_ = info;
+  if (info) {
+    
+  } else {
+    
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:grpc_cli.SetTelemetryPropertyResponse.info)
+}
+inline ::grpc_cli::PosInfo* SetTelemetryPropertyResponse::release_info() {
+  
+  ::grpc_cli::PosInfo* temp = info_;
+  info_ = nullptr;
+  if (GetArena() != nullptr) {
+    temp = ::PROTOBUF_NAMESPACE_ID::internal::DuplicateIfNonNull(temp);
+  }
+  return temp;
+}
+inline ::grpc_cli::PosInfo* SetTelemetryPropertyResponse::unsafe_arena_release_info() {
+  // @@protoc_insertion_point(field_release:grpc_cli.SetTelemetryPropertyResponse.info)
+  
+  ::grpc_cli::PosInfo* temp = info_;
+  info_ = nullptr;
+  return temp;
+}
+inline ::grpc_cli::PosInfo* SetTelemetryPropertyResponse::_internal_mutable_info() {
+  
+  if (info_ == nullptr) {
+    auto* p = CreateMaybeMessage<::grpc_cli::PosInfo>(GetArena());
+    info_ = p;
+  }
+  return info_;
+}
+inline ::grpc_cli::PosInfo* SetTelemetryPropertyResponse::mutable_info() {
+  // @@protoc_insertion_point(field_mutable:grpc_cli.SetTelemetryPropertyResponse.info)
+  return _internal_mutable_info();
+}
+inline void SetTelemetryPropertyResponse::set_allocated_info(::grpc_cli::PosInfo* info) {
+  ::PROTOBUF_NAMESPACE_ID::Arena* message_arena = GetArena();
+  if (message_arena == nullptr) {
+    delete info_;
+  }
+  if (info) {
+    ::PROTOBUF_NAMESPACE_ID::Arena* submessage_arena =
+      ::PROTOBUF_NAMESPACE_ID::Arena::GetArena(info);
+    if (message_arena != submessage_arena) {
+      info = ::PROTOBUF_NAMESPACE_ID::internal::GetOwnedMessage(
+          message_arena, info, submessage_arena);
+    }
+    
+  } else {
+    
+  }
+  info_ = info;
+  // @@protoc_insertion_point(field_set_allocated:grpc_cli.SetTelemetryPropertyResponse.info)
 }
 
 // -------------------------------------------------------------------
@@ -68346,6 +69772,14 @@ inline void SetVolumePropertyResponse::set_allocated_info(::grpc_cli::PosInfo* i
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/src/cli/command_processor.cpp
+++ b/src/cli/command_processor.cpp
@@ -259,6 +259,28 @@ StopTelemetryResponse* reply)
 }
 
 grpc::Status
+CommandProcessor::ExecuteSetTelemetryPropertyCommand(const SetTelemetryPropertyRequest* request,
+SetTelemetryPropertyResponse* reply)
+{
+    reply->set_command(request->command());
+    reply->set_rid(request->rid());
+
+    TelemetryClient* tc = TelemetryClientSingleton::Instance();
+
+    std::string publicationListPath = (request->param()).publicationlistpath();
+
+    if (publicationListPath != "")
+    {
+        tc->LoadPublicationList(publicationListPath);
+    }    
+
+    _SetEventStatus(EID(SUCCESS), reply->mutable_result()->mutable_status());
+    _SetPosInfo(reply->mutable_info());
+    
+    return grpc::Status::OK;
+}
+
+grpc::Status
 CommandProcessor::ExecuteResetEventWrrCommand(const ResetEventWrrRequest* request,
     ResetEventWrrResponse* reply)
 {

--- a/src/cli/command_processor.h
+++ b/src/cli/command_processor.h
@@ -61,6 +61,8 @@ using grpc_cli::SetSystemPropertyRequest;
 using grpc_cli::SetSystemPropertyResponse;
 using grpc_cli::StartTelemetryRequest;
 using grpc_cli::StartTelemetryResponse;
+using grpc_cli::SetTelemetryPropertyRequest;
+using grpc_cli::SetTelemetryPropertyResponse;
 using grpc_cli::StopTelemetryRequest;
 using grpc_cli::StopTelemetryResponse;
 using grpc_cli::ResetEventWrrRequest;
@@ -142,6 +144,7 @@ public:
     // Telemetry Commands
     grpc::Status ExecuteStartTelemetryCommand(const StartTelemetryRequest* request, StartTelemetryResponse* reply);
     grpc::Status ExecuteStopTelemetryCommand(const StopTelemetryRequest* request, StopTelemetryResponse* reply);
+    grpc::Status ExecuteSetTelemetryPropertyCommand(const SetTelemetryPropertyRequest* request, SetTelemetryPropertyResponse* reply);
 
     // Developer COmmands
     grpc::Status ExecuteResetEventWrrCommand(const ResetEventWrrRequest* request, ResetEventWrrResponse* reply);

--- a/src/cli/grpc_cli_server.cpp
+++ b/src/cli/grpc_cli_server.cpp
@@ -162,6 +162,23 @@ class PosCliServiceImpl final : public PosCli::Service {
   }
 
   grpc::Status
+  SetTelemetryProperty(ServerContext* context, const SetTelemetryPropertyRequest* request,
+                  SetTelemetryPropertyResponse* reply) override
+  {
+    _LogCliRequest(request);
+
+    grpc::Status status = pc->ExecuteSetTelemetryPropertyCommand(request, reply);
+    if (context->IsCancelled()) {
+      _LogGrpcTimeout(request, reply);
+      return Status(StatusCode::CANCELLED, GRPC_TIMEOUT_MESSAGE);
+    }
+
+    _LogCliResponse(reply, status);
+
+    return status;
+  }
+
+  grpc::Status
   UpdateEventWrr(ServerContext* context, const UpdateEventWrrRequest* request,
                   UpdateEventWrrResponse* reply) override
   {

--- a/src/telemetry/telemetry_client/telemetry_client.cpp
+++ b/src/telemetry/telemetry_client/telemetry_client.cpp
@@ -199,4 +199,15 @@ TelemetryClient::IsPublisherRegistered(const std::string name)
     return (ret != publisherList.end());
 }
 
+bool
+TelemetryClient::LoadPublicationList(std::string filePath)
+{
+    for (auto &p : publisherList)
+    {
+        p.second->LoadPublicationList(filePath);
+    }
+    
+    return true;
+}
+
 } // namespace pos

--- a/src/telemetry/telemetry_client/telemetry_client.h
+++ b/src/telemetry/telemetry_client/telemetry_client.h
@@ -63,6 +63,7 @@ public:
     virtual bool StopUsingDataPoolForAllPublisher(void);
     virtual bool Notify(const std::string& key, const std::string& value) override;
     virtual bool IsPublisherRegistered(const std::string name);
+    virtual bool LoadPublicationList(std::string filePath);
 
 private:
     std::map<std::string, TelemetryPublisher*> publisherList;

--- a/tool/cli/cmd/grpcmgr/grpcmgr.go
+++ b/tool/cli/cmd/grpcmgr/grpcmgr.go
@@ -173,6 +173,29 @@ func SendStopTelemetryRpc(req *pb.StopTelemetryRequest) (*pb.StopTelemetryRespon
 	return res, err
 }
 
+func SendSetTelemetryPropertyRpc(req *pb.SetTelemetryPropertyRequest) (*pb.SetTelemetryPropertyResponse, error) {
+	conn, err := dialToCliServer()
+	if err != nil {
+		err := errors.New(fmt.Sprintf("%s (internal error message: %s)",
+			dialErrorMsg, err.Error()))
+		return nil, err
+	}
+	defer conn.Close()
+
+	c := pb.NewPosCliClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(globals.ReqTimeout))
+	defer cancel()
+
+	res, err := c.SetTelemetryProperty(ctx, req)
+
+	if err != nil {
+		log.Error("error: ", err.Error())
+		return nil, err
+	}
+
+	return res, err
+}
+
 func SendResetEventWrrPolicyRpc(req *pb.ResetEventWrrRequest) (*pb.ResetEventWrrResponse, error) {
 	conn, err := dialToCliServer()
 	if err != nil {

--- a/tool/cli/cmd/pos_cli_syntax.ebnf
+++ b/tool/cli/cmd/pos_cli_syntax.ebnf
@@ -323,6 +323,9 @@ TelemetryStartCmd = TelemetryCmd , ( "start" ) ;
 
 TelemetryStopCmd = TelemetryCmd , ( "stop" ) ;
 
+TelemetrySetPropertyCmd = TelemetryCmd , ( "set-property" ) ,
+[ "--publication-list-path" ] , Identifier ;
+
 DevelCmd = "devel" ,
   ( ResetMbrCmd
   | StopRebuildingCmd

--- a/tool/cli/cmd/telemetrycmds/general.go
+++ b/tool/cli/cmd/telemetrycmds/general.go
@@ -14,7 +14,7 @@ PoseidonOS will not gather the internal statistics once you execute
 the temeletry stop command.  
 
 Syntax: 
-  poseidonos-cli telemetry [start|stop]
+  poseidonos-cli telemetry [start|stop|set-property]
 
 Example (to start telemetry PoseidonOS):
   poseidonos-cli telemetry start
@@ -27,5 +27,5 @@ Example (to start telemetry PoseidonOS):
 func init() {
 	TelemetryCmd.AddCommand(StartTelemetryCmd)
 	TelemetryCmd.AddCommand(StopTelemetryCmd)
-
+	TelemetryCmd.AddCommand(SetTelemetryPropCmd)
 }

--- a/tool/cli/cmd/telemetrycmds/set_telemetry_property.go
+++ b/tool/cli/cmd/telemetrycmds/set_telemetry_property.go
@@ -1,0 +1,71 @@
+package telemetrycmds
+
+import (
+	"fmt"
+
+	pb "cli/api"
+	"cli/cmd/displaymgr"
+	"cli/cmd/globals"
+	"cli/cmd/grpcmgr"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+var SetTelemetryPropCmd = &cobra.Command{
+	Use:   "set-property",
+	Short: "Set properties of telemetry.",
+	Long: `
+  Set properties of telemetry.
+
+Syntax:
+  poseidonos-cli telemetry set-property --publication-list-path path
+          `,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		var command = "SETTELEMETRYPROPERTY"
+		req, buildErr := buildSetTelemetryPropertyReq(command)
+		if buildErr != nil {
+			fmt.Printf("failed to build request: %v", buildErr)
+			return buildErr
+		}
+
+		reqJson, err := protojson.Marshal(req)
+		if err != nil {
+			fmt.Printf("failed to marshal the protobuf request: %v", err)
+			return err
+		}
+		displaymgr.PrintRequest(string(reqJson))
+
+		res, gRpcErr := grpcmgr.SendSetTelemetryPropertyRpc(req)
+		if gRpcErr != nil {
+			globals.PrintErrMsg(gRpcErr)
+			return gRpcErr
+		}
+
+		printErr := displaymgr.PrintProtoResponse(command, res)
+		if printErr != nil {
+			fmt.Printf("failed to print the response: %v", printErr)
+			return printErr
+		}
+
+		return nil
+	},
+}
+
+func buildSetTelemetryPropertyReq(command string) (*pb.SetTelemetryPropertyRequest, error) {
+
+	param := &pb.SetTelemetryPropertyRequest_Param{PublicationListPath: set_telemetry_property_publicationListPath}
+
+	uuid := globals.GenerateUUID()
+	req := &pb.SetTelemetryPropertyRequest{Command: command, Rid: uuid, Requestor: "cli", Param: param}
+
+	return req, nil
+}
+
+var set_telemetry_property_publicationListPath = ""
+
+func init() {
+	SetTelemetryPropCmd.Flags().StringVarP(&set_telemetry_property_publicationListPath,
+		"publication-list-path", "", "", "The path of the telemetry publication list file.")
+}


### PR DESCRIPTION
Add SETTELEMETRYPROPERTY command, which updates the property of PoseidonOS telemetry module.

For now, only a flag to update metric publication list has been added to the command.

Add and update documents accordingly.