### PR TITLE
[AWIBOF-7196] reset vsc seg info after segment freed by GC.

### DIFF
--- a/src/allocator/context_manager/context_manager.cpp
+++ b/src/allocator/context_manager/context_manager.cpp
@@ -70,6 +70,7 @@ ContextManager::ContextManager(TelemetryPublisher* tp,
     blockAllocStatus = blockAllocStatus_;
     contextReplayer = ctxReplayer_;
     telPublisher = tp;
+    segmentContextUpdater = nullptr;
 }
 
 ContextManager::ContextManager(TelemetryPublisher* tp, AllocatorAddressInfo* info, uint32_t arrayId_)
@@ -90,6 +91,7 @@ ContextManager::ContextManager(TelemetryPublisher* tp, AllocatorAddressInfo* inf
     ioManager = new ContextIoManager(info, tp, segmentFileIo, allocatorFileIo, rebuildFileIo);
 
     rebuildCtx->SetAllocatorFileIo(rebuildFileIo);
+    segmentContextUpdater = nullptr;
 }
 
 ContextManager::~ContextManager(void)
@@ -268,5 +270,17 @@ ContextManager::ResetFlushedInfo(int logGroupId)
     }
 
     logGroupIdInProgress = INVALID_LOG_GROUP_ID;
+}
+
+void
+ContextManager::SetSegmentContextUpdaterPtr(ISegmentCtx *segmentContextUpdater_)
+{
+    segmentContextUpdater = segmentContextUpdater_;
+}
+
+ISegmentCtx*
+ContextManager::GetSegmentContextUpdaterPtr(void)
+{
+    return segmentContextUpdater;
 }
 } // namespace pos

--- a/src/allocator/context_manager/context_manager.h
+++ b/src/allocator/context_manager/context_manager.h
@@ -104,6 +104,8 @@ public:
     virtual void PrepareVersionedSegmentCtx(IVersionedSegmentContext* versionedSegCtx_);
     virtual void ResetFlushedInfo(int logGroupId);
     virtual void SetAllocateDuplicatedFlush(bool flag);
+    virtual void SetSegmentContextUpdaterPtr(ISegmentCtx* segmentContextUpdater_);
+    virtual ISegmentCtx* GetSegmentContextUpdaterPtr(void);
 
 private:
     ContextIoManager* ioManager;
@@ -125,6 +127,8 @@ private:
     static const int ALL_LOG_GROUP = -1;
     int logGroupIdInProgress;
     bool allowDuplicatedFlush;
+
+    ISegmentCtx* segmentContextUpdater;
 };
 
 } // namespace pos

--- a/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
@@ -879,6 +879,7 @@ SegmentCtx::GetSegmentInfos(void)
 void
 SegmentCtx::ResetInfos(SegmentId segId)
 {
+    // TODO (dh.ihm) : need to check if there is additional implementation.
     return;
 }
 } // namespace pos

--- a/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
@@ -875,4 +875,10 @@ SegmentCtx::GetSegmentInfos(void)
 {
     return segmentInfos;
 }
+
+void
+SegmentCtx::ResetInfos(SegmentId segId)
+{
+    return;
+}
 } // namespace pos

--- a/src/allocator/context_manager/segment_ctx/segment_ctx.h
+++ b/src/allocator/context_manager/segment_ctx/segment_ctx.h
@@ -117,6 +117,7 @@ public:
     virtual bool UpdateStripeCount(StripeId lsid, int logGroupId);
 
     virtual SegmentInfo* GetSegmentInfos(void);
+    virtual void ResetInfos(SegmentId segId);
 
     static const uint32_t SIG_SEGMENT_CTX = 0xAFAFAFAF;
 

--- a/src/allocator/i_context_manager.h
+++ b/src/allocator/i_context_manager.h
@@ -62,6 +62,8 @@ public:
     virtual void PrepareVersionedSegmentCtx(IVersionedSegmentContext* versionedSegCtx_) = 0;
     virtual void ResetFlushedInfo(int logGroupId) = 0;
     virtual void SetAllocateDuplicatedFlush(bool flag) = 0;
