### PR TITLE
[AWIBOF-6999] Fix misleading error return when fe qos is disabled

### DIFF
--- a/src/cli/create_qos_volume_policy_command.cpp
+++ b/src/cli/create_qos_volume_policy_command.cpp
@@ -62,7 +62,7 @@ QosCreateVolumePolicyCommand::Execute(json& doc, string rid)
     string ioType;
     if (false == QosManagerSingleton::Instance()->IsFeQosEnabled())
     {
-        return jFormat.MakeResponse("CREATEQOSVOLUMEPOLICY", rid, QosReturnCode::FAILURE, "Fe qos is disabled. So skipping QOS Settings.", GetPosInfo());
+        return jFormat.MakeResponse("CREATEQOSVOLUMEPOLICY", rid, EID(QOS_CLI_FE_QOS_DISABLED), "Fe qos is disabled. So skipping QOS Settings.", GetPosInfo());
     }
 
     if (doc["param"].contains("array") && doc["param"].contains("vol"))


### PR DESCRIPTION
fe qos disable인 상태에서  qos 설정시 -1 에러 리턴하는것을 수정하였습니다 (level 0 tc 중 나온 item)