### PR TITLE
Revise log messages

### DIFF
--- a/src/allocator/context_manager/allocator_file_io.cpp
+++ b/src/allocator/context_manager/allocator_file_io.cpp
@@ -277,8 +277,8 @@ AllocatorFileIo::_FlushCompletedThenCB(AsyncMetaFileIoCtx* ctx)
     assert(header->sig == client->GetSignature());
 
     _AfterFlush(ctx);
-    POS_TRACE_DEBUG(EID(ALLOCATOR_META_ARCHIVE_STORE),
-        "[AllocatorFlush] File flushed, sig:{}, version:{}", header->sig, header->ctxVersion);
+    POS_TRACE_DEBUG(EID(ALLOCATOR_META_ARCHIVE_STORE_COMPLETED),
+        "sig:{}, version:{}", header->sig, header->ctxVersion);
 
     AllocatorIoCtx* ioContext = reinterpret_cast<AllocatorIoCtx*>(ctx);
     ioContext->clientCallback();

--- a/src/allocator/context_manager/context_io_manager.cpp
+++ b/src/allocator/context_manager/context_io_manager.cpp
@@ -132,7 +132,7 @@ ContextIoManager::FlushContexts(EventSmartPtr callback, bool sync, char* externa
         POS_TRACE_INFO(EID(ALLOCATOR_META_ARCHIVE_STORE), "ALLOCATOR_META_ARCHIVE_FLUSH_IN_PROGRESS sync {}", sync);
         return EID(ALLOCATOR_META_ARCHIVE_FLUSH_IN_PROGRESS);
     }
-    POS_TRACE_INFO(EID(ALLOCATOR_META_ARCHIVE_STORE), "[AllocatorFlush] sync:{}, start to flush", sync);
+    POS_TRACE_INFO(EID(ALLOCATOR_META_ARCHIVE_STORE), "Started, sync:{}", sync);
 
     int ret = 0;
     flushCallback = callback;
