### PR TITLE
[AWIBOF-7068] action workflow push and dispatch trigger fix

### DIFF
--- a/.github/workflows/package_upload.yml
+++ b/.github/workflows/package_upload.yml
@@ -24,10 +24,17 @@ jobs:
     steps:
     - run: |
         sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-    - uses: actions/checkout@v1
+
+    - name: Personal repo checkout
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      uses: actions/checkout@v1
       with:
         repository: ${{ github.event.inputs.owner }}/poseidonos
         ref: ${{ github.event.inputs.sha }}
+
+    - name: Release branch checkout
+      if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call'}}
+      uses: actions/checkout@v1
 
     - name: Build Setup
       working-directory: ${{github.workspace}}/../poseidonos

--- a/.github/workflows/package_upload.yml
+++ b/.github/workflows/package_upload.yml
@@ -36,12 +36,21 @@ jobs:
       if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call'}}
       uses: actions/checkout@v1
 
-    - name: Build Setup
+    - name: Build Setup on push or call
+      if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call'}}
       working-directory: ${{github.workspace}}/../poseidonos
       run: |
         sudo apt update
         chmod +x .github/workflows/script/build_setup.sh
-        .github/workflows/script/build_setup.sh -r ${{ github.event.inputs.sha }} -d ${{github.workspace}}/../poseidonos -c --with-fpic
+        .github/workflows/script/build_setup.sh -r ${{github.sha}} -d ${{github.workspace}}/../poseidonos -c --with-fpic
+
+    - name: Build Setup on dispatch
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      working-directory: ${{github.workspace}}/../poseidonos
+      run: |
+        sudo apt update
+        chmod +x .github/workflows/script/build_setup.sh
+        .github/workflows/script/build_setup.sh -r ${{github.event.inputs.sha}} -d ${{github.workspace}}/../poseidonos -c --with-fpic
 
     - name: package build
       working-directory: ${{github.workspace}}/../poseidonos


### PR DESCRIPTION
push로 트리거 될 때에 workflow_dispatch의 값을 참조하지 않고 checkout 및 build시에 sha값을 따로 참조하도록 변경