### PR TITLE
[AWIBOF-7075] Remove debug event logs from TelemetryPublisher

### DIFF
--- a/src/telemetry/telemetry_client/telemetry_publisher.cpp
+++ b/src/telemetry/telemetry_client/telemetry_publisher.cpp
@@ -230,15 +230,9 @@ TelemetryPublisher::_LoadPublicationList(std::string filePath)
 void
 TelemetryPublisher::_RemoveMetricNotToPublish(POSMetricVector* metricList)
 {
-    POS_TRACE_DEBUG(EID(TELEMETRY_DEBUG_MSG),
-            "list_size:{}", metricList->size());
-
     auto it = metricList->begin();
     while(it != metricList->end())
     {
-        POS_TRACE_DEBUG(EID(TELEMETRY_DEBUG_MSG),
-            "name:{}, _ShouldPublish():{}", it->GetName(), _ShouldPublish(it->GetName()));
-
         if (_ShouldPublish(it->GetName()) == false)
         {
             it = metricList->erase(it);
@@ -248,9 +242,6 @@ TelemetryPublisher::_RemoveMetricNotToPublish(POSMetricVector* metricList)
             ++it;
         }
     }
-
-    POS_TRACE_DEBUG(EID(TELEMETRY_DEBUG_MSG),
-            "list_size:{}", metricList->size());   
 }
 
 bool


### PR DESCRIPTION
Remove debug event logs from TelemetryPublisher because they reduce the readability of the event log.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>