### PR TITLE
[AWIBOF-7028] Disable omitempty when marshalling protobuf to json

### DIFF
--- a/tool/cli/cmd/displaymgr/display_response.go
+++ b/tool/cli/cmd/displaymgr/display_response.go
@@ -25,9 +25,12 @@ func toByte(displayUnit bool, size uint64) string {
 }
 
 func PrintProtoResponse(command string, res protoreflect.ProtoMessage) error {
-	resByte, err := protojson.Marshal(res)
+	m := protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}
+	resByte, err := m.Marshal(res)
 	if err != nil {
-		fmt.Println("failed to marshal the protobuf response: %v", err)
+		fmt.Printf("failed to marshal the protobuf response: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
Disable omitempty option when marshalling protobuf to json in CLI.

Previously, when a protobuf field is 0, the field is omitted in json response. It caused errors in testing scripts.

To fix the errors, this commit disables omitempty option.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>