+    virtual void SetSegmentContextUpdaterPtr(ISegmentCtx* segmentContextUpdater_) = 0;
+    virtual ISegmentCtx* GetSegmentContextUpdaterPtr(void) = 0;
 
 private:
     static const int ALL_LOG_GROUP = -1;

--- a/src/allocator/i_segment_ctx.h
+++ b/src/allocator/i_segment_ctx.h
@@ -46,6 +46,7 @@ public:
     virtual void ValidateBlocksWithGroupId(VirtualBlks blks, int logGroupId) = 0;
     virtual bool InvalidateBlocksWithGroupId(VirtualBlks blks, bool isForced, int logGroupId) = 0;
     virtual bool UpdateStripeCount(StripeId lsid, int logGroupId) = 0;
+    virtual void ResetInfos(SegmentId segId) = 0;
 };
 
 } // namespace pos

--- a/src/gc/copier.cpp
+++ b/src/gc/copier.cpp
@@ -49,6 +49,7 @@
 #include "src/include/backend_event.h"
 #include "src/io/general_io/io_submit_handler.h"
 #include "src/logger/logger.h"
+#include "src/metadata/segment_context_updater.h"
 
 namespace pos
 {
@@ -313,6 +314,8 @@ Copier::_CleanUpVictimSegments(void)
             POS_TRACE_INFO(EID(GC_RELEASE_VICTIM_SEGMENT),
                 "Move to free list among the victim lists, VictimSegid:{}, validCount:{}", victimSegId, validCount);
             segmentCtx->MoveToFreeState(victimSegId);
+            SegmentContextUpdater* segmentCtxUpdater = (SegmentContextUpdater*)iContextManager->GetSegmentContextUpdaterPtr();
+            segmentCtxUpdater->ResetInfos(victimSegId);
         }
     }
 }

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -245,6 +245,7 @@ VersionedSegmentCtx::ResetInfosAfterSegmentFreed(SegmentId targetSegmentId)
     for (int groupId = 0; groupId < config->GetNumLogGroups(); groupId++)
     {
         segmentInfoDiffs[groupId]->ResetOccupiedStripeCount(targetSegmentId);
+        segmentInfoDiffs[groupId]->ResetValidBlockCount(targetSegmentId);
     }
     segmentInfos[targetSegmentId].SetOccupiedStripeCount(0);
     segmentInfos[targetSegmentId].SetState(SegmentState::FREE);

--- a/src/journal_manager/log_buffer/versioned_segment_info.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_info.cpp
@@ -75,6 +75,12 @@ VersionedSegmentInfo::ResetOccupiedStripeCount(SegmentId segId)
     changedOccupiedStripeCount[segId] = 0;
 }
 
+void
+VersionedSegmentInfo::ResetValidBlockCount(SegmentId segId)
+{
+    changedValidBlockCount[segId] = 0;
+}
+
 tbb::concurrent_unordered_map<SegmentId, int>
 VersionedSegmentInfo::GetChangedValidBlockCount(void)
 {

--- a/src/journal_manager/log_buffer/versioned_segment_info.h
+++ b/src/journal_manager/log_buffer/versioned_segment_info.h
@@ -49,7 +49,8 @@ public:
     virtual void DecreaseValidBlockCount(SegmentId segId, uint32_t cnt);
     virtual void IncreaseOccupiedStripeCount(SegmentId segId);
     virtual void ResetOccupiedStripeCount(SegmentId segId);
-
+    virtual void ResetValidBlockCount(SegmentId segId);
+    
     virtual tbb::concurrent_unordered_map<SegmentId, int> GetChangedValidBlockCount(void);
     virtual tbb::concurrent_unordered_map<SegmentId, uint32_t> GetChangedOccupiedStripeCount(void);
 

--- a/src/metadata/meta_event_factory.cpp
+++ b/src/metadata/meta_event_factory.cpp
@@ -53,6 +53,7 @@ MetaEventFactory::MetaEventFactory(IVSAMap* vsaMap, IStripeMap* stripeMap,
   contextManager(contextManager),
   arrayInfo(arrayInfo)
 {
+    contextManager->SetSegmentContextUpdaterPtr(segmentCtx);
 }
 
 CallbackSmartPtr

--- a/src/metadata/segment_context_updater.cpp
+++ b/src/metadata/segment_context_updater.cpp
@@ -112,4 +112,10 @@ SegmentContextUpdater::UpdateStripeCount(StripeId lsid, int logGroupId)
     pthread_rwlock_unlock(&lock);
     return ret;
 }
+
+void
+SegmentContextUpdater::ResetInfos(SegmentId segId)
+{
+    versionedContext->ResetInfosAfterSegmentFreed(segId);
+}
 } // namespace pos

