### PR TITLE
[SHPOS-945] Fix log buffer parser to remove invalid logs 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ DOCDIR = $(TOP)/doc
 #################################################
 # nvme driver : unvme, libaio
 
-POS_VERSION = v0.12.0-rc1
+POS_VERSION = v0.12.0-rc2
 
 DEFINE += -DPOS_VERSION=\"$(POS_VERSION)\"
 DEFINE += -DUNVME_BUILD

--- a/src/event/pos_event.yaml
+++ b/src/event/pos_event.yaml
@@ -2932,7 +2932,7 @@ Root:
     Solution:
   -
     Id: 3056
-    Name: JOURNAL_REPLAY_LOG_PARSE
+    Name: MULTIPLE_SEQ_NUM_FOUND_WITHOUT_CHECKPOINT
     Severity:
     Message:
     Cause:

--- a/src/event/pos_event.yaml
+++ b/src/event/pos_event.yaml
@@ -2928,11 +2928,18 @@ Root:
     Name: JOURNAL_INVALID_LOG_FOUND
     Severity:
     Message:
-    Cause:
-    Solution:
+    Cause: Some of the old logs can not be erased becuase log offset can be additionally increased for mpage align. align.
+    Solution: Ignore the old logs by sequence number
   -
     Id: 3056
     Name: MULTIPLE_SEQ_NUM_FOUND_WITHOUT_CHECKPOINT
+    Severity:
+    Message:
+    Cause:
+    Solution:
+  -
+    Id: 3057
+    Name: JOURNAL_LOG_GROUP_FOOTER_FOUND
     Severity:
     Message:
     Cause:

--- a/src/event/pos_event.yaml
+++ b/src/event/pos_event.yaml
@@ -2931,6 +2931,13 @@ Root:
     Cause:
     Solution:
   -
+    Id: 3056
+    Name: JOURNAL_REPLAY_LOG_PARSE
+    Severity:
+    Message:
+    Cause:
+    Solution:
+  -
     Id: 3060
     Name: JOURNAL_REPLAY_STRIPE_FLUSH
     Severity:

--- a/src/journal_manager/log/log_buffer_parser.cpp
+++ b/src/journal_manager/log/log_buffer_parser.cpp
@@ -110,10 +110,10 @@ LogBufferParser::GetLogs(void* buffer, uint64_t bufferSize, LogList& logs)
             LogGroupFooter footer = *(LogGroupFooter*)(dataPtr);
             if (footer.isReseted)
             {
-                int event = static_cast<int>(EID(JOURNAL_REPLAY_LOG_PARSE));
-                POS_TRACE_INFO(event, "Reseted footer is found. Found logs with SeqNumber ({}) or less will be reseted ", footer.resetedSequenceNumber);
+                int event = static_cast<int>(EID(MULTIPLE_SEQ_NUM_FOUND_WITHOUT_CHECKPOINT));
+                POS_TRACE_INFO(event, "LogGroup Footer Reset is found. Found logs with SeqNumber ({}) or less will be reset", footer.resetedSequenceNumber);
                 logs.EraseReplayLogGroup(footer.resetedSequenceNumber);
-                _ResetedLogFound(footer.resetedSequenceNumber);
+                _LogResetFound(footer.resetedSequenceNumber);
             }
             else
             {
@@ -187,7 +187,7 @@ LogBufferParser::_LogFound(LogHandlerInterface* log)
 }
 
 void