@@ -211,7 +211,9 @@ ContextIoManager::_FlushCompleted(void)
 
     if (remaining == 0 && flushInProgress.exchange(false) == true)
     {
-        POS_TRACE_DEBUG(EID(ALLOCATOR_META_ARCHIVE_STORE), "[AllocatorFlush] Complete to flush allocator files");
+        POS_TRACE_DEBUG(EID(ALLOCATOR_META_ARCHIVE_STORE),
+            "Completed, remaining:{}, flushInProgress:{}", remaining, flushInProgress);
+
         if (flushCallback != nullptr)
         {
             eventScheduler->EnqueueEvent(flushCallback);

--- a/src/allocator/context_manager/context_manager.cpp
+++ b/src/allocator/context_manager/context_manager.cpp
@@ -255,7 +255,7 @@ ContextManager::PrepareVersionedSegmentCtx(IVersionedSegmentContext* versionedSe
 void
 ContextManager::ResetFlushedInfo(int logGroupId)
 {
-    POS_TRACE_INFO(EID(JOURNAL_CHECKPOINT_COMPLETED), "ContextManager::ResetFlushedInfo {}", logGroupId);
+    POS_TRACE_INFO(EID(VERSIONED_SEGMENT_INFO), "ResetFlushedInfo, logGroupId:{}", logGroupId);
 
     if (ALL_LOG_GROUP == logGroupId)
     {

--- a/src/event/pos_event.yaml
+++ b/src/event/pos_event.yaml
@@ -2825,7 +2825,7 @@ Root:
     Solution:
   -
     Id: 3031
-    Name: JOURNAL_FLUSH_LOG_GROUP
+    Name: JOURNAL_RELEASE_LOG_GROUP_STARTED
     Severity:
     Message:
     Cause:
@@ -2839,7 +2839,7 @@ Root:
     Solution:
   -
     Id: 3033
-    Name: JOURNAL_CHECKPOINT_STATUS
+    Name: JOURNAL_CHECKPOINT_STATUS_CHANGED
     Severity:
     Message:
     Cause:
@@ -2860,7 +2860,7 @@ Root:
     Solution:
   -
     Id: 3036
-    Name: JOUNRAL_WRITE_LOG_GROUP_FOOTER
+    Name: JOURNAL_WRITE_LOG_GROUP_FOOTER
     Severity:
     Message:
     Cause:
@@ -2879,7 +2879,13 @@ Root:
     Message:
     Cause:
     Solution:
-
+  -
+    Id: 3039
+    Name: JOURNAL_LOG_GROUP_ALLOCATED
+    Severity:
+    Message:
+    Cause:
+    Solution:
   -
     Id: 3040
     Name: JOURNAL_HANDLE_VOLUME_DELETION
@@ -2887,7 +2893,27 @@ Root:
     Message:
     Cause:
     Solution:
-
+  -
+    Id: 3041
+    Name: JOURNAL_CHECKPOINT_FLUSH_METADATA
+    Severity:
+    Message:
+    Cause:
+    Solution:
+  -
+    Id: 3042
+    Name: JOURNAL_CHECKPOINT_FLUSH_COMPLETED
+    Severity:
+    Message:
+    Cause:
+    Solution:
+  -
+    Id: 3043
+    Name: JOURNAL_RELEASE_LOG_GROUP_COMPLETED
+    Severity:
+    Message:
+    Cause:
+    Solution:
   -
     Id: 3050
     Name: JOURNAL_REPLAY_STARTED
@@ -3000,7 +3026,13 @@ Root:
     Message:
     Cause:
     Solution:
-
+  -
+    Id: 3068
+    Name: VERSIONED_SEGMENT_INFO
+    Severity:
+    Message:
+    Cause:
+    Solution:
   -
     Id: 3070
     Name: ROCKSDB_LOG_BUFFER_OPENED
@@ -3293,7 +3325,7 @@ Root:
     Solution:
   -
     Id: 3116
-    Name: REVMAP_GET_MFS_ALIGNED_IOSIZE_FAILURE
+    Name: COPY_MAP_HEADER
     Severity:
     Message:
     Cause:
@@ -3508,8 +3540,13 @@ Root:
     Message:
     Cause:
     Solution:
-
-  
+  -
+    Id: 3147
+    Name: MAP_FLUSH_FAILED
+    Severity:
+    Message:
+    Cause:
+    Solution:
   # Allocator: 3150 - 3299
   -
     Id: 3150
@@ -3973,7 +4010,13 @@ Root:
     Message:
     Cause:
     Solution:
-
+  -
+    Id: 3216
+    Name: ALLOCATOR_META_ARCHIVE_STORE_COMPLETED
+    Severity:
+    Message:
+    Cause:
+    Solution:
   # Metadata: 3300 - 3399
   -
     Id: 3300

--- a/src/journal_manager/checkpoint/checkpoint_handler.cpp
+++ b/src/journal_manager/checkpoint/checkpoint_handler.cpp
@@ -98,20 +98,18 @@ CheckpointHandler::Start(MapList pendingDirtyMaps, EventSmartPtr callback)
     }
     else
     {
-        int eventId = static_cast<int>(EID(JOURNAL_CHECKPOINT_STARTED));
-        POS_TRACE_INFO(eventId, "Checkpoint started with {} maps to flush, arrayId:{}", numMapsToFlush, arrayId);
+        POS_TRACE_INFO(EID(JOURNAL_CHECKPOINT_FLUSH_METADATA),
+            "logGroupId:{}, numMapsToFlush:{}, arrayId:{}", logGroupIdInProgress, numMapsToFlush, arrayId);
 
         for (auto mapId : pendingDirtyMaps)
         {
-            eventId = static_cast<int>(EID(JOURNAL_DEBUG));
-
             EventSmartPtr eventMapFlush(new CheckpointMetaFlushCompleted(this, mapId, logGroupIdInProgress));
             ret = mapFlush->FlushDirtyMpages(mapId, eventMapFlush);
             if (ret != 0)
             {
                 // TODO(Cheolho.kang): Add status that can additionally indicate checkpoint status
                 POS_TRACE_ERROR(EID(JOURNAL_CHECKPOINT_FAILED),
-                    "Failed to start flushing dirty map pages, arrayId:{}", arrayId);
+                    "mapId:{}, arrayId:{}", mapId, arrayId);
                 return ret;
             }
         }
@@ -152,8 +150,6 @@ CheckpointHandler::FlushCompleted(int metaId, int logGroupId)
 {
     if (metaId == ALLOCATOR_META_ID)
     {
-        POS_TRACE_INFO(EID(JOURNAL_CHECKPOINT_STATUS),
-            "Allocator meta flush completed, arrayId:{}", arrayId);
         assert(allocatorMetaFlushCompleted == false);
 
         allocatorMetaFlushCompleted = true;
@@ -161,10 +157,12 @@ CheckpointHandler::FlushCompleted(int metaId, int logGroupId)
     }
     else
     {
-        POS_TRACE_INFO(EID(JOURNAL_CHECKPOINT_STATUS),
-            "Map {} flush completed, arrayId:{}", metaId, arrayId);
         _CheckMapFlushCompleted();
     }
+
+    POS_TRACE_INFO(EID(JOURNAL_CHECKPOINT_FLUSH_COMPLETED),
+        "metaId:{}, numMapsFlushed:{}, allocatorCompleted:{}, arrayId:{}",
+        metaId, mapFlushCompleted, allocatorMetaFlushCompleted, arrayId);
 
     _TryToComplete();
     return 0;
@@ -173,14 +171,13 @@ CheckpointHandler::FlushCompleted(int metaId, int logGroupId)
 void
 CheckpointHandler::_TryToComplete(void)
 {
-    POS_TRACE_DEBUG(EID(JOURNAL_CHECKPOINT_STATUS),
-        "Try to complete CP, mapCompleted {} allocatorCompleted {}, arrayId:{}",
-        mapFlushCompleted, allocatorMetaFlushCompleted, arrayId);
-
     std::unique_lock<std::mutex> lock(completionLock);
     if ((mapFlushCompleted == true) && (allocatorMetaFlushCompleted == true)
         && (status != COMPLETED))
     {
+        POS_TRACE_INFO(EID(JOURNAL_CHECKPOINT_COMPLETED),
+            "logGroupId:{}, arrayId:{}", logGroupIdInProgress, arrayId);
+
         // check status to complete checkpoint only once
         _SetStatus(COMPLETED);
 
@@ -193,7 +190,6 @@ CheckpointHandler::_TryToComplete(void)
         _Reset();
 
         scheduler->EnqueueEvent(tempCheckpointCompletionCallback);
-        POS_TRACE_INFO(EID(JOURNAL_CHECKPOINT_COMPLETED), "Checkpoint completed, arrayId:{}", arrayId);
     }
 }
 
@@ -212,8 +208,8 @@ CheckpointHandler::_Reset(void)
 void
 CheckpointHandler::_SetStatus(CheckpointStatus to)
 {
-    POS_TRACE_DEBUG(EID(JOURNAL_CHECKPOINT_STATUS),
-        "Checkpoint status changed from {} to {}, arrayId:{}", status, to, arrayId);
+    POS_TRACE_DEBUG(EID(JOURNAL_CHECKPOINT_STATUS_CHANGED),
+        "from:{}, to:{}, arrayId:{}", status, to, arrayId);
 
     status = to;
 }

--- a/src/journal_manager/checkpoint/log_group_release_status.cpp
+++ b/src/journal_manager/checkpoint/log_group_release_status.cpp
@@ -49,31 +49,41 @@ LogGroupReleaseStatus::SetWaiting(uint32_t seqNum)
 {
     assert(status == ReleaseStatus::INIT);
 
+    ReleaseStatus from = status;
+
     sequenceNumber = seqNum;
     status = ReleaseStatus::WAITING;
 
-    POS_TRACE_DEBUG(EID(JOURNAL_LOG_GROUP_STATUS_CHANGED),
-        "ReleaseStatus, id: {}, status: {}", id, status);
+    _PrintStatusChangedLog(from);
 }
 
 void
 LogGroupReleaseStatus::SetReleasing(void)
 {
     assert(status == ReleaseStatus::WAITING);
+
+    ReleaseStatus from = status;
     status = ReleaseStatus::RELEASING;
 
-    POS_TRACE_DEBUG(EID(JOURNAL_LOG_GROUP_STATUS_CHANGED),
-        "ReleaseStatus, id: {}, status: {}", id, status);
+    _PrintStatusChangedLog(from);
 }
 
 void
 LogGroupReleaseStatus::Reset(void)
 {
     sequenceNumber = 0;
+
+    ReleaseStatus from = status;
     status = ReleaseStatus::INIT;
 
+    _PrintStatusChangedLog(from);
+}
+
+void
+LogGroupReleaseStatus::_PrintStatusChangedLog(ReleaseStatus from)
+{
     POS_TRACE_DEBUG(EID(JOURNAL_LOG_GROUP_STATUS_CHANGED),
-        "ReleaseStatus, id: {}, status: {}", id, status);
+        "logGroupId:{}, from:{}, to:{}", id, from, status);
 }
 
 uint32_t

--- a/src/journal_manager/checkpoint/log_group_release_status.h
+++ b/src/journal_manager/checkpoint/log_group_release_status.h
@@ -60,6 +60,8 @@ public:
     bool IsReleasing(void);
 
 private:
+    void _PrintStatusChangedLog(ReleaseStatus from);
+
     int id;
     uint32_t sequenceNumber;
     ReleaseStatus status;

--- a/src/journal_manager/checkpoint/log_group_releaser.cpp
+++ b/src/journal_manager/checkpoint/log_group_releaser.cpp
@@ -112,8 +112,8 @@ LogGroupReleaser::_FlushNextLogGroup(void)
         {
             logGroups[nextLogGroupId].SetReleasing();
 
-            POS_TRACE_INFO(EID(JOURNAL_FLUSH_LOG_GROUP),
-                "Flush next log group {}, seq number {}", nextLogGroupId, logGroups[nextLogGroupId].GetSeqNum());
+            POS_TRACE_INFO(EID(JOURNAL_RELEASE_LOG_GROUP_STARTED),
+                "logGroupId:{}, sequenceNumber:{}", nextLogGroupId, logGroups[nextLogGroupId].GetSeqNum());
 
             _TriggerCheckpoint();
         }
@@ -131,8 +131,8 @@ LogGroupReleaser::_TriggerCheckpoint(void)
     LogGroupFooter footer;
     uint64_t footerOffset;
 
-    POS_TRACE_DEBUG(EID(JOURNAL_CHECKPOINT_STARTED),
-        "Submit checkpoint start for log group {}", nextLogGroupId);
+    POS_TRACE_INFO(EID(JOURNAL_CHECKPOINT_STARTED),
+        "logGroupId:{}", nextLogGroupId);
 
     _CreateFlushingLogGroupFooter(footer, footerOffset);
 
@@ -176,6 +176,9 @@ LogGroupReleaser::_CreateFlushingLogGroupFooter(LogGroupFooter& footer, uint64_t
 void
 LogGroupReleaser::LogGroupResetCompleted(int logGroupId)
 {
+    POS_TRACE_INFO(EID(JOURNAL_RELEASE_LOG_GROUP_COMPLETED),
+        "logGroupId:{}", logGroupId);
+
     releaseNotifier->NotifyLogBufferReseted(logGroupId);
 
     logGroups[nextLogGroupId].Reset();

--- a/src/journal_manager/log_buffer/log_group_footer_write_event.cpp
+++ b/src/journal_manager/log_buffer/log_group_footer_write_event.cpp
@@ -60,14 +60,16 @@ LogGroupFooterWriteEvent::Execute(void)
     int result = logBuffer->InternalIo(context);
     if (result != 0)
     {
-        POS_TRACE_DEBUG(EID(JOUNRAL_WRITE_LOG_GROUP_FOOTER),
-            "Failed to write log group footer");
+        POS_TRACE_WARN(EID(JOURNAL_WRITE_LOG_GROUP_FOOTER),
+            "Failed to write log group footer, logGroupId:{}, lastCheckpointedSeginfoVersion: {}, isReseted:{}, resetedSequenceNumber: {}",
+            logGroupId, footer.lastCheckpointedSeginfoVersion, footer.isReseted, footer.resetedSequenceNumber);
         return false;
     }
     else
     {
-        POS_TRACE_DEBUG(EID(JOUNRAL_WRITE_LOG_GROUP_FOOTER),
-            "Write log group footer (id {}, version {})", logGroupId, footer.lastCheckpointedSeginfoVersion);
+        POS_TRACE_INFO(EID(JOURNAL_WRITE_LOG_GROUP_FOOTER),
+            "logGroupId:{}, lastCheckpointedSeginfoVersion: {}, isReseted:{}, resetedSequenceNumber: {}",
+            logGroupId, footer.lastCheckpointedSeginfoVersion, footer.isReseted, footer.resetedSequenceNumber);
         return true;
     }
 }

--- a/src/journal_manager/log_buffer/reset_log_group.cpp
+++ b/src/journal_manager/log_buffer/reset_log_group.cpp
@@ -51,19 +51,6 @@ bool
 ResetLogGroup::Execute(void)
 {
     EventSmartPtr event(new LogGroupFooterWriteEvent(logBuffer, footer, footerOffset, logGroupId, callback));
-    bool result = event->Execute();
-    if (result != true)
-    {
-        POS_TRACE_ERROR(EID(JOUNRAL_WRITE_LOG_GROUP_FOOTER),
-            "Failed to reset log group using log group footer");
-        return false;
-    }
-    else
-    {
-        POS_TRACE_DEBUG(EID(JOUNRAL_WRITE_LOG_GROUP_FOOTER),
-            "Success to reset log group using log group footer (LogGroupId {}, seqNum {})", logGroupId, footer.resetedSequenceNumber);
-        return true;
-    }
-    return 0;
+    return event->Execute();
 }
 } // namespace pos

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -202,7 +202,7 @@ VersionedSegmentCtx::ResetFlushedInfo(int logGroupId)
     _CheckLogGroupIdValidity(logGroupId);
     segmentInfoDiffs[logGroupId]->Reset();
 
-    POS_TRACE_INFO(EID(JOURNAL_CHECKPOINT_COMPLETED), "Versioned segment info is flushed, logGroup {}", logGroupId);
+    POS_TRACE_INFO(EID(VERSIONED_SEGMENT_INFO), "Versioned segment info is flushed, logGroupId:{}", logGroupId);
 }
 
 int

--- a/src/journal_manager/log_write/buffer_offset_allocator.cpp
+++ b/src/journal_manager/log_write/buffer_offset_allocator.cpp
@@ -125,8 +125,8 @@ BufferOffsetAllocator::AllocateBuffer(uint32_t logSize, uint64_t& allocatedOffse
     {
         statusList[currentLogGroupId]->SetActive(_GetNextSeqNum());
 
-        POS_TRACE_DEBUG(EID(JOURNAL_DEBUG),
-            "New log group {} is allocated", currentLogGroupId);
+        POS_TRACE_INFO(EID(JOURNAL_LOG_GROUP_ALLOCATED),
+            "logGroupId:{}", currentLogGroupId);
     }
 
     uint64_t offset = 0;
@@ -168,8 +168,8 @@ BufferOffsetAllocator::_GetNewActiveGroup(void)
     else
     {
         statusList[currentLogGroupId]->SetActive(_GetNextSeqNum());
-        POS_TRACE_DEBUG(EID(JOURNAL_DEBUG),
-            "New log group {} is allocated", currentLogGroupId);
+        POS_TRACE_INFO(EID(JOURNAL_LOG_GROUP_ALLOCATED),
+            "logGroupId:{}", currentLogGroupId);
         return 0;
     }
 }
@@ -188,9 +188,6 @@ BufferOffsetAllocator::_TryToSetFull(int id)
     {
         uint32_t sequenceNumber = statusList[id]->GetSeqNum();
         releaser->MarkLogGroupFull(id, sequenceNumber);
-
-        POS_TRACE_DEBUG(EID(JOURNAL_LOG_GROUP_FULL),
-            "Log group id {} is added to full log group", id);
     }
 }
 

--- a/src/journal_manager/log_write/log_group_buffer_status.cpp
+++ b/src/journal_manager/log_write/log_group_buffer_status.cpp
@@ -122,8 +122,8 @@ LogGroupBufferStatus::TryToSetFull(void)
         _SetStatus(LogGroupStatus::FULL);
 
         POS_TRACE_DEBUG(EID(JOURNAL_LOG_GROUP_FULL),
-            "Log group is fully filled, added {} filled {}",
-            numLogsAdded, numLogsFilled);
+            "sequenceNumber:{}, added:{}, filled:{}",
+            seqNum, numLogsAdded, numLogsFilled);
 
         return true;
     }

