### PR TITLE
[AWIBOF-7290] fixed by CI Test

### DIFF
--- a/test/system/longterm/72hour_test.py
+++ b/test/system/longterm/72hour_test.py
@@ -250,7 +250,7 @@ def create_array():
         return False
 
 def mount_pos():
-    out = cli.mount_array(ARRAYNAME + " --timeout " + CLI_MOUNT_TIMEOUT)
+    out = cli.mount_array(ARRAYNAME + " --timeout " + str(CLI_MOUNT_TIMEOUT))
     code = json_parser.get_response_code(out)
     if code == 0:
         write_log ("array mounted successfully")


### PR DESCRIPTION
fixed
- fixed invalid value to str
- fixed python parsing error

result
- 72hour test working

72hour test에서 CLI_MOUNT_TIMEOUT이 string이 아닌 int로 인식되어 생긴 문제를 수정했습니다.