### PR TITLE
[SHPOS-959] Fix uint64 display bug for CLI display

### DIFF
--- a/tool/cli/cmd/displaymgr/display_response.go
+++ b/tool/cli/cmd/displaymgr/display_response.go
@@ -84,12 +84,12 @@ func printResInJSON(resJSON string) {
 func printResToHumanReadable(command string, resJSON string, displayUnit bool) {
 	switch command {
 	case "LISTARRAY":
-		res := messages.ListArrayResponse{}
-		json.Unmarshal([]byte(resJSON), &res)
+		res := &pb.ListArrayResponse{}
+		json.Unmarshal([]byte(resJSON), res)
 
-		if res.RESULT.STATUS.CODE != globals.CliServerSuccessCode {
-			printEventInfo(res.RESULT.STATUS.CODE, res.RESULT.STATUS.EVENTNAME,
-				res.RESULT.STATUS.DESCRIPTION, res.RESULT.STATUS.CAUSE, res.RESULT.STATUS.SOLUTION)
+		status := res.GetResult().GetStatus()
+		if isFailed(*status) {
+			printEvent(*status)
 			return
 		}
 
@@ -120,19 +120,17 @@ func printResToHumanReadable(command string, resJSON string, displayUnit bool) {
 				globals.FieldSeparator+"----------")
 
 		// Data
-		for _, array := range res.RESULT.DATA.ARRAYLIST {
-			total, _ := strconv.ParseUint(array.CAPACITY, 10, 64)
-			used, _ := strconv.ParseUint(array.USED, 10, 64)
+		for _, array := range res.GetResult().GetData().GetArrayList() {
 			fmt.Fprint(w,
-				strconv.Itoa(array.ARRAYINDEX)+"\t"+
-					globals.FieldSeparator+array.ARRAYNAME+"\t"+
-					globals.FieldSeparator+array.STATUS+"\t"+
-					globals.FieldSeparator+array.CREATEDATETIME+"\t"+
-					globals.FieldSeparator+array.UPDATEDATETIME+"\t"+
-					globals.FieldSeparator+toByte(displayUnit, total)+"\t"+
-					globals.FieldSeparator+toByte(displayUnit, used)+"\t"+
-					globals.FieldSeparator+strconv.FormatBool(array.WRITETHROUGH)+"\t"+
-					globals.FieldSeparator+array.DATARAID)
+				strconv.Itoa(int(array.GetIndex()))+"\t"+
+					globals.FieldSeparator+array.GetName()+"\t"+
+					globals.FieldSeparator+array.GetStatus()+"\t"+
+					globals.FieldSeparator+array.GetCreateDatetime()+"\t"+
+					globals.FieldSeparator+array.GetUpdateDatetime()+"\t"+
+					globals.FieldSeparator+toByte(displayUnit, array.GetCapacity())+"\t"+
+					globals.FieldSeparator+toByte(displayUnit, array.GetUsed())+"\t"+
+					globals.FieldSeparator+strconv.FormatBool(array.GetWriteThroughEnabled())+"\t"+
+					globals.FieldSeparator+array.GetDataRaid())
 
 			fmt.Fprintln(w, "")
 		}

--- a/tool/cli/cmd/displaymgr/display_response_test.go
+++ b/tool/cli/cmd/displaymgr/display_response_test.go
@@ -10,23 +10,26 @@ import (
 // This testing tests if the response is parsed and displayed well in human readable form for LISTARRAY command
 func TestListArrayResHumanReadable(t *testing.T) {
 	var command = "LISTARRAY"
-	var resJSON = `{"command":"LISTARRAY","rid":"fromCLI",
-	"result":{"status":{"code":0,"description":"DONE"},
-	"data":{"arrayList": [{"createDatetime": "2021-04-16 15:52:14 +0900",
-	"devicelist": [{"sn": "uram0","type": "BUFFER"},
-	{"sn": "S4H2NE0M600736","type": "DATA"},
-	{"sn": "S4H2NE0M600745","type": "DATA"},
-	{"sn": "S4H2NE0M600763","type": "DATA"}],
-	"index": 0,"name": "ARRAY0","status":"Mounted","updateDatetime": "2021-04-16 15:52:14 +0900"},
-	{"createDatetime": "2021-04-16 15:52:14 +0900","devicelist": [{"sn": "uram1","type": "BUFFER"},
-	{"sn": "S4H2NE0M600744","type": "DATA"},{"sn": "S4H2NE0M600743","type": "DATA"},
-	{"sn": "S4H2NE0M600746","type": "DATA"}],"index": 1,"name": "ARRAY1","status":"Unmounted",
-	"updateDatetime": "2021-04-16 15:52:14 +0900"}]}}}`
+	var resJSON = `{"command":"LISTARRAY", "rid":"941604e2-5693-11ed-a87c-005056adcaa2",` +
+		`"result":{"status":{"code":0, "eventName":"SUCCESS",` +
+		`"description":"NONE", "cause":"NONE", "solution":"NONE"},` +
+		`"data":{"arrayList":[{"index":0, "uniqueId":0, "name":"POSArray",` +
+		`"status":"Unmounted", "state":"", "situation":"",` +
+		`"createDatetime":"2022-10-19 08:22:32 +0000", "updateDatetime":"2022-10-19 08:22:41 +0000",` +
+		`"rebuildingProgress":"", "capacity":119829587559, "used":0, "gcMode":"",` +
+		`"metaRaid":"", "dataRaid":"RAID5", "writeThroughEnabled":false, "devicelist":[]},` +
+		`{"index":1, "uniqueId":1, "name":"POSArray2",` +
+		`"status":"Unmounted", "state":"", "situation":"",` +
+		`"createDatetime":"2022-10-19 08:22:32 +0000", "updateDatetime":"2022-10-19 08:22:41 +0000",` +
+		`"rebuildingProgress":"", "capacity":219829587559, "used":103012340, "gcMode":"",` +
+		`"metaRaid":"", "dataRaid":"RAID5", "writeThroughEnabled":false, "devicelist":[]}` +
+		`]}},` +
+		`"info":{"version":"v0.12.0-rc1"}}`
 
-	expected := `Index |Name       |DatetimeCreated           |DatetimeUpdated           |Status
------ |---------- |---------------------     |---------------------     |----------
-0     |ARRAY0     |2021-04-16 15:52:14 +0900 |2021-04-16 15:52:14 +0900 |Mounted
-1     |ARRAY1     |2021-04-16 15:52:14 +0900 |2021-04-16 15:52:14 +0900 |Unmounted
+	expected := `Index |Name       |Status     |DatetimeCreated           |DatetimeUpdated           |TotalCapacity |UsedCapacity  |WriteThrough  |RAID
+----- |---------- |---------- |---------------------     |---------------------     |------------- |------------- |------------- |----------
+0     |POSArray   |Unmounted  |2022-10-19 08:22:32 +0000 |2022-10-19 08:22:41 +0000 |119829587559  |0             |false         |RAID5
+1     |POSArray2  |Unmounted  |2022-10-19 08:22:32 +0000 |2022-10-19 08:22:41 +0000 |219829587559  |103012340     |false         |RAID5
 `
 
 	output := hookResponse(command, resJSON, false, false)


### PR DESCRIPTION
Fix uint64 display bug when CLI prints out the response in a human readable form.

The bug is because total and used capacities were treated as strings in the CLI response display module.

This commit removes the type conversion on the capacities.

Signed-off-by: mjlee34 <jun20.lee@samsung.com>