### PR TITLE
[AWIBOF-7057] reset used variables before executing check point completion routine. 

### DIFF
--- a/src/journal_manager/checkpoint/checkpoint_handler.cpp
+++ b/src/journal_manager/checkpoint/checkpoint_handler.cpp
@@ -184,13 +184,15 @@ CheckpointHandler::_TryToComplete(void)
         // check status to complete checkpoint only once
         _SetStatus(COMPLETED);
 
-        // completed status must not be changed by ohter threads
+        // completed status must not be changed by other threads
         assert(status == COMPLETED);
+
+        // reset used variables before executing the completion routine.
+        _Reset();
 
         scheduler->EnqueueEvent(checkpointCompletionCallback);
         POS_TRACE_INFO(EID(JOURNAL_CHECKPOINT_COMPLETED), "Checkpoint completed, arrayId:{}", arrayId);
 
-        _Reset();
     }
 }
 
@@ -202,8 +204,6 @@ CheckpointHandler::_Reset(void)
 
     numMapsToFlush = 0;
     numMapsFlushed = 0;
-
-    checkpointCompletionCallback = nullptr;
 }
 
 void


### PR DESCRIPTION
…tion.

code changes:
move completion lock to begin of CheckpointHandler::Start().