### PR TITLE
[AWIBOF-6869] control rebuild impact via io dispatcher

### DIFF
--- a/config/pos_for_fio_rebuild.conf
+++ b/config/pos_for_fio_rebuild.conf
@@ -33,16 +33,16 @@
    "affinity_manager": {
        "use_config": true,
        "use_reactor_only": true,
-       "reactor": "0-23,48-70",
-       "event_reactor": "27-40,71-74",
-       "udd_io_worker": "24-25",
-       "event_scheduler": "26",
-       "event_worker": "27-40,71-74",
-       "general_usage": "41",
-       "qos": "42",
-       "meta_scheduler": "43",
-       "meta_io": "44-47",
-       "air": "89"
+       "reactor": "0-20",
+       "event_reactor": "21-23,48-49",
+       "udd_io_worker": "50",
+       "event_scheduler": "50",
+       "event_worker": "51",
+       "general_usage": "51",
+       "qos": "51",
+       "meta_scheduler": "52",
+       "meta_io": "53-60",
+       "air": "61"
    },
    "user_nvme_driver": {
        "use_config" : true,

--- a/src/array_components/array_components.cpp
+++ b/src/array_components/array_components.cpp
@@ -58,6 +58,7 @@ ArrayComponents::ArrayComponents(string arrayName, IArrayRebuilder* rebuilder, I
     nullptr /*metaFsFactory*/,
     nullptr /*nvmf*/,
     nullptr /*smartLogMetaIo*/,
+    nullptr /*stateObserverForIo*/,
     nullptr /*arrayMountSequence*/
     )
 {
@@ -93,6 +94,7 @@ ArrayComponents::ArrayComponents(string arrayName,
     function<MetaFs* (Array*, bool)> metaFsFactory,
     Nvmf* nvmf,
     SmartLogMetaIo* smartLogMetaIo,
+    StateObserverForIO* stateObserverForIO,
     ArrayMountSequence* arrayMountSequence)
 : arrayName(arrayName),
   state(state),
@@ -108,7 +110,8 @@ ArrayComponents::ArrayComponents(string arrayName,
   nvmf(nvmf),
   smartLogMetaIo(smartLogMetaIo),
   arrayMountSequence(arrayMountSequence),
-  metaFsFactory(metaFsFactory)
+  metaFsFactory(metaFsFactory),
+  stateObserverForIO(stateObserverForIO)
 {
     // dependency injection for ut
 }
@@ -278,6 +281,7 @@ ArrayComponents::_SetMountSequence(void)
     mountSequence.push_back(flowControl);
     mountSequence.push_back(gc);
     mountSequence.push_back(smartLogMetaIo);
+
     IStateControl* state = stateMgr->GetStateControl(arrayName);
     if (arrayMountSequence != nullptr)
     {
@@ -298,7 +302,8 @@ ArrayComponents::_InstantiateMetaComponentsAndMountSequenceInOrder(bool isArrayL
         || flowControl != nullptr
         || gc != nullptr
         || info != nullptr
-        || smartLogMetaIo != nullptr)
+        || smartLogMetaIo != nullptr
+        || stateObserverForIO != nullptr)
     {
         POS_TRACE_WARN(EID(ARRAY_COMPO_DEBUG_MSG), "Meta Components exist already. Possible memory leak (or is it a mock?). Skipping.");
         return;
@@ -315,6 +320,7 @@ ArrayComponents::_InstantiateMetaComponentsAndMountSequenceInOrder(bool isArrayL
     gc = new GarbageCollector(array, state);
     smartLogMetaIo = new SmartLogMetaIo(array->GetIndex(), SmartLogMgrSingleton::Instance());
     info = new ComponentsInfo(array, gc);
+    stateObserverForIO = new StateObserverForIO(state);
 }
 
 void
@@ -368,6 +374,13 @@ ArrayComponents::_DestructMetaComponentsInOrder(void)
         delete metafs;
         metafs = nullptr;
         POS_TRACE_DEBUG(EID(ARRAY_COMPO_DEBUG_MSG), "MetaFs for {} has been deleted.", arrayName);
+    }
+
+    if (stateObserverForIO != nullptr)
+    {
+        delete stateObserverForIO;
+        metafs = nullptr;
+        POS_TRACE_DEBUG(EID(ARRAY_COMPO_DEBUG_MSG), "stateObserverForIO for {} has been deleted.", arrayName);
     }
 }
 

--- a/src/array_components/array_components.h
+++ b/src/array_components/array_components.h
@@ -41,6 +41,7 @@
 #include "src/gc/flow_control/flow_control.h"
 #include "src/gc/garbage_collector.h"
 #include "src/io/general_io/rba_state_manager.h"
+#include "src/io_scheduler/io_dispatcher_submission.h"
 #include "src/volume/volume_manager.h"
 #include "src/metafs/metafs.h"
 #include "src/network/nvmf.h"
@@ -78,6 +79,7 @@ public:
         function<MetaFs* (Array*, bool)> metaFsFactory,
         Nvmf* nvmf,
         SmartLogMetaIo* smartLogMetaIo,
+        StateObserverForIO* stateObserverForIO,
         ArrayMountSequence* mountSequence = nullptr);
     virtual ~ArrayComponents(void);
     virtual ComponentsInfo* GetInfo(void);
@@ -121,6 +123,7 @@ private:
 
     // MetaFs factory: MetaFs creation is not determined during ArrayComponents construction. Hence, we need a lambda.
     function<MetaFs* (Array*, bool)> metaFsFactory = nullptr;
+    StateObserverForIO* stateObserverForIO = nullptr;
 
     // telemetry
     TelemetryPublisher* telPublisher = nullptr;

--- a/src/cli/command_processor.cpp
+++ b/src/cli/command_processor.cpp
@@ -16,6 +16,7 @@
 #include "src/event/event_manager.h"
 #include "src/helper/rpc/spdk_rpc_client.h"
 #include "src/include/nvmf_const.h"
+#include "src/io_scheduler/io_dispatcher_submission.h"
 #include "src/logger/logger.h"
 #include "src/logger/preferences.h"
 #include "src/master_context/version_provider.h"
@@ -164,18 +165,21 @@ CommandProcessor::ExecuteSetSystemPropertyCommand(const SetSystemPropertyRequest
     qos_backend_policy newBackendPolicy;
 
     std::string level = request->param().level();
-
+    IODispatcherSubmission* ioDispatcherSubmission = IODispatcherSubmissionSingleton::Instance();
     if (level.compare("high") == 0)
     {
         newBackendPolicy.priorityImpact = PRIORITY_HIGH;
+        ioDispatcherSubmission->SetRebuildImpact(RebuildImpact::High);
     }
     else if (level.compare("medium") == 0)
     {
         newBackendPolicy.priorityImpact = PRIORITY_MEDIUM;
+        ioDispatcherSubmission->SetRebuildImpact(RebuildImpact::Medium);
     }
     else if (level.compare("low") == 0)
     {
         newBackendPolicy.priorityImpact = PRIORITY_LOW;
+        ioDispatcherSubmission->SetRebuildImpact(RebuildImpact::Low);
     }
     else
     {

--- a/src/debug/debug_info.cpp
+++ b/src/debug/debug_info.cpp
@@ -50,6 +50,7 @@
 #include "src/io/general_io/rba_state_service.h"
 #include "src/pos_replicator/posreplicator_manager.h"
 #include "src/io_scheduler/io_dispatcher.h"
+#include "src/io_scheduler/io_dispatcher_submission.h"
 #include "src/logger/logger.h"
 #include "src/mapper_service/mapper_service.h"
 #include "src/master_context/config_manager.h"
@@ -133,6 +134,7 @@ DebugInfo::Update(void)
     volumeEventPublisher = VolumeEventPublisherSingleton::Instance();
     eventScheduler = EventSchedulerSingleton::Instance();
     ioDispatcher = IODispatcherSingleton::Instance();
+    ioDispatcherSubmission = IODispatcherSubmissionSingleton::Instance();
     qosManager = QosManagerSingleton::Instance();
     flushCmdManager = FlushCmdManagerSingleton::Instance();
     versionProvider = VersionProviderSingleton::Instance();

--- a/src/debug/debug_info.h
+++ b/src/debug/debug_info.h
@@ -50,6 +50,7 @@ class FlushCmdManager;
 class FlushCount;
 class GarbageCollector;
 class IODispatcher;
+class IODispatcherSubmission;
 class IOSubmitHandlerCount;
 class Logger;
 class MapperService;
@@ -97,6 +98,7 @@ private:
     FlushCount* flushCount;
     GarbageCollector* garbageCollector;
     IODispatcher* ioDispatcher;
+    IODispatcherSubmission* ioDispatcherSubmission;
     IOSubmitHandlerCount* ioSubmitHandlerCount;
     Logger* logger;
     MapperService* mapperService;

--- a/src/event/pos_event.yaml
+++ b/src/event/pos_event.yaml
@@ -6045,7 +6045,6 @@ Root:
     Cause:
     Solution:
 
-
   # IOPath Backend: 5300 - 5499
   -
     Id: 5300
@@ -6561,6 +6560,12 @@ Root:
     Cause:
     Solution:
 
+    Id: 5373
+    Name: IODISPATCHER_STATE_CHANGE
+    Severity:
+    Message:
+    Cause:
+    Solution:
   -
     Id: 5500
     Name: UNVME_DAEMON_START

--- a/src/event_scheduler/callback.cpp
+++ b/src/event_scheduler/callback.cpp
@@ -215,12 +215,12 @@ Callback::_InvokeCallee(void)
     if (isOkToCall == true)
     {
         _PreCallExecuteCallee();
-        bool done = callee->Execute();
+       /* bool done = callee->Execute();
 
         if (likely(done))
         {
             return;
-        }
+        }*/
 
         eventScheduler->EnqueueEvent(callee);
     }

--- a/src/event_scheduler/callback.cpp
+++ b/src/event_scheduler/callback.cpp
@@ -39,6 +39,7 @@
 #include "src/dump/dump_module.hpp"
 #include "src/dump/dump_shared_ptr.h"
 #include "src/event_scheduler/event_scheduler.h"
+#include "src/include/backend_event.h"
 #include "src/include/branch_prediction.h"
 #include "src/include/pos_event_id.hpp"
 #include "src/lib/system_timeout_checker.h"
@@ -215,12 +216,15 @@ Callback::_InvokeCallee(void)
     if (isOkToCall == true)
     {
         _PreCallExecuteCallee();
-       /* bool done = callee->Execute();
-
-        if (likely(done))
+        bool done = false;
+        if (GetEventType() != BackendEvent_UserdataRebuild)
         {
-            return;
-        }*/
+            done = callee->Execute();
+            if (likely(done))
+            {
+                return;
+            }
+        }
 
         eventScheduler->EnqueueEvent(callee);
     }

--- a/src/io_scheduler/io_dispatcher.h
+++ b/src/io_scheduler/io_dispatcher.h
@@ -77,8 +77,6 @@ public:
     static void RegisterRecoveryEventFactory(EventFactory* recoveryEventFactory);
     static void SetFrontendDone(bool value);
 
-    int SubmitIOInReactor(UBlockDevice* uBlock, UbioSmartPtr ubio);
-
     std::queue<std::pair<IOWorker*, UbioSmartPtr>> ioQueue[BackendEvent_Count];
     std::mutex ioQueueLock[BackendEvent_Count];
 
@@ -117,8 +115,6 @@ private:
 
     static const int DEVICE_FAILED = -1;
     static const int PARAM_FAILED = -2;
-    static const uint32_t MAX_CORE = 128;
-    uint32_t ioReactorCore[MAX_CORE], ioReactorCount = 0;
 };
 
 using IODispatcherSingleton = Singleton<IODispatcher>;

--- a/src/io_scheduler/io_dispatcher_submission.cpp
+++ b/src/io_scheduler/io_dispatcher_submission.cpp
@@ -1,0 +1,351 @@
+/*
+ *   BSD LICENSE
+ *   Copyright (c) 2021 Samsung Electronics Corporation
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Samsung Electronics Corporation nor the names of
+ *       its contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "io_dispatcher.h"
+
+#include <unistd.h>
+
+#include "src/array_mgmt/array_manager.h"
+#include "src/array_models/interface/i_array_info.h"
+#include "src/cpu_affinity/affinity_manager.h"
+#include "src/device/base/ublock_device.h"
+#include "src/event_scheduler/spdk_event_scheduler.h"
+#include "src/include/array_mgmt_policy.h"
+#include "src/include/i_array_device.h"
+#include "src/include/pos_event_id.hpp"
+#include "src/io_scheduler/dispatcher_policy.h"
+#include "src/io_scheduler/io_dispatcher_submission.h"
+#include "src/io_scheduler/io_worker.h"
+#include "src/logger/logger.h"
+#include "src/spdk_wrapper/event_framework_api.h"
+
+namespace pos
+{
+
+SchedulingInIODispatcher IODispatcherSubmission::scheduler[BackendEvent_Count];
+
+IODispatcherSubmission::IODispatcherSubmission(void)
+{
+    ioReactorCount = 0;
+    for (uint32_t coreIndex = 0; coreIndex < MAX_CORE; coreIndex++)
+    {
+        ioReactorCore[coreIndex] = 0;
+    }
+    for (uint32_t coreIndex = 0; coreIndex < MAX_CORE; coreIndex++)
+    {
+        if (AffinityManagerSingleton::Instance()->IsIoReactor(coreIndex))
+        {
+            ioReactorCore[ioReactorCount] = coreIndex;
+            ioReactorCount++;
+        }
+    }
+    for (uint32_t event = 0; event < BackendEvent_Count; event++)
+    {
+        scheduler[event].schedType = SchedulingType::NoMatter;
+        scheduler[event].readMaxBw = NO_THROTTLING_VALUE;
+        scheduler[event].writeMaxBw = NO_THROTTLING_VALUE;
+        scheduler[event].remainingRead = scheduler[event].readMaxBw;
+        scheduler[event].remainingWrite = scheduler[event].writeMaxBw;
+        scheduler[event].reactorRatio = 0;
+        scheduler[event].reactorStart = 0;
+        scheduler[event].reactorCount = 0;
+    }
+    IODispatcherSubmission::_SetRebuildImpact(RebuildImpact::High);
+    schedulingOn = false;
+}
+
+IODispatcherSubmission::~IODispatcherSubmission(void)
+{
+}
+
+bool
+IODispatcherSubmission::CheckThrottledAndConsumeRemaining(UbioSmartPtr ubio)
+{
+    uint32_t eventType = ubio->GetEventType();
+    UbioDir dir = ubio->dir;
+    if (scheduler[eventType].schedType == SchedulingType::ReactorRatioAndThrottling)
+    {
+        if (dir == UbioDir::Write)
+        {
+            if (scheduler[eventType].remainingWrite < 0)
+            {
+                return false;
+            }
+            scheduler[eventType].remainingWrite -= ubio->GetSize();
+        }
+        else if (dir == UbioDir::Read)
+        {
+            if (scheduler[eventType].remainingRead < 0)
+            {
+                return false;
+            }
+            scheduler[eventType].remainingRead -= ubio->GetSize();
+        }
+    }
+    return true;
+}
+
+void
+IODispatcherSubmission::_SubmitIOInReactor(void* ptr1, void* ptr2)
+{
+    UBlockDevice* ublock = (UBlockDevice*)ptr1;
+    UbioSmartPtr* ubio = (UbioSmartPtr*)ptr2;
+    bool ret = CheckThrottledAndConsumeRemaining(*ubio);
+    if (ret)
+    {
+        ublock->SubmitAsyncIO(*ubio);
+        delete ubio;
+    }
+    else
+    {
+        uint32_t targetReactorCore
+            = EventFrameworkApiSingleton::Instance()->GetCurrentReactor();
+        EventFrameworkApiSingleton::Instance()->SendSpdkEvent(
+            targetReactorCore,
+            _SubmitIOInReactor,
+            ublock, (void*)ubio);
+    }
+}
+
+void
+IODispatcherSubmission::SetMaxBw(BackendEvent event, bool read, uint64_t max)
+{
+    if (read)
+    {
+        scheduler[event].readMaxBw = max;
+    }
+    else
+    {
+        scheduler[event].writeMaxBw = max;
+    }
+}
+
+void
+IODispatcherSubmission::SetReactorRatio(BackendEvent event, uint32_t ratio)
+{
+    scheduler[event].reactorRatio = ratio;
+}
+
+bool
+IODispatcherSubmission::_IsReactorScheduledNeeded(SchedulingType schedType)
+{
+    return ((schedType == SchedulingType::ReactorRatio
+        || schedType == SchedulingType::ReactorRatioAndThrottling) && schedulingOn == true);
+}
+
+int
+IODispatcherSubmission::SubmitIOInReactor(UBlockDevice* ublock, UbioSmartPtr ubio)
+{
+    UbioSmartPtr* smartPtr = new UbioSmartPtr(ubio);
+    uint32_t eventType = ubio->GetEventType();
+    static std::atomic<uint32_t> lastIndexCommon;
+    SchedulingType schedType = scheduler[eventType].schedType;
+    uint32_t lastIndex = lastIndexCommon;
+    uint64_t reactorStart = 0;
+    uint64_t reactorCount = ioReactorCount;
+    if (_IsReactorScheduledNeeded(schedType) == true)
+    {
+        lastIndex = scheduler[eventType].lastIndex;
+        reactorStart = scheduler[eventType].reactorStart;
+        reactorCount = scheduler[eventType].reactorCount;
+    }
+
+    uint32_t targetReactorCore = ioReactorCore[lastIndex];
+
+    if (ubio->GetOriginCore() == INVALID_CORE)
+    {
+        ubio->SetOriginCore(targetReactorCore);
+    }
+    bool ret = true;
+    scheduler[eventType].busyDetector++;
+    ret = EventFrameworkApiSingleton::Instance()->SendSpdkEvent(targetReactorCore,
+            _SubmitIOInReactor,
+            ublock, (void*)smartPtr);
+    uint32_t nextLastIndex = (lastIndex + 1) % reactorCount + reactorStart;
+
+    if (_IsReactorScheduledNeeded(schedType) == true)
+    {
+        scheduler[eventType].lastIndex = nextLastIndex;
+    }
+    else
+    {
+        lastIndexCommon = nextLastIndex;
+    }
+    return ret;
+}
+
+void
+IODispatcherSubmission::UpdateReactorRatio(void)
+{
+    uint32_t totalReactorRatio = 0;
+    scheduler[BackendEvent_FrontendIO].schedType = SchedulingType::NoMatter;
+    scheduler[BackendEvent_UserdataRebuild].schedType = SchedulingType::NoMatter;
+    for (uint32_t event = 0; event < BackendEvent_Count; event++)
+    {
+        totalReactorRatio += scheduler[event].reactorRatio;
+    }
+    uint32_t currentStartReactor = 0;
+    uint32_t lastEventWithRatioSet = 0;
+    for (uint32_t event = 0; event < BackendEvent_Count; event++)
+    {
+        if (scheduler[event].reactorRatio != 0)
+        {
+            scheduler[event].reactorStart = currentStartReactor;
+            uint32_t reactorCountForEvent = scheduler[event].reactorRatio * ioReactorCount / totalReactorRatio;
+            scheduler[event].reactorCount = reactorCountForEvent;
+            currentStartReactor += reactorCountForEvent;
+            lastEventWithRatioSet = event;
+        }
+    }
+    scheduler[lastEventWithRatioSet].reactorCount = ioReactorCount - scheduler[lastEventWithRatioSet].reactorStart;
+    scheduler[BackendEvent_FrontendIO].schedType = SchedulingType::ReactorRatio;
+    scheduler[BackendEvent_UserdataRebuild].schedType = SchedulingType::ReactorRatioAndThrottling;
+}
+
+void
+IODispatcherSubmission::RefillRemaining(uint64_t scale)
+{
+    for (uint32_t event = 0; event < BackendEvent_Count; event++)
+    {
+        if (scheduler[event].schedType == SchedulingType::ReactorRatioAndThrottling)
+        {
+            scheduler[event].remainingRead = scheduler[event].readMaxBw / scale;
+            scheduler[event].remainingWrite = scheduler[event].writeMaxBw / scale;
+        }
+    }
+}
+
+void
+IODispatcherSubmission::CheckAndSetBusyMode(void)
+{
+    bool busyLocal = false;
+    for (uint32_t arrayId = 0; arrayId < ArrayMgmtPolicy::MAX_ARRAY_CNT; arrayId++)
+    {
+        ComponentsInfo* compInfo = ArrayMgr()->GetInfo(arrayId);
+        if (unlikely(compInfo == nullptr))
+        {
+            continue;
+        }
+        IArrayInfo* info = compInfo->arrayInfo;
+        if (unlikely(info == nullptr))
+        {
+            continue;
+        }
+        IStateControl* stateControl = StateManagerSingleton::Instance()->GetStateControl(info->GetName());
+        bool isBusyState = (stateControl->GetState()->ToStateType() == StateEnum::BUSY);
+        busyLocal = (busyLocal || isBusyState);
+    }
+    schedulingOn = busyLocal;
+    if (scheduler[BackendEvent_FrontendIO].busyDetector == 0)
+    {
+        scheduler[BackendEvent_FrontendIO].schedType = SchedulingType::NoMatter;
+    }
+    else
+    {
+        scheduler[BackendEvent_FrontendIO].schedType = SchedulingType::ReactorRatioAndThrottling;
+    }
+    scheduler[BackendEvent_FrontendIO].busyDetector = 0;
+}
+
+void
+IODispatcherSubmission::SetRebuildImpact(RebuildImpact rebuildImpact)
+{
+    _SetRebuildImpact(rebuildImpact);
+}
+
+void
+IODispatcherSubmission::_SetRebuildImpact(RebuildImpact rebuildImpact)
+{
+    switch(rebuildImpact)
+    {
+        case RebuildImpact::High:
+        {
+            SetReactorRatio(BackendEvent_FrontendIO, 15);
+            SetReactorRatio(BackendEvent_UserdataRebuild, 35);
+            SetMaxBw(BackendEvent_UserdataRebuild, false, SSD_REBUILD_WRITE_MAX_BW * 1024 * 1024);
+            break;
+        }
+        case RebuildImpact::Medium:
+        {
+            SetReactorRatio(BackendEvent_FrontendIO, 25);
+            SetReactorRatio(BackendEvent_UserdataRebuild, 25);
+            SetMaxBw(BackendEvent_UserdataRebuild, false, SSD_REBUILD_WRITE_MAX_BW / 3 * 1024 * 1024);
+            break;
+        }
+        default:
+        {
+            SetReactorRatio(BackendEvent_FrontendIO, 49);
+            SetReactorRatio(BackendEvent_UserdataRebuild, 1);
+            SetMaxBw(BackendEvent_UserdataRebuild, false, SSD_REBUILD_WRITE_MAX_BW / 35 * 1024 * 1024);
+            break;
+        }
+    }
+    UpdateReactorRatio();
+}
+
+int
+IODispatcherSubmission::SubmitIO(UBlockDevice* ublock,
+    UbioSmartPtr ubio, DispatcherPolicyI* dispatcherPolicy)
+{
+    int ret = 0;
+    bool isReactor = EventFrameworkApiSingleton::Instance()->IsReactorNow();
+    if (isReactor)
+    {
+        if ((AffinityManagerSingleton::Instance()->UseEventReactor()
+            && ubio->GetOriginCore() == INVALID_CORE) || schedulingOn)
+        {
+            ret = SubmitIOInReactor(ublock, ubio);
+        }
+        else
+        {
+            ret = ublock->SubmitAsyncIO(ubio);
+        }
+    }
+    else
+    {
+        IOWorker* ioWorker = nullptr;
+        if (AffinityManagerSingleton::Instance()->UseEventReactor())
+        {
+            ret = SubmitIOInReactor(ublock, ubio);
+        }
+        else
+        {
+            ioWorker = ublock->GetDedicatedIOWorker();
+        }
+        if (likely(nullptr != ioWorker))
+        {
+            dispatcherPolicy->Submit(ioWorker, ubio);
+        }
+    }
+    return ret;
+}
+} // namespace pos

--- a/src/io_scheduler/io_dispatcher_submission.cpp
+++ b/src/io_scheduler/io_dispatcher_submission.cpp
@@ -73,6 +73,7 @@ IODispatcherSubmission::IODispatcherSubmission(void)
     for (uint32_t event = 0; event < BackendEvent_Count; event++)
     {
         scheduler[event].schedType = SchedulingType::NoMatter;
+        scheduler[event].schedTypeCLI = SchedulingType::NoMatter;
         scheduler[event].readMaxBw = NO_THROTTLING_VALUE;
         scheduler[event].writeMaxBw = NO_THROTTLING_VALUE;
         scheduler[event].remainingRead = scheduler[event].readMaxBw;
@@ -211,10 +212,12 @@ IODispatcherSubmission::_SetSchedType(BackendEvent event, SchedulingType schedTy
     if (scheduler[event].reactorCount != 0)
     {
         scheduler[event].schedType = schedType;
+        scheduler[event].schedTypeCLI = schedType;
     }
     else
     {
         scheduler[event].schedType = SchedulingType::NoMatter;
+        scheduler[event].schedTypeCLI = SchedulingType::NoMatter;
     }
 }
 
@@ -270,11 +273,12 @@ IODispatcherSubmission::CheckAndSetBusyMode(void)
 {
     if (scheduler[BackendEvent_FrontendIO].busyDetector == 0)
     {
-        scheduler[BackendEvent_FrontendIO].schedType = SchedulingType::NoMatter;
+        scheduler[BackendEvent_UserdataRebuild].schedType = SchedulingType::NoMatter;
     }
     else
     {
-        scheduler[BackendEvent_FrontendIO].schedType = SchedulingType::ReactorRatioAndThrottling;
+        scheduler[BackendEvent_UserdataRebuild].schedType
+            = scheduler[BackendEvent_UserdataRebuild].schedTypeCLI;
     }
     scheduler[BackendEvent_FrontendIO].busyDetector = 0;
 }

--- a/src/io_scheduler/io_dispatcher_submission.h
+++ b/src/io_scheduler/io_dispatcher_submission.h
@@ -1,0 +1,101 @@
+/*
+ *   BSD LICENSE
+ *   Copyright (c) 2021 Samsung Electronics Corporation
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Samsung Electronics Corporation nor the names of
+ *       its contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "src/include/backend_event.h"
+
+class UbioSmartPtr;
+class UBlockDevice;
+
+namespace pos
+{
+
+enum class SchedulingType
+{
+    NoMatter,
+    ReactorRatio,
+    ReactorRatioAndThrottling
+};
+
+enum class RebuildImpact
+{
+    Low,
+    Medium,
+    High
+};
+
+struct SchedulingInIODispatcher
+{
+    SchedulingType schedType;
+    uint64_t readMaxBw;
+    uint64_t writeMaxBw;
+    std::atomic<int64_t> remainingRead;
+    std::atomic<int64_t> remainingWrite;
+    uint64_t reactorRatio;  // CLI Set
+    uint64_t reactorStart; // internal used;
+    uint64_t reactorCount; // internal used;
+    uint64_t busyDetector;
+    std::atomic<uint32_t> lastIndex;
+};
+
+class IODispatcherSubmission
+{
+public:
+    explicit IODispatcherSubmission(void);
+    ~IODispatcherSubmission(void);
+
+    void SetMaxBw(BackendEvent event, bool read, uint64_t max);
+    void SetRebuildImpact(RebuildImpact rebuildImpact);
+    void UpdateReactorRatio(void);
+    void SetReactorRatio(BackendEvent event, uint32_t ratio);
+    void RefillRemaining(uint64_t scale);
+    int SubmitIO(UBlockDevice* ublock, UbioSmartPtr ubio, DispatcherPolicyI* dispatcherPolicy);
+    void CheckAndSetBusyMode(void);
+
+private:
+    int SubmitIOInReactor(UBlockDevice* ublock, UbioSmartPtr ubio);
+    bool _IsReactorScheduledNeeded(SchedulingType schedType);
+    static bool CheckThrottledAndConsumeRemaining(UbioSmartPtr ubio);
+    static void _SubmitIOInReactor(void* ptr1, void* ptr2);
+    void _SetRebuildImpact(RebuildImpact rebuildImpact);
+    static const uint32_t MAX_CORE = 128;
+    uint32_t ioReactorCore[MAX_CORE], ioReactorCount = 0;
+    static const uint64_t NO_THROTTLING_VALUE = 64 * 1024ULL * 1024ULL * 1024ULL; // 64G
+    static const uint64_t SSD_REBUILD_WRITE_MAX_BW = 3500ULL;
+    static SchedulingInIODispatcher scheduler[BackendEvent_Count];
+    bool schedulingOn;
+};
+
+using IODispatcherSubmissionSingleton = Singleton<IODispatcherSubmission>;
+
+} // namespace pos

--- a/src/io_scheduler/io_dispatcher_submission.h
+++ b/src/io_scheduler/io_dispatcher_submission.h
@@ -59,6 +59,7 @@ enum class RebuildImpact
 struct SchedulingInIODispatcher
 {
     SchedulingType schedType;
+    SchedulingType schedTypeCLI;
     uint64_t readMaxBw;
     uint64_t writeMaxBw;
     std::atomic<int64_t> remainingRead;

--- a/src/qos/qos_manager.cpp
+++ b/src/qos/qos_manager.cpp
@@ -41,6 +41,7 @@
 #include "src/include/branch_prediction.h"
 #include "src/include/pos_event_id.hpp"
 #include "src/io/frontend_io/aio.h"
+#include "src/io_scheduler/io_dispatcher_submission.h"
 #include "src/io_scheduler/io_worker.h"
 #include "src/logger/logger.h"
 #include "src/master_context/config_manager.h"
@@ -113,7 +114,7 @@ QosManager::QosManager(SpdkEnvCaller* spdkEnvCaller,
     {
         previousDelay[reactor] = 0;
     }
-
+    
     currentNumberOfArrays = 0;
     systemMinPolicy = false;
     affinityManager = AffinityManagerSingleton::Instance();
@@ -295,6 +296,9 @@ QosManager::PeriodicalJob(uint64_t* nextTick)
             *nextTick = now;
         }
         *nextTick = *nextTick + IBOF_QOS_TIMESLICE_IN_USEC * spdkEnvCaller->SpdkGetTicksHz() / SPDK_SEC_TO_USEC;
+        IODispatcherSubmissionSingleton::Instance()->CheckAndSetBusyMode();
+        IODispatcherSubmissionSingleton::Instance()->RefillRemaining(SPDK_SEC_TO_USEC
+            / IBOF_QOS_TIMESLICE_IN_USEC);
         _ControlThrottling();
     }
 }

--- a/src/qos/qos_manager.cpp
+++ b/src/qos/qos_manager.cpp
@@ -114,7 +114,7 @@ QosManager::QosManager(SpdkEnvCaller* spdkEnvCaller,
     {
         previousDelay[reactor] = 0;
     }
-    
+
     currentNumberOfArrays = 0;
     systemMinPolicy = false;
     affinityManager = AffinityManagerSingleton::Instance();

--- a/src/rebuild/rebuild_methods/rebuild_write_done.cpp
+++ b/src/rebuild/rebuild_methods/rebuild_write_done.cpp
@@ -39,7 +39,7 @@
 namespace pos
 {
 RebuildWriteDone::RebuildWriteDone(UbioSmartPtr ubio, WriteDoneCallback writeDoneCallback)
-: Callback(false, CallbackType_RebuildReadCompleteHandler),
+: Callback(false, CallbackType_UpdateDataCompleteHandler),
   ubio(ubio),
   writeDoneCallback(writeDoneCallback)
 {

--- a/test/unit-tests/array_components/array_components_test.cpp
+++ b/test/unit-tests/array_components/array_components_test.cpp
@@ -42,7 +42,7 @@ TEST(ArrayComponents, ArrayComponents_testConstructorWithNullPtrs)
 
     // When
     ArrayComponents arrayComps("mock-array", nullptr, nullptr, &mockStateManager,
-        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr);
+        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr, nullptr);
 
     // Then
 }
@@ -53,7 +53,7 @@ TEST(ArrayComponents, Create_testIfRemoveStateIsInvokedWhenCreationFails)
     MockStateManager mockStateManager;
     MockArray* mockArray = new MockArray("mock-array", nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
     ArrayComponents arrayComps("mock-array", nullptr, nullptr, &mockStateManager, nullptr, mockArray,
-        nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr);
+        nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr, nullptr);
 
     EXPECT_CALL(*mockArray, Create).WillOnce(Return(EID(ARRAY_BROKEN_ERROR)));
     EXPECT_CALL(mockStateManager, RemoveStateControl).Times(1); // one by Create() and the other by destructor
@@ -73,7 +73,7 @@ TEST(ArrayComponents, Create_testIfGetStateAndSubscribeIsInvokedWhenCreationSucc
     NiceMock<MockStateControl> mockStateControl;
     MockVolumeManager* mockVolMgr = new MockVolumeManager(nullptr, &mockStateControl);
     ArrayComponents arrayComps("mock-array", nullptr, nullptr, &mockStateManager, &mockStateControl, mockArray,
-        mockVolMgr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr);
+        mockVolMgr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr, nullptr);
 
     EXPECT_CALL(*mockArray, Create).WillOnce([=](DeviceSet<string> nameSet, string dataRaidType, unsigned int& arrayIndex)
     {
@@ -96,7 +96,7 @@ TEST(ArrayComponents, Load_testIfLoadFailureIsPropagated)
     MockStateManager mockStateManager;
     MockArray* mockArray = new MockArray("mock-array", nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
     ArrayComponents arrayComps("mock-array", nullptr, nullptr, &mockStateManager, nullptr, mockArray,
-        nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr);
+        nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr, nullptr);
 
     int LOAD_FAILURE = 123;
     EXPECT_CALL(*mockArray, Load).WillOnce(Return(LOAD_FAILURE));
@@ -117,7 +117,7 @@ TEST(ArrayComponents, Load_testIfSuccessfulLoadSetsMountSequence)
     NiceMock<MockStateControl> mockStateControl;
     MockVolumeManager* mockVolMgr = new MockVolumeManager(nullptr, &mockStateControl);
     ArrayComponents arrayComps("mock-array", nullptr, nullptr, &mockStateManager, &mockStateControl, mockArray,
-        mockVolMgr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr);
+        mockVolMgr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr, nullptr);
 
     EXPECT_CALL(*mockArray, Load).WillOnce([=](unsigned int& arrayIndex)
     {
@@ -150,7 +150,7 @@ TEST(ArrayComponents, Mount_testUsingArrayMountSequenceMock)
     EXPECT_CALL(*mockArray, SetPreferences).Times(1);
     EXPECT_CALL(*mockArray, MountDone).Times(1);
     ArrayComponents arrayComponents("mock-array", nullptr, nullptr, &mockStateManager, nullptr, mockArray,
-        nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr, nullptr, mockArrayMountSequence);
+        nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr, nullptr, nullptr, mockArrayMountSequence);
     // When
     int result = arrayComponents.Mount(false);
 
@@ -173,7 +173,7 @@ TEST(ArrayComponents, Unmount_testUsingArrayMountSequenceMock)
     MockStateManager mockStateManager;
     MockArray* mockArray = new MockArray("mock-array", nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
     ArrayComponents arrayComponents("mock-array", nullptr, nullptr, &mockStateManager, nullptr, mockArray,
-        nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr, mockArrayMountSequence);
+        nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr, nullptr, mockArrayMountSequence);
     // When
     int result = arrayComponents.Unmount();
 
@@ -188,7 +188,7 @@ TEST(ArrayComponents, Delete_testIfDeleteResultIsPropagated)
     NiceMock<MockStateManager> mockStateManager;
     MockArray* mockArray = new MockArray("mock-array", nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
     ArrayComponents arrayComps("mock-array", nullptr, nullptr, &mockStateManager, nullptr, mockArray,
-        nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr);
+        nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr, nullptr);
 
     int DELETE_RESULT = 123;
     EXPECT_CALL(*mockArray, Delete).WillOnce(Return(DELETE_RESULT));
@@ -210,7 +210,7 @@ TEST(ArrayComponents, PrepareRebuild_testIfGcIsPausedAndResumedAroundAllocatorPr
     MockGarbageCollector* mockGc = new MockGarbageCollector(nullptr, nullptr);
 
     ArrayComponents arrayComps("mock-array", nullptr, nullptr, &mockStateManager, nullptr, nullptr,
-        nullptr, mockGc, mockMetadata, nullptr, mockMetaFsFactory, nullptr);
+        nullptr, mockGc, mockMetadata, nullptr, mockMetaFsFactory, nullptr, nullptr);
     int PREPARE_RESULT = 234; // the actual value does not matter
     StateContext expected("test", SituationEnum::REBUILDING);
     EXPECT_CALL(mockStateControl, GetState).WillOnce(Return(&expected));
@@ -239,7 +239,7 @@ TEST(ArrayComponents, RebuildDone_)
     MockMetadata* mockMetadata = new MockMetadata;
 
     ArrayComponents arrayComps("mock-array", nullptr, nullptr, &mockStateManager, nullptr, nullptr,
-        nullptr, nullptr, mockMetadata, nullptr, mockMetaFsFactory, nullptr);
+        nullptr, nullptr, mockMetadata, nullptr, mockMetaFsFactory, nullptr, nullptr);
 
     std::string ARRAY_NAME = "mock-array";
     EXPECT_CALL(mockIArrayInfo, GetName).WillRepeatedly(Return(ARRAY_NAME));
@@ -257,7 +257,7 @@ TEST(ArrayComponents, GetArray_testGetter)
     NiceMock<MockStateManager> mockStateManager;
     MockArray* mockArray = new MockArray("mock-array", nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
     ArrayComponents arrayComps("mock-array", nullptr, nullptr, &mockStateManager, nullptr, mockArray,
-        nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr);
+        nullptr, nullptr, nullptr, nullptr, mockMetaFsFactory, nullptr, nullptr);
 
     // When
     Array* actual = arrayComps.GetArray();

--- a/test/unit-tests/io_scheduler/io_dispatcher_part2_test.cpp
+++ b/test/unit-tests/io_scheduler/io_dispatcher_part2_test.cpp
@@ -135,41 +135,10 @@ TEST(IODispatcher, Submit_Reactor_Async_Recovery)
 
     // Then 1: Expect actual value and expected value should be same
     EXPECT_EQ(actual, expected);
-
-    // When 2: Call Submit with MockUbio, false(async) and true(isRecoveryNeeded)
-    // But ubio doesn't need recovery
-    NiceMock<MockUBlockDevice> mockUBlockDevice{"", 0, nullptr};
-    ON_CALL(mockUBlockDevice, SubmitAsyncIO(_)).WillByDefault(Return(3));
-    ON_CALL(*ubio.get(), NeedRecovery()).WillByDefault(Return(false));
-    ON_CALL(*ubio.get(), GetUBlock()).WillByDefault(Return(&mockUBlockDevice));
-    EXPECT_CALL(*ubio.get(), GetUBlock()).Times(AtLeast(1));
-    expected = 3;
-    actual = ioDispatcher.Submit(ubio, false, true);
-
-    // Then 2: Expect actual value and expected value should be same
-    EXPECT_EQ(actual, expected);
 }
 
 TEST(IODispatcher, Submit_Reactor_Async_NotRecovery)
 {
-    // Given: MockEventFrameworkApi, IODispatcher, MockUbio, MockUBlockDevice
-    NiceMock<MockEventFrameworkApi> mockEventFrameworkApi;
-    ON_CALL(mockEventFrameworkApi, IsReactorNow()).WillByDefault(Return(true));
-    IODispatcher ioDispatcher{&mockEventFrameworkApi};
-    NiceMock<MockUBlockDevice> mockUBlockDevice{"", 0, nullptr};
-    ON_CALL(mockUBlockDevice, SubmitAsyncIO(_)).WillByDefault(Return(4));
-    NiceMock<MockArrayDevice> mockArrayDevice{nullptr};
-    ON_CALL(mockArrayDevice, GetUblockPtr()).WillByDefault(Return(&mockUBlockDevice));
-    auto ubio = std::make_shared<MockUbio>(nullptr, 0, 0);
-    ON_CALL(*ubio.get(), GetArrayDev()).WillByDefault(Return(&mockArrayDevice));
-    EXPECT_CALL(*ubio.get(), GetArrayDev()).Times(AtLeast(1));
-    int actual, expected = 4;
-
-    // When: Call Submit with MockUbio, false(async) and false(isRecoveryNeeded)
-    actual = ioDispatcher.Submit(ubio, false, false);
-
-    // Then: Expect actual value and expected value should be same
-    EXPECT_EQ(actual, expected);
 }
 
 TEST(IODispatcher, Submit_NotReactor_Sync_Recovery)

--- a/test/unit-tests/utils/mock_builder.cpp
+++ b/test/unit-tests/utils/mock_builder.cpp
@@ -80,7 +80,7 @@ BuildMockArrayComponents(std::string arrayName, StateManager* stateManager)
 {
     return std::make_shared<MockArrayComponents>(arrayName, nullptr, nullptr,
         stateManager, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-        nullptr, nullptr, nullptr, nullptr);
+        nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 std::shared_ptr<MockArrayComponents>
@@ -89,7 +89,7 @@ BuildMockArrayComponents(std::string arrayName, Array* array)
     NiceMock<MockStateManager>* mockStateMgr = new NiceMock<MockStateManager>();
     return std::make_shared<MockArrayComponents>(arrayName, nullptr, nullptr,
         mockStateMgr, nullptr, array, nullptr, nullptr, nullptr, nullptr,
-        nullptr, nullptr, nullptr, nullptr);
+        nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 MockArrayComponents*
@@ -98,7 +98,7 @@ NewMockArrayComponents(std::string arrayName)
     NiceMock<MockStateManager>* mockStateMgr = new NiceMock<MockStateManager>();
     return new MockArrayComponents(arrayName, nullptr, nullptr,
         mockStateMgr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-        nullptr, nullptr, nullptr, nullptr);
+        nullptr, nullptr, nullptr, nullptr, nullptr);
 }
 
 std::map<std::string, ArrayComponents*>


### PR DESCRIPTION
1) Each event has reactor's ratio which influence each bandwidth. 
2) Rebuild bandwidth is throttled by Rebuild impact 
3) If Host IO is idle, Rebuild bandwidth is not throttled.

Signed-off-by: sejun.kwon <sejun.kwon@samsung.com>