-LogBufferParser::_ResetedLogFound(uint32_t seqNumber)
+LogBufferParser::_LogResetFound(uint32_t seqNumber)
 {
     for (auto it = logsFound.cbegin(); it != logsFound.cend();)
     {
@@ -207,7 +207,7 @@ LogBufferParser::_GetLatestSequenceNumber(void)
 {
     if (logsFound.size() > 1)
     {
-        int event = static_cast<int>(EID(JOURNAL_REPLAY_LOG_PARSE));
+        int event = static_cast<int>(EID(MULTIPLE_SEQ_NUM_FOUND_WITHOUT_CHECKPOINT));
         POS_TRACE_ERROR(event, "Multiple sequence numbers are found without checkpoint.");
     }
 

--- a/src/journal_manager/log/log_buffer_parser.cpp
+++ b/src/journal_manager/log/log_buffer_parser.cpp
@@ -205,7 +205,6 @@ LogBufferParser::_ResetedLogFound(uint32_t seqNumber)
 uint32_t
 LogBufferParser::_GetLatestSequenceNumber(void)
 {
-    uint32_t seqNumber = -1;
     if (logsFound.size() > 1)
     {
         int event = static_cast<int>(EID(JOURNAL_REPLAY_LOG_PARSE));

--- a/src/journal_manager/log/log_buffer_parser.h
+++ b/src/journal_manager/log/log_buffer_parser.h
@@ -65,6 +65,7 @@ private:
     void _LogResetFound(uint32_t seqNumber);
     uint32_t _GetLatestSequenceNumber(void);
     void _PrintFoundLogTypes(void);
+    void _GetNextSearchOffset(uint64_t& searchOffset, uint64_t foundOffset);
 
     LogHandlerInterface* _GetLogHandler(char* ptr);
 

--- a/src/journal_manager/log/log_buffer_parser.h
+++ b/src/journal_manager/log/log_buffer_parser.h
@@ -62,7 +62,7 @@ private:
     };
 
     void _LogFound(LogHandlerInterface* log);
-    void _ResetedLogFound(uint32_t seqNumber);
+    void _LogResetFound(uint32_t seqNumber);
     uint32_t _GetLatestSequenceNumber(void);
     void _PrintFoundLogTypes(void);
 

--- a/src/journal_manager/log/log_buffer_parser.h
+++ b/src/journal_manager/log/log_buffer_parser.h
@@ -33,6 +33,7 @@
 #pragma once
 
 #include <cstdint>
+#include <map>
 #include <vector>
 
 #include "src/journal_manager/log/log_group_footer.h"
@@ -60,12 +61,14 @@ private:
         uint64_t maxOffset;
     };
 
-    void _LogFound(LogType type);
+    void _LogFound(LogHandlerInterface* log);
+    void _ResetedLogFound(uint32_t seqNumber);
+    uint32_t _GetLatestSequenceNumber(void);
     void _PrintFoundLogTypes(void);
 
     LogHandlerInterface* _GetLogHandler(char* ptr);
 
-    std::vector<int> logsFound;
+    std::map<uint32_t, std::vector<int>> logsFound;
 };
 
 } // namespace pos

--- a/src/journal_manager/log/log_event.h
+++ b/src/journal_manager/log/log_event.h
@@ -65,7 +65,7 @@ struct BlockWriteDoneLog : Log
     VirtualBlkAddr startVsa;
     int wbIndex;
     StripeAddr writeBufferStripeAddress;
-    uint8_t reserved[12];
+    uint8_t reserved[12] = {0, };
 };
 
 struct StripeMapUpdatedLog : Log

