### PR TITLE
[AWIBOF-7196] reset segment infos after segment freed. 

### DIFF
--- a/src/journal_manager/log_buffer/i_versioned_segment_context.h
+++ b/src/journal_manager/log_buffer/i_versioned_segment_context.h
@@ -55,6 +55,7 @@ public:
     virtual void ResetFlushedInfo(int logGroupId) = 0;
     virtual int GetNumSegments(void) = 0;
     virtual int GetNumLogGroups(void) = 0;
+    virtual void EraseSegmentInfo(int logGroupId, SegmentId targetSegmentId) = 0;
 
     // For UT
     virtual void Init(JournalConfiguration* journalConfiguration, SegmentInfo* loadedSegmentInfo, uint32_t numSegments,

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -238,4 +238,12 @@ VersionedSegmentCtx::_CheckSegIdValidity(int segId)
         assert(false);
     }
 }
+
+void
+VersionedSegmentCtx::ResetInfosAfterSegmentFreed(int logGroupId, SegmentId targetSegmentId)
+{
+    segmentInfoDiffs[logGroupId]->ResetOccupiedStripeCount(targetSegmentId);
+    segmentInfos[targetSegmentId].SetOccupiedStripeCount(0);
+    segmentInfos[targetSegmentId].SetState(SegmentState::FREE);
+}
 } // namespace pos

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -242,7 +242,10 @@ VersionedSegmentCtx::_CheckSegIdValidity(int segId)
 void
 VersionedSegmentCtx::ResetInfosAfterSegmentFreed(int logGroupId, SegmentId targetSegmentId)
 {
-    segmentInfoDiffs[logGroupId]->ResetOccupiedStripeCount(targetSegmentId);
+    for (int groupId = 0; groupId < config->GetNumLogGroups(); groupId++)
+    {
+        segmentInfoDiffs[groupId]->ResetOccupiedStripeCount(targetSegmentId);
+    }
     segmentInfos[targetSegmentId].SetOccupiedStripeCount(0);
     segmentInfos[targetSegmentId].SetState(SegmentState::FREE);
 }

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.h
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.h
@@ -62,6 +62,7 @@ public:
     virtual int GetNumLogGroups(void) override { return 0; };
     virtual void Init(JournalConfiguration* journalConfiguration, SegmentInfo* loadedSegmentInfo, uint32_t numSegments,
         std::vector<std::shared_ptr<VersionedSegmentInfo>> inputVersionedSegmentInfo) override {}
+    void ResetInfosAfterSegmentFreed(int logGroupId, SegmentId targetSegmentId);
 };
 
 class VersionedSegmentCtx : public IVersionedSegmentContext
@@ -85,6 +86,8 @@ public:
     virtual void ResetFlushedInfo(int logGroupId) override;
     virtual int GetNumSegments(void) override;
     virtual int GetNumLogGroups(void) override;
+
+    void ResetInfosAfterSegmentFreed(int logGroupId, SegmentId targetSegmentId);
 
 private:
     void _Init(JournalConfiguration* journalConfiguration, SegmentInfo* loadedSegmentInfo, uint32_t numSegments_);

--- a/src/journal_manager/log_buffer/versioned_segment_info.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_info.cpp
@@ -69,6 +69,12 @@ VersionedSegmentInfo::IncreaseOccupiedStripeCount(SegmentId segId)
     changedOccupiedStripeCount[segId]++;
 }
 
+void
+VersionedSegmentInfo::ResetOccupiedStripeCount(SegmentId segId)
+{
+    changedOccupiedStripeCount[segId] = 0;
+}
+
 tbb::concurrent_unordered_map<SegmentId, int>
 VersionedSegmentInfo::GetChangedValidBlockCount(void)
 {

--- a/src/journal_manager/log_buffer/versioned_segment_info.h
+++ b/src/journal_manager/log_buffer/versioned_segment_info.h
@@ -48,6 +48,7 @@ public:
     virtual void IncreaseValidBlockCount(SegmentId segId, uint32_t cnt);
     virtual void DecreaseValidBlockCount(SegmentId segId, uint32_t cnt);
     virtual void IncreaseOccupiedStripeCount(SegmentId segId);
+    virtual void ResetOccupiedStripeCount(SegmentId segId);
 
     virtual tbb::concurrent_unordered_map<SegmentId, int> GetChangedValidBlockCount(void);
     virtual tbb::concurrent_unordered_map<SegmentId, uint32_t> GetChangedOccupiedStripeCount(void);

--- a/src/metadata/segment_context_updater.cpp
+++ b/src/metadata/segment_context_updater.cpp
@@ -83,7 +83,14 @@ SegmentContextUpdater::InvalidateBlocksWithGroupId(VirtualBlks blks, bool isForc
     pthread_rwlock_wrlock(&lock);
     SegmentId segmentId = blks.startVsa.stripeId / addrInfo->stripesPerSegment;
     bool ret = activeSegmentCtx->InvalidateBlks(blks, isForced);
-    versionedContext->DecreaseValidBlockCount(logGroupId, segmentId, blks.numBlks);
+    if (true == ret)
+    {
+        versionedContext->EraseSegmentInfo(logGroupId, segmentId);
+    }
+    else
+    {
+        versionedContext->DecreaseValidBlockCount(logGroupId, segmentId, blks.numBlks);
+    }
     pthread_rwlock_unlock(&lock);
     return ret;
 }
@@ -93,8 +100,15 @@ SegmentContextUpdater::UpdateStripeCount(StripeId lsid, int logGroupId)
 {
     pthread_rwlock_wrlock(&lock);
     SegmentId segmentId = lsid / addrInfo->stripesPerSegment;
-    versionedContext->IncreaseOccupiedStripeCount(logGroupId, segmentId);
     bool ret = activeSegmentCtx->UpdateOccupiedStripeCount(lsid);
+    if (true == ret)
+    {
+        versionedContext->EraseSegmentInfo(logGroupId, segmentId);
+    }
+    else
+    {
+        versionedContext->IncreaseOccupiedStripeCount(logGroupId, segmentId);
+    }
     pthread_rwlock_unlock(&lock);
     return ret;
 }


### PR DESCRIPTION
segment free 이후, vsc 의 segment info 중 occupied stripe count reset이 되지 않아, 중복해서 counting이 되는 이슈입니다. 
R9 Long-term test 에서 valid block count under flow assert 이슈 분석 중 추가로 발견 되었습니다. 