### PR TITLE
[SHPOS-942] Change total and used capacities to string type

### DIFF
--- a/tool/cli/patches/protojson_encode.patch
+++ b/tool/cli/patches/protojson_encode.patch
@@ -1,0 +1,11 @@
+--- encode.go	2022-10-20 14:13:22.126921685 +0900
++++ encode_patch.go	2022-10-20 14:23:15.318912480 +0900
+@@ -274,7 +274,7 @@
+ 	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
+ 		protoreflect.Sfixed64Kind, protoreflect.Fixed64Kind:
+ 		// 64-bit integers are written out as JSON string.
+-		e.WriteString(val.String())
++		e.WriteUint(val.Uint())
+ 
+ 	case protoreflect.FloatKind:
+ 		// Encoder.WriteFloat handles the special numbers NaN and infinites.

--- a/tool/cli/script/build_cli.sh
+++ b/tool/cli/script/build_cli.sh
@@ -20,6 +20,8 @@ protoc --go_out=api --go_opt=paths=source_relative \
 
 # Build CLI binary
 lib/pnconnector/script/build_resource.sh
+${GO} install
+patch ${GOPATH}/pkg/mod/google.golang.org/protobuf@v1.28.0/encoding/protojson/encode.go patches/protojson_encode.patch
 ${GO} build -tags debug,ssloff -ldflags "-X cli/cmd.PosCliVersion=$POS_CLI_VERSION -X cli/cmd.GitCommit=$GIT_COMMIT_CLI -X cli/cmd.BuildTime=$BUILD_TIME_CLI -X cli/cmd.RootDir=$ROOT_DIR"
 mv ./cli bin/poseidonos-cli
 


### PR DESCRIPTION
Change total and used capacities to string type.

This is a workaround because of gRPC.

When converting protobuf to json message, gRPC prints out an uint64 value as string (with " "). This is a known issue that is being discussed among gRPC developers.

This commit changes the total and used capacities from uint64 to string until the bug is fixed.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>