### PR TITLE
[AWIBOF-7290] fixed cli timeout value to larger value

### DIFF
--- a/test/system/lib/json_parser.py
+++ b/test/system/lib/json_parser.py
@@ -5,10 +5,13 @@ def get_response_code(result):
     code = 0
     output = result.splitlines()
     output_count = len(output)
-    for i in range(0, output_count):
-        data = json.loads(output[i])
-        code |= data['Response']['result']['status']['code']
-    return code
+    try:
+        for i in range(0, output_count):
+            data = json.loads(output[i])
+            code |= data['Response']['result']['status']['code']
+        return code
+    except:
+        return -1
 
 def get_data_code(result):
     data = json.loads(result)

--- a/test/system/longterm/72hour_test.py
+++ b/test/system/longterm/72hour_test.py
@@ -247,7 +247,7 @@ def create_array():
         return False
 
 def mount_pos():
-    out = cli.mount_array(ARRAYNAME)
+    out = cli.mount_array(ARRAYNAME + " --timeout 1800")
     code = json_parser.get_response_code(out)
     if code == 0:
         write_log ("array mounted successfully")

--- a/test/system/longterm/72hour_test.py
+++ b/test/system/longterm/72hour_test.py
@@ -28,6 +28,9 @@ TESTTIME_IN_HOUR = 72
 ELAPSED_MIN = 0
 ELAPSED_HOUR = 0
 RC = True
+# CLI MOUNT TIMEOUT
+# In Write Through mode, larger timeout value for mount is needed than cli default timeout becasuse of large number of IO
+CLI_MOUNT_TIMEOUT = 1800
 
 #for PM
 # DATA = "unvme-ns-0,unvme-ns-1,unvme-ns-2,unvme-ns-3,unvme-ns-4"
@@ -247,7 +250,7 @@ def create_array():
         return False
 
 def mount_pos():
-    out = cli.mount_array(ARRAYNAME + " --timeout 1800")
+    out = cli.mount_array(ARRAYNAME + " --timeout " + CLI_MOUNT_TIMEOUT)
     code = json_parser.get_response_code(out)
     if code == 0:
         write_log ("array mounted successfully")

--- a/test/system/longterm/72hour_test.py
+++ b/test/system/longterm/72hour_test.py
@@ -28,8 +28,8 @@ TESTTIME_IN_HOUR = 72
 ELAPSED_MIN = 0
 ELAPSED_HOUR = 0
 RC = True
-# CLI MOUNT TIMEOUT
-# In Write Through mode, larger timeout value for mount is needed than cli default timeout becasuse of large number of IO
+# CLI timeout in seconds for array mount command
+# In Write Through mode, larger timeout value for mount is needed than cli default timeout because of large number of IO
 CLI_MOUNT_TIMEOUT = 1800
 
 #for PM


### PR DESCRIPTION
문제 상황
: write back -> write through 로 CI 설정이 바뀌면서 mount시 소요되는 시간의 증가로 인해 cli timeout이 발생 하는 것으로 생각됩니다.
  그로 인해 mount fail 이후 스크립트가 작동이 정상적으로 동작하지 않아 테스트가 실패한 것으로 생각됩니다.

해결 방법
- 스크립트에서 cli timeout시 발생하는 timeout을 크게 늘렸습니다.
- 숫자 자체는 우선은 작동하는지 확인하기 위해서 크게 늘려 놓은 것이라 추후에 세부 조정이 필요할 것으로 생각됩니다.


추가사항
(2022-10-25)
cli timeout 값이 정확한 측정값이 아니고 예측 값이기 때문에 혹시나 모를 또 다른 timeout이 발생할 수 있습니다.
그럴 경우에 대비해 cli response를 확인하는 코드에 예외 처리를 추가하여 cli timeout이 발생해도 POS가 dump를 생성 할 수 있도록 처리했습니다.

