### PR TITLE
[AWIBOF-7053] Fix memory leak by CLI-related modules

### DIFF
--- a/src/cli/cli_server.cpp
+++ b/src/cli/cli_server.cpp
@@ -496,6 +496,7 @@ CLIServer()
 #endif
     shutdown(sock_fd, SHUT_RDWR);
     close(sock_fd);
+    free(event);
 }
 
 void

--- a/src/main/poseidonos.cpp
+++ b/src/main/poseidonos.cpp
@@ -187,6 +187,10 @@ Poseidonos::Terminate(void)
     SmartCollectorSingleton::ResetInstance();
 
     TraceExporterSingleton::ResetInstance();
+    ConfigManagerSingleton::ResetInstance();
+    VersionProviderSingleton::ResetInstance();
+
+    free(GrpcCliServerThread);
 
     POS_TRACE_TRACE(EID(POS_TRACE_TERMINATED), "");
 }


### PR DESCRIPTION
Fix memory leak by CLI-related modules.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>