### PR TITLE
[AWIBOF-7099] add concurrency on precommit test

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -13,6 +13,10 @@ on:
        tags:
           description: 'Test scenario tags'
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   IO_Exception_Test:
     runs-on: VM


### PR DESCRIPTION
- add concurrency on precommit test 
~ 한 PR에선 하나의 workflow만 돌아가도록 설정 (PR이 update 돼도 이전에 돌렸던 Workflow가 취소가 안돼 자원을 낭비)