--- a/src/mapper/map/map_header.cpp
+++ b/src/mapper/map/map_header.cpp
@@ -89,7 +89,7 @@ MapHeader::CopyToBuffer(char* buffer)
     header->numTotalMpages = mPageMap->GetNumBits();
     header->numUsedBlks = numUsedBlks;
     header->age = ++age;
-    POS_TRACE_INFO(EID(MAPPER_INFO), "[Mapper MapHeader] Load, age:{}, numValidPgs:{}, numUsedBlks:{}", header->age, header->numValidMpages, header->numUsedBlks);
+    POS_TRACE_INFO(EID(COPY_MAP_HEADER), "mapId:{}, age:{}, numValidPgs:{}, numUsedBlks:{}", mapId, header->age, header->numValidMpages, header->numUsedBlks);
     memcpy((buffer + sizeof(MpageInfo)), (void*)mPageMap->GetMapAddr(), mPageMap->GetNumEntry() * BITMAP_ENTRY_SIZE);
     return 0;
 }

--- a/src/mapper/map/map_io_handler.cpp
+++ b/src/mapper/map/map_io_handler.cpp
@@ -255,14 +255,13 @@ MapIoHandler::FlushTouchedPages(EventSmartPtr callback)
     delete copiedBitmap;
     if (touchedPages->GetNumBitsSet() != 0)
     {
-        POS_TRACE_DEBUG(EID(MAP_FLUSH_STARTED), "[MAPPER FlushTouchedPages mapId:{}] started", mapId);
         numPagesToAsyncIo = touchedPages->GetNumBitsSet();
         std::unique_ptr<SequentialPageFinder> sequentialPages = std::make_unique<SequentialPageFinder>(touchedPages);
         _Flush(std::move(sequentialPages));
     }
     else
     {
-        POS_TRACE_DEBUG(EID(MAP_FLUSH_COMPLETED), "[MAPPER FlushTouchedPages mapId:{}] completed, W/O any pages to flush", mapId);
+        POS_TRACE_DEBUG(EID(MAP_FLUSH_COMPLETED), "mapId:{}, numPagesToAsyncIo:0", mapId);
         _CompleteFlush();
         // TODO(r.saraf) Handle callback returning false value (callback executed in _CompleteFlush)
     }
