### PR TITLE
[AWIBOF-7309] Fix CLI protojson patch bug

### DIFF
--- a/tool/cli/patches/protojson_encode.patch
+++ b/tool/cli/patches/protojson_encode.patch
@@ -1,11 +1,15 @@
---- encode.go	2022-10-20 14:13:22.126921685 +0900
-+++ encode_patch.go	2022-10-20 14:23:15.318912480 +0900
-@@ -274,7 +274,7 @@
- 	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
- 		protoreflect.Sfixed64Kind, protoreflect.Fixed64Kind:
- 		// 64-bit integers are written out as JSON string.
--		e.WriteString(val.String())
-+		e.WriteUint(val.Uint())
+--- /root/go/pkg/mod/google.golang.org/protobuf@v1.28.0/encoding/protojson/encode.go	2022-10-26 13:58:41.394891124 +0900
++++ ../encode_diff.go	2022-10-26 14:02:53.590887211 +0900
+@@ -269,10 +269,10 @@
+ 	case pref.Int32Kind, pref.Sint32Kind, pref.Sfixed32Kind:
+ 		e.WriteInt(val.Int())
  
- 	case protoreflect.FloatKind:
- 		// Encoder.WriteFloat handles the special numbers NaN and infinites.
+-	case pref.Uint32Kind, pref.Fixed32Kind:
++	case pref.Uint32Kind, pref.Fixed32Kind, pref.Uint64Kind:
+ 		e.WriteUint(val.Uint())
+ 
+-	case pref.Int64Kind, pref.Sint64Kind, pref.Uint64Kind,
++	case pref.Int64Kind, pref.Sint64Kind, 
+ 		pref.Sfixed64Kind, pref.Fixed64Kind:
+ 		// 64-bit integers are written out as JSON string.
+ 		e.WriteString(val.String())

--- a/tool/cli/script/build_cli.sh
+++ b/tool/cli/script/build_cli.sh
@@ -22,8 +22,9 @@ protoc --go_out=api --go_opt=paths=source_relative \
 lib/pnconnector/script/build_resource.sh
 
 # Patching protojson
+echo "Installing and patching protojson..."
+rm -rf ${GOPATH}/pkg/mod/google.golang.org/protobuf@v1.28.0
 ${GO} mod download
-patch -R -f ${GOPATH}/pkg/mod/google.golang.org/protobuf@v1.28.0/encoding/protojson/encode.go ./patches/protojson_encode.patch
 patch -f --silent ${GOPATH}/pkg/mod/google.golang.org/protobuf@v1.28.0/encoding/protojson/encode.go ./patches/protojson_encode.patch
 if [ $? -ne 0 ];
 then


### PR DESCRIPTION
Fix CLI protojson patch bug.

Previously, CLI goes to panic when CLI displays int64. This is because the patch for jsonproto has a bug, which prints out int64 as uint64.

This commit fixes the bug above.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>