### PR TITLE
[AWIBOF-7054] Not display start message when --json-res flag is specified

### DIFF
--- a/tool/cli/cmd/systemcmds/start_system.go
+++ b/tool/cli/cmd/systemcmds/start_system.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-    "os/exec"
+	"os/exec"
 	"path/filepath"
 
 	"cli/cmd/displaymgr"
@@ -37,7 +37,7 @@ Syntax:
 			log.Error("error:", err)
 		}
 
-		if globals.IsJSONReq != true {
+		if !(globals.IsJSONReq || globals.IsJSONRes) {
 			fmt.Println("Launching PoseidonOS...")
 		}
 


### PR DESCRIPTION
Not display start message (human readable) when --json-res flag is specified.

Previously, the human readable message caused some errors to test scripts, which parses the output of CLI as a json message.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>