### PR TITLE
Feature/awibof 6993 atomic value qos

### DIFF
--- a/src/io/frontend_io/unvmf_io_handler.cpp
+++ b/src/io/frontend_io/unvmf_io_handler.cpp
@@ -59,11 +59,15 @@ UNVMfCompleteHandler(void)
     {
         AIO aio;
         aio.CompleteIOs();
-        EventFrameworkApiSingleton::Instance()->CompleteEvents();
+        bool ret1 = EventFrameworkApiSingleton::Instance()->CompleteEvents();
         uint32_t currentReactor = EventFrameworkApiSingleton::Instance()->GetCurrentReactor();
         if (AffinityManagerSingleton::Instance()->IsEventReactor(currentReactor))
         {
-            EventFrameworkApiSingleton::Instance()->CompleteSingleQueueEvents();
+            bool ret2 = EventFrameworkApiSingleton::Instance()->CompleteSingleQueueEvents();
+            if (ret1 == true && ret2 == true)
+            {
+                usleep(1);
+            }
         }
     }
     catch (...)

--- a/src/qos/qos_manager.cpp
+++ b/src/qos/qos_manager.cpp
@@ -57,6 +57,7 @@
 
 namespace pos
 {
+bool QosManager::needThrottling;
 /* --------------------------------------------------------------------------*/
 /**
  * @Synopsis
@@ -312,6 +313,14 @@ QosManager::_ControlThrottling(void)
     QosUserPolicy& qosUserPolicy = qosContext->GetQosUserPolicy();
     AllVolumeUserPolicy& allVolUserPolicy = qosUserPolicy.GetAllVolumeUserPolicy();
     std::vector<std::pair<uint32_t, uint32_t>> minVols = allVolUserPolicy.GetMinimumGuaranteeVolume();
+    if (minVols.empty())
+    {
+        needThrottling = false;
+    }
+    else
+    {
+        needThrottling = true;
+    }
     for (auto iter : minVols)
     {
         uint32_t arrayId = iter.first;

--- a/src/qos/qos_manager.h
+++ b/src/qos/qos_manager.h
@@ -138,6 +138,8 @@ public:
     void SetMinimumVolume(uint32_t arrayId, uint32_t volId, uint64_t value, bool iops);
     void PeriodicalJob(uint64_t* nextTick);
 
+    static bool needThrottling;
+
 private:
     virtual void _Finalize(void);
     void _QosWorker(void);

--- a/src/qos/qos_volume_manager.cpp
+++ b/src/qos/qos_volume_manager.cpp
@@ -466,6 +466,10 @@ bool
 QosVolumeManager::_SpecialRateLimit(uint32_t volId)
 {
     bool results = false;
+    if (QosManager::needThrottling == false)
+    {
+        return results;
+    }
     if (minVolumeBw[volId] == 0 && minVolumeIops[volId] == 0 &&
         (remainingNotThrottledVolumesBw < 0 || remainingNotThrottledVolumesIops < 0))
     {
@@ -935,7 +939,11 @@ int
 QosVolumeManager::VolumeQosPoller(IbofIoSubmissionAdapter* aioSubmission, double offset)
 {
     uint32_t retVal = 0;
-
+    uint32_t currentReactor = EventFrameworkApiSingleton::Instance()->GetCurrentReactor();
+    if (AffinityManagerSingleton::Instance()->IsEventReactor(currentReactor))
+    {
+        return retVal;
+    }
     for (uint32_t volId = 0; volId < MAX_VOLUME_COUNT; volId++)
     {
         while (!IsExitQosSet())

--- a/src/spdk_wrapper/event_framework_api.cpp
+++ b/src/spdk_wrapper/event_framework_api.cpp
@@ -142,12 +142,12 @@ EventFrameworkApi::SendSpdkEvent(EventFuncOneParam func, void* arg1)
     return true;
 }
 
-void
+bool
 EventFrameworkApi::CompleteEvents(void)
 {
     if (IsReactorNow() == false)
     {
-        return;
+        return false;
     }
 
     uint32_t core = GetCurrentReactor();
@@ -165,14 +165,19 @@ EventFrameworkApi::CompleteEvents(void)
             break;
         }
     }
+    if (eventQueue.empty() == true)
+    {
+	    return true;
+    }
+    return false;
 }
 
-void
+bool
 EventFrameworkApi::CompleteSingleQueueEvents(void)
 {
     if (IsReactorNow() == false)
     {
-        return;
+        return false;
     }
     uint32_t numaIndex = 0;
     if (numaDedicatedSchedulingPolicy)
@@ -193,6 +198,11 @@ EventFrameworkApi::CompleteSingleQueueEvents(void)
             break;
         }
     }
+    if (eventQueue.empty() == true)
+    {
+        return true;
+    }
+    return false;
 }
 
 uint32_t

--- a/src/spdk_wrapper/event_framework_api.h
+++ b/src/spdk_wrapper/event_framework_api.h
@@ -73,8 +73,8 @@ public:
             void* arg2);
     virtual bool SendSpdkEvent(uint32_t core, EventFuncOneParam func, void* arg1);
     virtual bool SendSpdkEvent(EventFuncOneParam func, void* arg1);
-    void CompleteEvents(void);
-    void CompleteSingleQueueEvents(void);
+    bool CompleteEvents(void);
+    bool CompleteSingleQueueEvents(void);
 
     virtual uint32_t GetFirstReactor(void);
     virtual uint32_t GetCurrentReactor(void);


### PR DESCRIPTION
fe_qos enable 시 4k random read 성능이 기존 22-23GB/s -> 12GB/s로 하락하는 이슈를 해결한 커밋입니다. 

1. min volume throttling 설정하지 않았을 때는 SpecialRateLimit skip
2. event reactor에서는 QosPoller 돌지않게 바로 return 
3. event reactor에서 completion queue가 empty인경우 usleep 

위 commit을 적용하면 약 22GB/s 성능이 나오는 것을 확인하였습니다. (multi array 200G)