### PR TITLE
[AWIBOF-7025] Change the return code for AUTOCREATEARRAY to 0

### DIFF
--- a/src/cli/command_processor.cpp
+++ b/src/cli/command_processor.cpp
@@ -599,7 +599,7 @@ CommandProcessor::ExecuteAutocreateArrayCommand(const AutocreateArrayRequest* re
     else
     {
         QosManagerSingleton::Instance()->UpdateArrayMap(arrayName);
-        POS_TRACE_INFO(EID(CLI_AUTOCREATE_ARRAY_SUCCESS), "");
+        POS_TRACE_INFO(EID(SUCCESS), "");
         _SetEventStatus(ret, reply->mutable_result()->mutable_status());
         _SetPosInfo(reply->mutable_info());
         return grpc::Status::OK;


### PR DESCRIPTION
Change the return code for AUTOCREATEARRAY from EID(AUTOCREATEARRAYSUCCESS) to EID(SUCCESS), which is 0.

This change is because the command execution is recognized as a failure by some test scripts, which consider return code 0 is success.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>