### PR TITLE
Fix capitalization typo

### DIFF
--- a/src/event_scheduler/backend_event_ratio_policy.cpp
+++ b/src/event_scheduler/backend_event_ratio_policy.cpp
@@ -49,7 +49,7 @@ namespace pos
 {
 BackendEventRatioPolicy::BackendEventRatioPolicy(
     QosManager* qosManager,
-    std::vector<EventWorker*>* workerarray, uint32_t workerCount, uint32_t ioWorkerCount)
+    std::vector<EventWorker*>* workerArray, uint32_t workerCount, uint32_t ioWorkerCount)
 : BackendPolicy(qosManager, workerArray, workerCount, ioWorkerCount)
 {
     totalEventCount = MAX_EVENTS_PER_EVENT_WORKER * workerCount;

--- a/src/event_scheduler/backend_event_ratio_policy.h
+++ b/src/event_scheduler/backend_event_ratio_policy.h
@@ -42,7 +42,7 @@ namespace pos
 class BackendEventRatioPolicy : public BackendPolicy
 {
 public:
-    BackendEventRatioPolicy(QosManager* qosManager, std::vector<EventWorker*>* workerarray, uint32_t workerCount, uint32_t ioWorkerCount = 1);
+    BackendEventRatioPolicy(QosManager* qosManager, std::vector<EventWorker*>* workerArray, uint32_t workerCount, uint32_t ioWorkerCount = 1);
     ~BackendEventRatioPolicy();
     virtual void EnqueueEvent(EventSmartPtr input);
     virtual std::queue<EventSmartPtr> DequeueEvents(void);


### PR DESCRIPTION
Just spotted a typo.
The variable is declared as 'workerarray' but it is used in constructor right below as 'workerArray'.
I don't know why the compiler does not complain.
I think it will be better to fix this anyway, though.