### PR TITLE
[AWIBOF-6942] Reactor Wrapping IO is moved from uram internal to device manager

### DIFF
--- a/src/device/base/ublock_device.cpp
+++ b/src/device/base/ublock_device.cpp
@@ -172,8 +172,6 @@ UBlockDevice::Open(void)
         return false;
     }
 
-    returnValue = _WrapupOpenDeviceSpecific(devCtx);
-
     return returnValue;
 }
 
@@ -185,7 +183,7 @@ UBlockDevice::_OpenDeviceDriver(DeviceContext* deviceContextToOpen)
 }
 
 bool
-UBlockDevice::_WrapupOpenDeviceSpecific(DeviceContext* devicecontext)
+UBlockDevice::WrapupOpenDeviceSpecific(void)
 {
     return true;
 }

--- a/src/device/base/ublock_device.h
+++ b/src/device/base/ublock_device.h
@@ -79,6 +79,7 @@ public:
 
     virtual void SetDedicatedIOWorker(IOWorker* ioWorker);
     virtual IOWorker* GetDedicatedIOWorker(void);
+    virtual bool WrapupOpenDeviceSpecific(void);
 
 protected:
     virtual DeviceContext* _AllocateDeviceContext(void) = 0;
@@ -91,8 +92,6 @@ protected:
     DeviceProperty* property;
 
 private:
-    virtual bool _WrapupOpenDeviceSpecific(DeviceContext* devicecontext);
-
     bool _RegisterContextToCurrentCore(DeviceContext* devCtx);
     bool _RegisterThread(void);
     void _UnRegisterContextToCurrentCore(void);

--- a/src/device/device_manager.cpp
+++ b/src/device/device_manager.cpp
@@ -527,6 +527,7 @@ DeviceManager::_PrepareDevice(UblockSharedPtr dev)
     ioDispatcher->AddDeviceForReactor(dev);
     cpu_set_t ioWorkerCpuSet = affinityManager->GetCpuSet(CoreType::UDD_IO_WORKER);
     ioDispatcher->AddDeviceForIOWorker(dev, ioWorkerCpuSet);
+    dev->WrapupOpenDeviceSpecific();
 }
 
 } // namespace pos

--- a/src/device/uram/uram.h
+++ b/src/device/uram/uram.h
@@ -53,6 +53,7 @@ public:
     ~Uram(void) override;
     int SubmitAsyncIO(UbioSmartPtr ubio) override;
     void* GetByteAddress(void) override;
+    bool WrapupOpenDeviceSpecific(void) override;
 
 private:
     static const uint32_t MAX_THREAD_COUNT = 128;
@@ -63,10 +64,9 @@ private:
     std::atomic<uint32_t> requestCount;
     DeviceContext* _AllocateDeviceContext(void) override;
     void _ReleaseDeviceContext(DeviceContext* deviceContextToRelease) override;
-    bool _WrapupOpenDeviceSpecific(DeviceContext* deviceContext) override;
     void _InitByteAddress(void);
     static void _RequestAsyncIo(void* arg1);
-    bool _RecoverBackup(DeviceContext* deviceContext);
+    bool _RecoverBackup(void);
     void *baseByteAddress;
 };
 

--- a/test/unit-tests/device/base/ublock_device_mock.h
+++ b/test/unit-tests/device/base/ublock_device_mock.h
@@ -37,7 +37,7 @@ public:
     MOCK_METHOD(IOWorker*, GetDedicatedIOWorker, (), (override));
     MOCK_METHOD(DeviceContext*, _AllocateDeviceContext, (), (override));
     MOCK_METHOD(void, _ReleaseDeviceContext, (DeviceContext * deviceContextToRelease), (override));
-    MOCK_METHOD(bool, _WrapupOpenDeviceSpecific, (DeviceContext * devicecontext), (override));
+    MOCK_METHOD(bool, WrapupOpenDeviceSpecific, (), (override));
     MOCK_METHOD(void*, GetByteAddress, (), (override));
 };
 

--- a/test/unit-tests/device/uram/uram_mock.h
+++ b/test/unit-tests/device/uram/uram_mock.h
@@ -15,7 +15,7 @@ public:
     MOCK_METHOD(int, SubmitAsyncIO, (UbioSmartPtr ubio), (override));
     MOCK_METHOD(DeviceContext*, _AllocateDeviceContext, (), (override));
     MOCK_METHOD(void, _ReleaseDeviceContext, (DeviceContext * deviceContextToRelease), (override));
-    MOCK_METHOD(bool, _WrapupOpenDeviceSpecific, (DeviceContext * deviceContext), (override));
+    MOCK_METHOD(bool, WrapupOpenDeviceSpecific, (), (override));
 };
 
 } // namespace pos


### PR DESCRIPTION

Signed-off-by: sejun.kwon <sejun.kwon@samsung.com>