--- a/src/journal_manager/replay/replay_handler.cpp
+++ b/src/journal_manager/replay/replay_handler.cpp
@@ -157,7 +157,7 @@ ReplayHandler::_ExecuteReplayTasks(void)
 
         if (result != 0)
         {
-            // TODO (cheolho.kang): Add sequence to dump journal buffer
+            // TODO (cheolho.kang): For debuggability, Add the process of dumping the journal log buffer before dispose.
             if (result > 0)
             {
                 reporter->CompleteAll();

--- a/src/journal_manager/replay/replay_handler.cpp
+++ b/src/journal_manager/replay/replay_handler.cpp
@@ -157,6 +157,7 @@ ReplayHandler::_ExecuteReplayTasks(void)
 
         if (result != 0)
         {
+            // TODO (cheolho.kang): Add sequence to dump journal buffer
             if (result > 0)
             {
                 reporter->CompleteAll();

--- a/src/journal_manager/replay/replay_log_list.cpp
+++ b/src/journal_manager/replay/replay_log_list.cpp
@@ -107,7 +107,7 @@ ReplayLogList::EraseReplayLogGroup(uint32_t seqNum)
         {
             int event = static_cast<int>(EID(JOURNAL_INVALID_LOG_FOUND));
             POS_TRACE_INFO(event, "Erasing Replay Log Group for SeqNum {} with {} entries", it->first, it->second.logs.size());
-            for (ReplayLog replayLog : it->second.logs)
+            for (const ReplayLog& replayLog : it->second.logs)
             {
                 delete replayLog.log;
             }

--- a/src/journal_manager/replay/replay_log_list.cpp
+++ b/src/journal_manager/replay/replay_log_list.cpp
@@ -102,6 +102,7 @@ ReplayLogList::EraseReplayLogGroup(uint32_t seqNum)
 {
     for (auto it = logGroups.cbegin(); it != logGroups.cend();)
     {
+        // TODO (cheolho.kang): It should be refactored later to erase replay logs with invalid sequence numbers using LogBufferParser.logs 
         if (it->first <= seqNum || it->first == LOG_VALID_MARK)
         {
             int event = static_cast<int>(EID(JOURNAL_INVALID_LOG_FOUND));

--- a/src/journal_manager/replay/replay_log_list.cpp
+++ b/src/journal_manager/replay/replay_log_list.cpp
@@ -107,7 +107,7 @@ ReplayLogList::EraseReplayLogGroup(uint32_t seqNum)
         {
             int event = static_cast<int>(EID(JOURNAL_INVALID_LOG_FOUND));
             POS_TRACE_INFO(event, "Erasing Replay Log Group for SeqNum {} with {} entries", it->first, it->second.logs.size());
-            for (const ReplayLog& replayLog : it->second.logs)
+            for (ReplayLog replayLog : it->second.logs)
             {
                 delete replayLog.log;
             }

--- a/src/journal_manager/replay/replay_log_list.cpp
+++ b/src/journal_manager/replay/replay_log_list.cpp
@@ -32,6 +32,7 @@
 
 #include "src/journal_manager/replay/replay_log_list.h"
 
+#include "src/journal_manager/log/log_event.h"
 #include "src/journal_manager/log/log_handler.h"
 #include "src/journal_manager/log/volume_deleted_log_handler.h"
 #include "src/logger/logger.h"
@@ -99,14 +100,23 @@ ReplayLogList::SetLogGroupFooter(uint32_t seqNum, LogGroupFooter footer)
 void
 ReplayLogList::EraseReplayLogGroup(uint32_t seqNum)
 {
-    ReplayLogGroup replayLogGroup = logGroups[seqNum];
-    int event = static_cast<int>(EID(JOURNAL_INVALID_LOG_FOUND));
-    POS_TRACE_INFO(event, "Erasing Replay Log Group for SeqNum {} with {} entries", seqNum, replayLogGroup.logs.size());
-    for (ReplayLog replayLog : replayLogGroup.logs)
+    for (auto it = logGroups.cbegin(); it != logGroups.cend();)
     {
-        delete replayLog.log;
+        if (it->first <= seqNum || it->first == LOG_VALID_MARK)
+        {
+            int event = static_cast<int>(EID(JOURNAL_INVALID_LOG_FOUND));
+            POS_TRACE_INFO(event, "Erasing Replay Log Group for SeqNum {} with {} entries", it->first, it->second.logs.size());
+            for (ReplayLog replayLog : it->second.logs)
+            {
+                delete replayLog.log;
+            }
+            logGroups.erase(it++);
+        }
+        else
+        {
+            it++;
+        }
     }
-    logGroups.erase(seqNum);
 }
 
 ReplayLogGroup

--- a/test/unit-tests/journal_manager/log/log_buffer_parser_test.cpp
+++ b/test/unit-tests/journal_manager/log/log_buffer_parser_test.cpp
@@ -373,16 +373,17 @@ TEST(LogBufferParser, GetLogs_testIfSeveralOldSequenceNumber)
     LogBufferParser parser;
     int result = parser.GetLogs(logBuffer, logBufferSize, logList);
 
-    // Then: LogBufferParser will return the error code
+    // Then: LogBufferParser will return the success code
     int expect = 0;
     EXPECT_EQ(result, expect);
     free(logBuffer);
 }
 
+// Test scenario to verify the journal log buffer with actual journal file extracted from core dump.
+// It will be used later to use this TC with the test script
 TEST(LogBufferParser, DISABLED_GetLogs_testWithRealDump)
 {
-    // Given
-
+    // Given: Actual journal log buffer file getting through memory dump
     int fd = open("log_group.out", O_RDWR, 0777);
     EXPECT_TRUE(fd != -1);
 

--- a/test/unit-tests/journal_manager/log/log_list_mock.h
+++ b/test/unit-tests/journal_manager/log/log_list_mock.h
@@ -15,6 +15,7 @@ public:
     MOCK_METHOD(void, AddLog, (LogHandlerInterface * log), (override));
     MOCK_METHOD(bool, IsEmpty, (), (override));
     MOCK_METHOD(void, SetLogGroupFooter, (uint32_t seqNum, LogGroupFooter footer), (override));
+    MOCK_METHOD(void, EraseReplayLogGroup, (uint32_t seqNum), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/journal_manager/replay/replay_log_list_mock.h
+++ b/test/unit-tests/journal_manager/replay/replay_log_list_mock.h
@@ -13,6 +13,7 @@ public:
     MOCK_METHOD(void, AddLog, (LogHandlerInterface* log), (override));
     MOCK_METHOD(bool, IsEmpty, (), (override));
     MOCK_METHOD(void, SetLogGroupFooter, (uint32_t seqNum, LogGroupFooter footer), (override));
+    MOCK_METHOD(void, EraseReplayLogGroup, (uint32_t seqNum), (override));
     MOCK_METHOD(ReplayLogGroup, PopReplayLogGroup, (), (override));
 };
 


### PR DESCRIPTION
[Revieweee] 
- Review 목적: footer에 기록된 resetedSequenceNumber보다 더 과거의 log가 발견된 case에 대한 error handling
- 참고 문서: SHPOS-945
- 주요 review 파일: log_buffer_parser.cpp, replay_log_list.cpp
- 검증 방법 또는 TC: IT/UT

[Reviewer] 
- Checklist 
1) ReplayLogList.EraseReplayLogGroup()에서 map 순회하며 log 지우는 알고리즘에 대한 검토
2) LogBufferParser의 logsFound를 sequence number 단위로 모아서 관리하고, 이를 통해 seqNumSeen 변수를 없앤 것에 대한 검토
3) UT 시나리오 