@@ -483,7 +482,7 @@ int
 MapIoHandler::_IssueFlushHeader(void)
 {
     status = FLUSHING_HEADER;
-    POS_TRACE_DEBUG(EID(MAP_FLUSH_ONGOING), "Starting Flush mapId:{} Header", mapId);
+    POS_TRACE_DEBUG(EID(MAP_FLUSH_ONGOING), "Flush map header, mapId:{}", mapId);
 
     MapFlushIoContext* headerFlushReq = new MapFlushIoContext();
     headerFlushReq->opcode = MetaFsIoOpcode::Write;
@@ -518,7 +517,7 @@ MapIoHandler::_MpageFlushed(AsyncMetaFileIoCtx* ctx)
     int ret = EID(SUCCESS);
     bool flushCompleted = _IncreaseAsyncIoDonePageNum(numMpages);
 
-    POS_TRACE_DEBUG(EID(MAP_FLUSH_ONGOING), "Map {} startMpage {} numMpages {} flush completed ", mapId, startMpage, numMpages);
+    POS_TRACE_DEBUG(EID(MAP_FLUSH_ONGOING), "Mpage flushed, Map:{}, startMpage:{}, numMpages:{}", mapId, startMpage, numMpages);
 
     // After mpage flushing, Flush header data
     if (flushCompleted)
@@ -558,7 +557,7 @@ MapIoHandler::_HeaderFlushed(AsyncMetaFileIoCtx* ctx)
         // mpage & header flush done
         status = FLUSHING_DONE;
         _ResetAsyncIoPageNum();
-        POS_TRACE_DEBUG(EID(MAP_FLUSH_COMPLETED), "mapId:{} Flush Completed", mapId);
+        POS_TRACE_DEBUG(EID(MAP_FLUSH_COMPLETED), "Header flushed, mapId:{}", mapId);
     }
 
     _CompleteFlush();