--- a/src/metadata/segment_context_updater.h
+++ b/src/metadata/segment_context_updater.h
@@ -52,7 +52,8 @@ public:
     virtual void ValidateBlocksWithGroupId(VirtualBlks blks, int logGroupId);
     virtual bool InvalidateBlocksWithGroupId(VirtualBlks blks, bool isForced, int logGroupId);
     virtual bool UpdateStripeCount(StripeId lsid, int logGroupId);
-
+    virtual void ResetInfos(SegmentId segId);
+    
 private:
     const PartitionLogicalSize* addrInfo;
     ISegmentCtx* activeSegmentCtx;

--- a/test/integration-tests/journal/fake/i_context_manager_mock.h
+++ b/test/integration-tests/journal/fake/i_context_manager_mock.h
@@ -34,6 +34,8 @@ public:
     virtual void PrepareVersionedSegmentCtx(IVersionedSegmentContext* versionedSegCtx) { return; }
     virtual void ResetFlushedInfo(int logGroupId) { return; }
     virtual void SetAllocateDuplicatedFlush(bool flag) { return; }
+    virtual void SetSegmentContextUpdaterPtr(ISegmentCtx* segmentContextUpdater_) { return; }
+    virtual ISegmentCtx* GetSegmentContextUpdaterPtr(void) { return nullptr; }
 
     IContextManagerMock(void)
     {

--- a/test/unit-tests/allocator/context_manager/context_manager_mock.h
+++ b/test/unit-tests/allocator/context_manager/context_manager_mock.h
@@ -5,6 +5,7 @@
 #include "src/allocator/context_manager/context_manager.h"
 #include "src/journal_manager/log_buffer/versioned_segment_ctx.h"
 
+
 namespace pos
 {
 class MockContextManager : public ContextManager
@@ -39,6 +40,8 @@ public:
     MOCK_METHOD(void, PrepareVersionedSegmentCtx, (IVersionedSegmentContext* versionedSegCtx), (override));
     MOCK_METHOD(void, ResetFlushedInfo, (int logGroupId), (override));
     MOCK_METHOD(void, SetAllocateDuplicatedFlush, (bool flag), (override));
+    MOCK_METHOD(void, SetSegmentContextUpdaterPtr, (ISegmentCtx* segmentContextUpdater_), (override));
+    MOCK_METHOD(ISegmentCtx*, GetSegmentContextUpdaterPtr, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_mock.h
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_mock.h
@@ -57,5 +57,6 @@ public:
     MOCK_METHOD(void, ValidateBlocksWithGroupId, (VirtualBlks blks, int logGroupId), (override));
     MOCK_METHOD(bool, InvalidateBlocksWithGroupId, (VirtualBlks blks, bool isForced, int logGroupId), (override));
     MOCK_METHOD(bool, UpdateStripeCount, (StripeId lsid, int logGroupId), (override));
+    MOCK_METHOD(void, ResetInfos, (SegmentId segId), (override));
 };
 } // namespace pos

--- a/test/unit-tests/allocator/i_context_manager_mock.h
+++ b/test/unit-tests/allocator/i_context_manager_mock.h
@@ -25,6 +25,8 @@ public:
     MOCK_METHOD(void, PrepareVersionedSegmentCtx, (IVersionedSegmentContext* versionedSegCtx), (override));
     MOCK_METHOD(void, ResetFlushedInfo, (int logGroupId), (override));
     MOCK_METHOD(void, SetAllocateDuplicatedFlush, (bool flag), (override));
+    MOCK_METHOD(void, SetSegmentContextUpdaterPtr, (ISegmentCtx* segmentContextUpdater_), (override));
+    MOCK_METHOD(ISegmentCtx*, GetSegmentContextUpdaterPtr, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/allocator/i_segment_ctx_mock.h
+++ b/test/unit-tests/allocator/i_segment_ctx_mock.h
@@ -16,6 +16,7 @@ public:
     MOCK_METHOD(void, ValidateBlocksWithGroupId, (VirtualBlks blks, int logGroupId), (override));
     MOCK_METHOD(bool, InvalidateBlocksWithGroupId, (VirtualBlks blks, bool isForced, int logGroupId), (override));
     MOCK_METHOD(bool, UpdateStripeCount, (StripeId lsid, int logGroupId), (override));
+    MOCK_METHOD(void, ResetInfos, (SegmentId segId), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_info_mock.h
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_info_mock.h
@@ -52,6 +52,7 @@ public:
     MOCK_METHOD((tbb::concurrent_unordered_map<SegmentId, int>), GetChangedValidBlockCount, (), (override));
     MOCK_METHOD((tbb::concurrent_unordered_map<SegmentId, uint32_t>), GetChangedOccupiedStripeCount, (), (override));
     MOCK_METHOD(void, ResetOccupiedStripeCount, (SegmentId segId), (override));
+    MOCK_METHOD(void, ResetValidBlockCount, (SegmentId segId), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/metadata/metadata_test.cpp
+++ b/test/unit-tests/metadata/metadata_test.cpp
@@ -92,9 +92,11 @@ TEST(Metadata, Init_testIfEverySequenceIsInitialized)
     NiceMock<MockJournalManager>* journal = new NiceMock<MockJournalManager>(&arrayInfo, &stateControl);
     NiceMock<MockMetaFsFileControlApi> metaFsCtrl;
     NiceMock<MockMetaService> metaService;
+    NiceMock<MockIContextManager> contextManager;
 
     ON_CALL(arrayInfo, GetName).WillByDefault(Return("POSArray"));
     ON_CALL(arrayInfo, GetIndex).WillByDefault(Return(0));
+    ON_CALL(*allocator, GetIContextManager).WillByDefault(Return(&contextManager));
 
     Metadata meta(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);
 
@@ -120,9 +122,11 @@ TEST(Metadata, Init_testIfDoNothingWhenInitFailed)
     NiceMock<MockJournalManager>* journal = new NiceMock<MockJournalManager>(&arrayInfo, &stateControl);
     NiceMock<MockMetaFsFileControlApi> metaFsCtrl;
     NiceMock<MockMetaService> metaService;
+    NiceMock<MockIContextManager> contextManager;
 
     ON_CALL(arrayInfo, GetName).WillByDefault(Return("POSArray"));
     ON_CALL(arrayInfo, GetIndex).WillByDefault(Return(0));
+    ON_CALL(*allocator, GetIContextManager).WillByDefault(Return(&contextManager));
 
     Metadata meta(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);
 
@@ -150,6 +154,9 @@ TEST(Metadata, Dispose_testIfAllSequenceInvokeDispose)
     NiceMock<MockJournalManager>* journal = new NiceMock<MockJournalManager>(&arrayInfo, &stateControl);
     NiceMock<MockMetaFsFileControlApi> metaFsCtrl;
     NiceMock<MockMetaService> metaService;
+    NiceMock<MockIContextManager> contextManager;
+
+    ON_CALL(*allocator, GetIContextManager).WillByDefault(Return(&contextManager));
 
     Metadata meta(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);
 
@@ -175,6 +182,9 @@ TEST(Metadata, Shutdown_testIfAllComponentsAreDisposed)
     NiceMock<MockJournalManager>* journal = new NiceMock<MockJournalManager>(&arrayInfo, &stateControl);
     NiceMock<MockMetaFsFileControlApi> metaFsCtrl;
     NiceMock<MockMetaService> metaService;
+    NiceMock<MockIContextManager> contextManager;
+
+    ON_CALL(*allocator, GetIContextManager).WillByDefault(Return(&contextManager));
 
     Metadata meta(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);
 
@@ -198,6 +208,9 @@ TEST(Metadata, Flush_testFlush)
     NiceMock<MockJournalManager>* journal = new NiceMock<MockJournalManager>(&arrayInfo, &stateControl);
     NiceMock<MockMetaFsFileControlApi> metaFsCtrl;
     NiceMock<MockMetaService> metaService;
+    NiceMock<MockIContextManager> contextManager;
+
+    ON_CALL(*allocator, GetIContextManager).WillByDefault(Return(&contextManager));
 
     Metadata meta(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);
 
@@ -214,11 +227,12 @@ TEST(Metadata, NeedRebuildAgain_testIfAllocatorIsCalled)
     NiceMock<MockJournalManager>* journal = new NiceMock<MockJournalManager>(&arrayInfo, &stateControl);
     NiceMock<MockMetaFsFileControlApi> metaFsCtrl;
     NiceMock<MockMetaService> metaService;
-    Metadata meta(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);
-
     NiceMock<MockIContextManager> contextManager;
 
-    EXPECT_CALL(*allocator, GetIContextManager).WillOnce(Return(&contextManager));
+    ON_CALL(*allocator, GetIContextManager).WillByDefault(Return(&contextManager));
+
+    Metadata meta(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);
+
     EXPECT_CALL(contextManager, NeedRebuildAgain).WillOnce(Return(true));
 
     bool ret = meta.NeedRebuildAgain();
@@ -235,6 +249,10 @@ TEST(Metadata, NeedRebuildAgain_testWithInvalidContextManager)
     NiceMock<MockJournalManager>* journal = new NiceMock<MockJournalManager>(&arrayInfo, &stateControl);
     NiceMock<MockMetaFsFileControlApi> metaFsCtrl;
     NiceMock<MockMetaService> metaService;
+    NiceMock<MockIContextManager> contextManager;
+
+    ON_CALL(*allocator, GetIContextManager).WillByDefault(Return(&contextManager));
+
     Metadata meta(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);
 
     EXPECT_CALL(*allocator, GetIContextManager).WillOnce(Return(nullptr));
@@ -253,6 +271,9 @@ TEST(Metadata, PrepareRebuild_testIfAllocatorIsCalled)
     NiceMock<MockJournalManager>* journal = new NiceMock<MockJournalManager>(&arrayInfo, &stateControl);
     NiceMock<MockMetaFsFileControlApi> metaFsCtrl;
     NiceMock<MockMetaService> metaService;
+    NiceMock<MockIContextManager> contextManager;
+
+    ON_CALL(*allocator, GetIContextManager).WillByDefault(Return(&contextManager));
 
     Metadata meta(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);
 
@@ -272,12 +293,12 @@ TEST(Metadata, StopRebuilding_testIfAllocatorIsCalled)
     NiceMock<MockJournalManager>* journal = new NiceMock<MockJournalManager>(&arrayInfo, &stateControl);
     NiceMock<MockMetaFsFileControlApi> metaFsCtrl;
     NiceMock<MockMetaService> metaService;
+    NiceMock<MockIContextManager> contextManager;
+
+    ON_CALL(*allocator, GetIContextManager).WillByDefault(Return(&contextManager));
 
     Metadata meta(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);
 
-    NiceMock<MockIContextManager> contextManager;
-
-    EXPECT_CALL(*allocator, GetIContextManager).WillOnce(Return(&contextManager));
     EXPECT_CALL(contextManager, StopRebuilding);
 
     meta.StopRebuilding();
@@ -293,10 +314,11 @@ TEST(Metadata, StopRebuilding_testWithInvalidContextManager)
     NiceMock<MockJournalManager>* journal = new NiceMock<MockJournalManager>(&arrayInfo, &stateControl);
     NiceMock<MockMetaFsFileControlApi> metaFsCtrl;
     NiceMock<MockMetaService> metaService;
+    NiceMock<MockIContextManager> contextManager;
+
+    ON_CALL(*allocator, GetIContextManager).WillByDefault(Return(&contextManager));
 
     Metadata meta(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);
-
-    EXPECT_CALL(*allocator, GetIContextManager).WillOnce(Return(nullptr));
 
     meta.StopRebuilding();
 }

--- a/test/unit-tests/metadata/metadata_test.cpp
+++ b/test/unit-tests/metadata/metadata_test.cpp
@@ -42,6 +42,9 @@ TEST(Metadata, Metadata_testContructor)
         NiceMock<MockJournalManager>* journal = new NiceMock<MockJournalManager>(&arrayInfo, &stateControl);
         NiceMock<MockMetaFsFileControlApi> metaFsCtrl;
         NiceMock<MockMetaService> metaService;
+        NiceMock<MockIContextManager> contextManager;
+
+        EXPECT_CALL(*allocator, GetIContextManager).WillOnce(Return(&contextManager));
 
         // When 2
         Metadata metaForUt(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);
@@ -54,6 +57,9 @@ TEST(Metadata, Metadata_testContructor)
         NiceMock<MockJournalManager>* journal = new NiceMock<MockJournalManager>(&arrayInfo, &stateControl);
         NiceMock<MockMetaFsFileControlApi> metaFsCtrl;
         NiceMock<MockMetaService> metaService;
+        NiceMock<MockIContextManager> contextManager;
+
+        EXPECT_CALL(*allocator, GetIContextManager).WillOnce(Return(&contextManager));
 
         // When 3
         Metadata* metataInHeap = new Metadata(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);
@@ -67,6 +73,9 @@ TEST(Metadata, Metadata_testContructor)
         NiceMock<MockJournalManager>* journal = new NiceMock<MockJournalManager>(&arrayInfo, &stateControl);
         NiceMock<MockMetaFsFileControlApi> metaFsCtrl;
         NiceMock<MockMetaService> metaService;
+        NiceMock<MockIContextManager> contextManager;
+
+        EXPECT_CALL(*allocator, GetIContextManager).WillOnce(Return(&contextManager));
 
         // When 4
         Metadata metaForUt(&arrayInfo, mapper, allocator, journal, &metaFsCtrl, &metaService);

--- a/test/unit-tests/metadata/segment_context_updater_mock.h
+++ b/test/unit-tests/metadata/segment_context_updater_mock.h
@@ -18,6 +18,7 @@ public:
     MOCK_METHOD(void, ValidateBlocksWithGroupId, (VirtualBlks blks, int logGroupId), (override));
     MOCK_METHOD(bool, InvalidateBlocksWithGroupId, (VirtualBlks blks, bool isForced, int logGroupId), (override));
     MOCK_METHOD(bool, UpdateStripeCount, (StripeId lsid, int logGroupId), (override));
+    MOCK_METHOD(void, ResetInfos, (SegmentId segId), (override));
 };
 
 } // namespace pos


### PR DESCRIPTION
github ci R9 longterm 평가에서 GC 수행 중 발생하는 vsc valid block count under flow issue fix 입니다. 
