### PR TITLE
[SHPOS-908] Fixed an issue where the data in the meta partition are o…

### DIFF
--- a/src/array/device/array_device.cpp
+++ b/src/array/device/array_device.cpp
@@ -108,9 +108,12 @@ ArrayDevice::SetState(ArrayDeviceState input)
     {
         devName = uBlock->GetName();
     }
-    state = input;
-    POS_TRACE_INFO(EID(ARRAY_EVENT_DEV_STATE_CHANGED),
-        "Array device [" + devName + "]'s state is changed to {} (0=normal, 1=fault, 2=rebuild)", input);
+    if (state != input)
+    {
+        POS_TRACE_TRACE(EID(ARRAY_EVENT_DEV_STATE_CHANGED),
+            "Array device [" + devName + "]'s state is changed from {} to {} (0=normal, 1=fault, 2=rebuild)", state, input);
+        state = input;
+    }
 }
 
 void

--- a/src/array/device/array_device.h
+++ b/src/array/device/array_device.h
@@ -55,8 +55,8 @@ public:
     UblockSharedPtr GetUblock(void) override;
     UBlockDevice* GetUblockPtr(void) override;
     void SetUblock(UblockSharedPtr uBlock) override;
-    string GetName(void);
-    string GetSerial(void);
+    string GetName(void) override;
+    string GetSerial(void) override;
     uint32_t GetDataIndex(void) { return dataIndex; }
     string PrevUblockInfo() { return prevUblockInfo; }
 

--- a/src/array/partition/stripe_partition.cpp
+++ b/src/array/partition/stripe_partition.cpp
@@ -497,7 +497,19 @@ StripePartition::GetQuickRebuildCtx(const QuickRebuildPair& rebuildPair)
         ctx.reset();
         return nullptr;
     }
-    
+
+    bool isInPlaceUpdate = type != PartitionType::USER_DATA;
+    if (isInPlaceUpdate == true)
+    {
+        // In the in-place update, the latest data of the src device is not guaranteed.
+        // Delegate to RAID-based recovery
+        assert(ctx->secondaryRp.size() != 0);
+        ctx->rp = ctx->secondaryRp;
+        ctx->secondaryRp.clear();
+        POS_TRACE_INFO(EID(REBUILD_CTX_DEBUG), "Quick rebuild pair was replaced in in-place write partition, part:{}, rpCnt:{}, backupRpCnt:{}",
+            PARTITION_TYPE_STR[type], ctx->rp.size(), ctx->secondaryRp.size());
+    }
+
     ctx->part = type;
     ctx->stripeCnt = logicalSize.totalStripes;
     ctx->size = GetPhysicalSize();

--- a/test/functional_requirements/fault_tolerance/QUICK_REBUILD_DURING_IO.py
+++ b/test/functional_requirements/fault_tolerance/QUICK_REBUILD_DURING_IO.py
@@ -23,7 +23,7 @@ ARRAYNAME = MOUNT_VOL_BASIC_1.ARRAYNAME
 def execute():
     MOUNT_VOL_BASIC_1.execute()
     fio_proc = fio.start_fio(0, 90)
-    time.sleep(10)
+    time.sleep(40)
     cli.replace_device(REPLACE_TARGET_DEV, ARRAYNAME)
     if api.wait_situation(ARRAYNAME, "REBUILDING") == True:
         if api.wait_situation(ARRAYNAME, "NORMAL") == True:


### PR DESCRIPTION
현상: Quick Rebuild 이후 새로 교체된 디바이스에서 Old data가 관측됨
원인: In-Place 업데이트 방식의 파티션에서는 교체되어 나간 Source device에  최신데이터가 보장되지 않음
수정: In-Place 업데이트 방식의 파티션에서는 src->dst copy 대신 RAID를 이용한 복원(RAID10 이 고정되기 때문에 리빌드 비용은 동일함)