--- a/src/mapper/stripemap/stripemap_manager.cpp
+++ b/src/mapper/stripemap/stripemap_manager.cpp
@@ -194,7 +194,7 @@ StripeMapManager::FlushTouchedPages(EventSmartPtr cb)
 {
     if (numWriteIssuedCount != 0)
     {
-        POS_TRACE_DEBUG(EID(MAP_FLUSH_COMPLETED), "[MAPPER StripeMap FlushTouchedPages] Failed to Issue Flush, Another Flush is still progressing, issuedCount:{}", numWriteIssuedCount);
+        POS_TRACE_DEBUG(EID(MAP_FLUSH_COMPLETED), "Failed to Issue Flush. Another Flush is still progressing, issuedCount:{}", numWriteIssuedCount);
         return ERRID(MAP_FLUSH_IN_PROGRESS);
     }
 
@@ -205,7 +205,7 @@ StripeMapManager::FlushTouchedPages(EventSmartPtr cb)
     POSMetricValue v;
     v.gauge = numWriteIssuedCount;
     tp->PublishData(TEL33009_MAP_STRIPE_FLUSH_PENDINGIO_CNT, v, MT_GAUGE);
-    POS_TRACE_INFO(EID(MAPPER_INFO), "[Mapper StripeMap FlushTouchedPages] Issue Flush StripeMap, array:{}, arrayId:{}",
+    POS_TRACE_INFO(EID(MAP_FLUSH_STARTED), "map:stripemap, array:{}, arrayId:{}",
         addrInfo->GetArrayName(), addrInfo->GetArrayId());
     int ret = stripeMap->FlushTouchedPages(eventStripeMap);
     if (ret < 0)
@@ -221,8 +221,9 @@ StripeMapManager::FlushTouchedPages(EventSmartPtr cb)
 void
 StripeMapManager::MapFlushDone(int mapId)
 {
-    POS_TRACE_INFO(EID(MAP_FLUSH_COMPLETED), "[Mapper StripeMap] StripeMap Flush Done, WritePendingCnt:{} @MapAsyncFlushDone, array:{}, arrayId:{}",
-        numWriteIssuedCount, addrInfo->GetArrayName(), addrInfo->GetArrayId());
+    POS_TRACE_INFO(EID(MAP_FLUSH_COMPLETED),
+        "map:stripemap, mapId:{}, arrayId:{}, numWriteIssued:{}",
+        mapId, addrInfo->GetArrayId(), numWriteIssuedCount);
     if (callback != nullptr)
     {
         eventScheduler->EnqueueEvent(callback);

--- a/src/mapper/vsamap/vsamap_manager.cpp
+++ b/src/mapper/vsamap/vsamap_manager.cpp
@@ -260,10 +260,10 @@ VSAMapManager::FlushTouchedPages(int volId, EventSmartPtr cb)
 {
     if (mapFlushState[volId] != MapFlushState::FLUSH_DONE)
     {
-        POS_TRACE_DEBUG(EID(MAP_FLUSH_COMPLETED), "[MAPPER VSAMap FlushTouchedPages] Failed to Issue Flush, Another Flush is still progressing in volume:{}, issuedCount:{}", volId, numWriteIssuedCount);
+        POS_TRACE_DEBUG(EID(MAP_FLUSH_COMPLETED), "Failed to Issue Flush, Another Flush is still progressing, volume:{}, issuedCount:{}", volId, numWriteIssuedCount);
         return ERRID(MAP_FLUSH_IN_PROGRESS);
     }
-    POS_TRACE_INFO(EID(MAPPER_INFO), "[Mapper VSAMap FlushTouchedPages] Issue Flush VSAMap, volume :{}, arrayId:{}", volId, addrInfo->GetArrayId());
+    POS_TRACE_INFO(EID(MAP_FLUSH_STARTED), "map:vsamap, volume:{}, arrayId:{}", volId, addrInfo->GetArrayId());
     assert(vsaMaps[volId] != nullptr);
     assert(vsaMaps[volId]->GetCallback() == nullptr);
     vsaMaps[volId]->SetCallback(cb);
@@ -281,11 +281,11 @@ VSAMapManager::FlushTouchedPages(int volId, EventSmartPtr cb)
         numWriteIssuedCount--;
         v.gauge = numWriteIssuedCount;
         tp->PublishData(TEL33008_MAP_VSA_FLUSH_PENDINGIO_CNT, v, MT_GAUGE);
-        POS_TRACE_ERROR(EID(MAPPER_FAILED), "[Mapper VSAMap FlushTouchedPages] failed to flush vsamap, volumeId:{}, arrayId:{}", volId, addrInfo->GetArrayId());
+        POS_TRACE_ERROR(EID(MAP_FLUSH_FAILED), "map:vsamap, volumeId:{}, arrayId:{}", volId, addrInfo->GetArrayId());
     }
     else
     {
-        POS_TRACE_INFO(EID(MAPPER_SUCCESS), "[Mapper VSAMap FlushTouchedPages] flush vsamp started volumeId:{}, arrayId:{}", volId, addrInfo->GetArrayId());
+        POS_TRACE_INFO(EID(MAP_FLUSH_ONGOING), "map:vsamap, volumeId:{}, arrayId:{}", volId, addrInfo->GetArrayId());
     }
     return ret;
 }
@@ -313,14 +313,8 @@ VSAMapManager::FlushAllMaps(void)
                 POSMetricValue v;
                 v.gauge = numWriteIssuedCount;
                 tp->PublishData(TEL33008_MAP_VSA_FLUSH_PENDINGIO_CNT, v, MT_GAUGE);
-                POS_TRACE_ERROR(EID(MAPPER_FAILED),
-                    "[Mapper VSAMap FlushAllMaps] failed to flush vsamap, volumeId:{}, arrayId:{}",
-                    volId, addrInfo->GetArrayId());
-            }
-            else
-            {
-                POS_TRACE_INFO(EID(MAPPER_SUCCESS),
-                    "[Mapper VSAMap FlushAllMaps] flush vsamp started volumeId:{}, arrayId:{}",
+                POS_TRACE_ERROR(EID(MAP_FLUSH_FAILED),
+                    "map:vsamap, volumeId:{}, arrayId:{}",
                     volId, addrInfo->GetArrayId());
             }
         }
@@ -403,8 +397,8 @@ void
 VSAMapManager::MapFlushDone(int mapId)
 {
     POS_TRACE_INFO(EID(MAP_FLUSH_COMPLETED),
-        "[Mapper VSAMap] arrayId:{} mapId:{} WritePendingCnt:{} Flushed Done",
-        addrInfo->GetArrayId(), mapId, numWriteIssuedCount);
+        "map:vsamap, mapId:{}, arrayId:{}, numWriteIssued:{}",
+        mapId, addrInfo->GetArrayId(), numWriteIssuedCount);
     EventSmartPtr callback = vsaMaps[mapId]->GetCallback();
     if (callback != nullptr)
     {


### PR DESCRIPTION
Journaling, Checkpointing 과정의 log message들 리뷰하고 수정하였습니다.
structured logging 포맷대로 variable을 넣어보았습니다 ㅎㅎ

분석할 때 보실만 할지 의견 주시면 감사하겠습니다 ㅎㅎ 

**수정 결과 로그 (info level)** 
debug level 결과는 AWIBOF-7266 에 첨부해두었습니다.
```
[2022-11-04 05:15:13.102158709][31239][31240][62709859][3006][ info  ]  JOURNAL_READY - NONE (cause: NONE, solution: NONE, variables: status changed current_state:0, prev_state:4, prev_state_repeat_count:0 times), source: journal_writer.cpp:100 _CanBeWritten(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:13.102177198][31239][31240][62709859][3039][ info  ]  JOURNAL_LOG_GROUP_ALLOCATED - NONE (cause: NONE, solution: NONE, variables: logGroupId:0), source: log_write/buffer_offset_allocator.cpp:129 AllocateBuffer(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:14.059420003][31239][31253][62709859][9511][ info  ]  TELEMETRY_CLIENT_PUBLISHREQUEST_SEND_FAILURE - Failed to send PublishRequest by gRPC. (cause: NONE, solution: NONE, variables: publish_failure_count:101, grpc_status_errorcode:14, grpc_status_errormsg:failed to connect to all addresses), source: /home/huijeong/workspace/poseidonos/ibofos2/src/telemetry/telemetry_client/grpc_global_publisher.cpp:144 _Se
[2022-11-04 05:15:16.344152026][31239][31254][62709859][9511][ info  ]  TELEMETRY_CLIENT_PUBLISHREQUEST_SEND_FAILURE - Failed to send PublishRequest by gRPC. (cause: NONE, solution: NONE, variables: publish_failure_count:101, grpc_status_errorcode:14, grpc_status_errormsg:failed to connect to all addresses), source: /home/huijeong/workspace/poseidonos/ibofos2/src/telemetry/telemetry_client/grpc_global_publisher.cpp:144 _Se
[2022-11-04 05:15:19.060445578][31239][31255][62709859][9511][ info  ]  TELEMETRY_CLIENT_PUBLISHREQUEST_SEND_FAILURE - Failed to send PublishRequest by gRPC. (cause: NONE, solution: NONE, variables: publish_failure_count:101, grpc_status_errorcode:14, grpc_status_errormsg:failed to connect to all addresses), source: /home/huijeong/workspace/poseidonos/ibofos2/src/telemetry/telemetry_client/grpc_global_publisher.cpp:144 _Se
[2022-11-04 05:15:22.065642294][31239][31255][62709859][9511][ info  ]  TELEMETRY_CLIENT_PUBLISHREQUEST_SEND_FAILURE - Failed to send PublishRequest by gRPC. (cause: NONE, solution: NONE, variables: publish_failure_count:101, grpc_status_errorcode:14, grpc_status_errormsg:failed to connect to all addresses), source: /home/huijeong/workspace/poseidonos/ibofos2/src/telemetry/telemetry_client/grpc_global_publisher.cpp:144 _Se
[2022-11-04 05:15:25.068787711][31239][31255][62709859][9511][ info  ]  TELEMETRY_CLIENT_PUBLISHREQUEST_SEND_FAILURE - Failed to send PublishRequest by gRPC. (cause: NONE, solution: NONE, variables: publish_failure_count:101, grpc_status_errorcode:14, grpc_status_errormsg:failed to connect to all addresses), source: /home/huijeong/workspace/poseidonos/ibofos2/src/telemetry/telemetry_client/grpc_global_publisher.cpp:144 _Se
[2022-11-04 05:15:28.071986719][31239][31255][62709859][9511][ info  ]  TELEMETRY_CLIENT_PUBLISHREQUEST_SEND_FAILURE - Failed to send PublishRequest by gRPC. (cause: NONE, solution: NONE, variables: publish_failure_count:101, grpc_status_errorcode:14, grpc_status_errormsg:failed to connect to all addresses), source: /home/huijeong/workspace/poseidonos/ibofos2/src/telemetry/telemetry_client/grpc_global_publisher.cpp:144 _Se
[2022-11-04 05:15:31.075096611][31239][31255][62709859][9511][ info  ]  TELEMETRY_CLIENT_PUBLISHREQUEST_SEND_FAILURE - Failed to send PublishRequest by gRPC. (cause: NONE, solution: NONE, variables: publish_failure_count:101, grpc_status_errorcode:14, grpc_status_errormsg:failed to connect to all addresses), source: /home/huijeong/workspace/poseidonos/ibofos2/src/telemetry/telemetry_client/grpc_global_publisher.cpp:144 _Se
[2022-11-04 05:15:34.078352030][31239][31255][62709859][9511][ info  ]  TELEMETRY_CLIENT_PUBLISHREQUEST_SEND_FAILURE - Failed to send PublishRequest by gRPC. (cause: NONE, solution: NONE, variables: publish_failure_count:101, grpc_status_errorcode:14, grpc_status_errormsg:failed to connect to all addresses), source: /home/huijeong/workspace/poseidonos/ibofos2/src/telemetry/telemetry_client/grpc_global_publisher.cpp:144 _Se
[2022-11-04 05:15:36.770861595][31239][31240][62709859][3039][ info  ]  JOURNAL_LOG_GROUP_ALLOCATED - NONE (cause: NONE, solution: NONE, variables: logGroupId:1), source: log_write/buffer_offset_allocator.cpp:172 _GetNewActiveGroup(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.771797480][31239][31253][62709859][3031][ info  ]  JOURNAL_RELEASE_LOG_GROUP_STARTED - NONE (cause: NONE, solution: NONE, variables: logGroupId:0, sequenceNumber:0), source: checkpoint/log_group_releaser.cpp:116 _FlushNextLogGroup(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.771803890][31239][31253][62709859][3032][ info  ]  JOURNAL_CHECKPOINT_STARTED - NONE (cause: NONE, solution: NONE, variables: logGroupId:0), source: checkpoint/log_group_releaser.cpp:135 _TriggerCheckpoint(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.773314829][31239][31253][62709859][3041][ info  ]  JOURNAL_CHECKPOINT_FLUSH_METADATA - NONE (cause: NONE, solution: NONE, variables: logGroupId:0, numMapsToFlush:3, arrayId:0), source: checkpoint/checkpoint_handler.cpp:102 Start(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.773325828][31239][31253][62709859][3101][ info  ]  MAP_FLUSH_STARTED - NONE (cause: NONE, solution: NONE, variables: map:vsamap, volume:1, arrayId:0), source: /home/huijeong/workspace/poseidonos/ibofos2/src/mapper/vsamap/vsamap_manager.cpp:266 FlushTouchedPages(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.773373193][31239][31253][62709859][3116][ info  ]  COPY_MAP_HEADER - NONE (cause: NONE, solution: NONE, variables: mapId:1, age:2, numValidPgs:10, numUsedBlks:4554), source: /home/huijeong/workspace/poseidonos/ibofos2/src/mapper/map/map_header.cpp:92 CopyToBuffer(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.773388128][31239][31253][62709859][3103][ info  ]  MAP_FLUSH_ONGOING - NONE (cause: NONE, solution: NONE, variables: map:vsamap, volumeId:1, arrayId:0), source: /home/huijeong/workspace/poseidonos/ibofos2/src/mapper/vsamap/vsamap_manager.cpp:288 FlushTouchedPages(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.773393133][31239][31253][62709859][3101][ info  ]  MAP_FLUSH_STARTED - NONE (cause: NONE, solution: NONE, variables: map:vsamap, volume:0, arrayId:0), source: /home/huijeong/workspace/poseidonos/ibofos2/src/mapper/vsamap/vsamap_manager.cpp:266 FlushTouchedPages(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.773420849][31239][31253][62709859][3116][ info  ]  COPY_MAP_HEADER - NONE (cause: NONE, solution: NONE, variables: mapId:0, age:2, numValidPgs:10, numUsedBlks:4664), source: /home/huijeong/workspace/poseidonos/ibofos2/src/mapper/map/map_header.cpp:92 CopyToBuffer(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.773428370][31239][31253][62709859][3103][ info  ]  MAP_FLUSH_ONGOING - NONE (cause: NONE, solution: NONE, variables: map:vsamap, volumeId:0, arrayId:0), source: /home/huijeong/workspace/poseidonos/ibofos2/src/mapper/vsamap/vsamap_manager.cpp:288 FlushTouchedPages(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.773455965][31239][31253][62709859][3101][ info  ]  MAP_FLUSH_STARTED - NONE (cause: NONE, solution: NONE, variables: map:stripe, array:POSArray0, arrayId:0), source: /home/huijeong/workspace/poseidonos/ibofos2/src/mapper/stripemap/stripemap_manager.cpp:209 FlushTouchedPages(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.773462982][31239][31253][62709859][3116][ info  ]  COPY_MAP_HEADER - NONE (cause: NONE, solution: NONE, variables: mapId:-1, age:2, numValidPgs:1, numUsedBlks:0), source: /home/huijeong/workspace/poseidonos/ibofos2/src/mapper/map/map_header.cpp:92 CopyToBuffer(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.773472053][31239][31253][62709859][3150][ info  ]  ALLOCATOR_META_ARCHIVE_STORE - NONE (cause: NONE, solution: NONE, variables: Started, sync:false), source: /home/huijeong/workspace/poseidonos/ibofos2/src/allocator/context_manager/context_io_manager.cpp:135 FlushContexts(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.773544857][31239][31253][62709859][9511][ info  ]  TELEMETRY_CLIENT_PUBLISHREQUEST_SEND_FAILURE - Failed to send PublishRequest by gRPC. (cause: NONE, solution: NONE, variables: publish_failure_count:101, grpc_status_errorcode:14, grpc_status_errormsg:failed to connect to all addresses), source: /home/huijeong/workspace/poseidonos/ibofos2/src/telemetry/telemetry_client/grpc_global_publisher.cpp:144 _Se
[2022-11-04 05:15:36.776736769][31239][31245][62709859][3068][ info  ]  VERSIONED_SEGMENT_INFO - NONE (cause: NONE, solution: NONE, variables: ResetFlushedInfo, logGroupId:0), source: /home/huijeong/workspace/poseidonos/ibofos2/src/allocator/context_manager/context_manager.cpp:258 ResetFlushedInfo(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.776771694][31239][31245][62709859][3042][ info  ]  JOURNAL_CHECKPOINT_FLUSH_COMPLETED - NONE (cause: NONE, solution: NONE, variables: metaId:1000, numMapsFlushed:false, allocatorCompleted:true, arrayId:0), source: checkpoint/checkpoint_handler.cpp:165 FlushCompleted(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.777585035][31239][31247][62709859][3104][ info  ]  MAP_FLUSH_COMPLETED - NONE (cause: NONE, solution: NONE, variables: map:stripemap, arrayId:0, numWriteIssued:1), source: /home/huijeong/workspace/poseidonos/ibofos2/src/mapper/stripemap/stripemap_manager.cpp:226 MapFlushDone(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.777649226][31239][31245][62709859][3042][ info  ]  JOURNAL_CHECKPOINT_FLUSH_COMPLETED - NONE (cause: NONE, solution: NONE, variables: metaId:-1, numMapsFlushed:false, allocatorCompleted:true, arrayId:0), source: checkpoint/checkpoint_handler.cpp:165 FlushCompleted(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.778266355][31239][31247][62709859][3104][ info  ]  MAP_FLUSH_COMPLETED - NONE (cause: NONE, solution: NONE, variables: map:vsamap, mapId:0, arrayId:0, numWriteIssued:2), source: /home/huijeong/workspace/poseidonos/ibofos2/src/mapper/vsamap/vsamap_manager.cpp:401 MapFlushDone(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.778388050][31239][31245][62709859][3042][ info  ]  JOURNAL_CHECKPOINT_FLUSH_COMPLETED - NONE (cause: NONE, solution: NONE, variables: metaId:0, numMapsFlushed:false, allocatorCompleted:true, arrayId:0), source: checkpoint/checkpoint_handler.cpp:165 FlushCompleted(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.778698519][31239][31246][62709859][3104][ info  ]  MAP_FLUSH_COMPLETED - NONE (cause: NONE, solution: NONE, variables: map:vsamap, mapId:1, arrayId:0, numWriteIssued:1), source: /home/huijeong/workspace/poseidonos/ibofos2/src/mapper/vsamap/vsamap_manager.cpp:401 MapFlushDone(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.778776791][31239][31245][62709859][3042][ info  ]  JOURNAL_CHECKPOINT_FLUSH_COMPLETED - NONE (cause: NONE, solution: NONE, variables: metaId:1, numMapsFlushed:true, allocatorCompleted:true, arrayId:0), source: checkpoint/checkpoint_handler.cpp:165 FlushCompleted(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.778790613][31239][31245][62709859][3034][ info  ]  JOURNAL_CHECKPOINT_COMPLETED - NONE (cause: NONE, solution: NONE, variables: logGroupId:0, arrayId:0), source: checkpoint/checkpoint_handler.cpp:179 _TryToComplete(), pos_version: v0.12.0-rc2
[2022-11-04 05:15:36.780026172][31239][31253][62709859][3043][ info  ]  JOURNAL_RELEASE_LOG_GROUP_COMPLETED - NONE (cause: NONE, solution: NONE, variables: logGroupId:0), source: checkpoint/log_group_releaser.cpp:180 LogGroupResetCompleted(), pos_version: v0.12.0-rc2
```
