### PR TITLE
[AWIBOF-7124] fix event_name for package build workflow call event

### DIFF
--- a/.github/workflows/package_upload.yml
+++ b/.github/workflows/package_upload.yml
@@ -21,36 +21,32 @@ on:
 jobs:
   Upload_Package:
     runs-on: VM
+    env:
+      Repo_owner: poseidonos
+      Commit_sha: ${{github.sha}}
+      
     steps:
     - run: |
         sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 
-    - name: Release branch checkout
-      if: ${{ github.event_name != 'workflow_dispatch'}}
-      uses: actions/checkout@v1
+    - name: Dispatch value override
+      if: ${{ github.event_name == 'workflow_dispatch'}}
+      run: |
+        echo "Repo_owner=${{inputs.owner}}" >> $GITHUB_ENV
+        echo "Commit_sha=${{inputs.sha}}" >> $GITHUB_ENV
 
-    - name: Personal repo checkout
-      if: ${{ github.event_name == 'workflow_dispatch' }}
+    - name: Checkout
       uses: actions/checkout@v1
       with:
-        repository: ${{ github.event.inputs.owner }}/poseidonos
-        ref: ${{ github.event.inputs.sha }}
+        repository: ${{ env.Repo_owner }}/poseidonos
+        ref: ${{ env.Commit_sha }}
 
-    - name: Build Setup on push or call
-      if: ${{ github.event_name != 'workflow_dispatch'}}
+    - name: Build Setup
       working-directory: ${{github.workspace}}/../poseidonos
       run: |
         sudo apt update
         chmod +x .github/workflows/script/build_setup.sh
-        .github/workflows/script/build_setup.sh -r ${{github.sha}} -d ${{github.workspace}}/../poseidonos -c --with-fpic
-
-    - name: Build Setup on dispatch
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      working-directory: ${{github.workspace}}/../poseidonos
-      run: |
-        sudo apt update
-        chmod +x .github/workflows/script/build_setup.sh
-        .github/workflows/script/build_setup.sh -r ${{github.event.inputs.sha}} -d ${{github.workspace}}/../poseidonos -c --with-fpic
+        .github/workflows/script/build_setup.sh -r ${{env.Commit_sha}} -d ${{github.workspace}}/../poseidonos -c --with-fpic
 
     - name: package build
       working-directory: ${{github.workspace}}/../poseidonos

--- a/.github/workflows/package_upload.yml
+++ b/.github/workflows/package_upload.yml
@@ -25,6 +25,10 @@ jobs:
     - run: |
         sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 
+    - name: Release branch checkout
+      if: ${{ github.event_name != 'workflow_dispatch'}}
+      uses: actions/checkout@v1
+
     - name: Personal repo checkout
       if: ${{ github.event_name == 'workflow_dispatch' }}
       uses: actions/checkout@v1
@@ -32,12 +36,8 @@ jobs:
         repository: ${{ github.event.inputs.owner }}/poseidonos
         ref: ${{ github.event.inputs.sha }}
 
-    - name: Release branch checkout
-      if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call'}}
-      uses: actions/checkout@v1
-
     - name: Build Setup on push or call
-      if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call'}}
+      if: ${{ github.event_name != 'workflow_dispatch'}}
       working-directory: ${{github.workspace}}/../poseidonos
       run: |
         sudo apt update

--- a/package/Makefile
+++ b/package/Makefile
@@ -12,7 +12,7 @@ all:
 	@cp -f ../config/pos.conf src/etc/pos/
 	@cp -f ../config/telemetry_default.yaml src/etc/pos/
 	@cp -f ../config/publication_list_default.yaml src/etc/pos/
-	@cp -f ../config/pos_event.yaml src/etc/pos/
+	@cp -f ../src/event/pos_event.yaml src/etc/pos/
 	
 	# Copy CLI man page files
 	@gzip --keep ../tool/cli/docs/manpage/*

--- a/package/Makefile
+++ b/package/Makefile
@@ -11,6 +11,8 @@ all:
 	@cp -rf ../lib/spdk src/usr/local/lib/
 	@cp -f ../config/pos.conf src/etc/pos/
 	@cp -f ../config/telemetry_default.yaml src/etc/pos/
+	@cp -f ../config/publication_list_default.yaml src/etc/pos/
+	@cp -f ../config/pos_event.yaml src/etc/pos/
 	
 	# Copy CLI man page files
 	@gzip --keep ../tool/cli/docs/manpage/*


### PR DESCRIPTION
workflow_call로 호출될 시 event_name이 caller workflow의 그것을 그대로 물려받는 특징이 있어
event_name을 workflow_call로 if를 통해 구별할 시에 인식을 못하는 문제 해결