### PR TITLE
[SHPOS-996] Fix performance degregation due to array info lock

### DIFF
--- a/src/bio/volume_io.h
+++ b/src/bio/volume_io.h
@@ -36,7 +36,7 @@
 #include <string>
 #include <vector>
 
-#include "src/array_mgmt/interface/i_array_mgmt.h"
+#include "src/volume/i_volume_info_manager.h"
 #include "src/bio/ubio.h"
 #include "src/include/smart_ptr_type.h"
 
@@ -72,9 +72,8 @@ public:
 
     VolumeIo(void) = delete;
     VolumeIo(void* buffer, uint32_t unitCount, int arrayId);
-    VolumeIo(void* buffer, uint32_t unitCount, int arrayId, IArrayMgmt* arrayMgmt);
+    VolumeIo(void* buffer, uint32_t unitCount, int arrayId, IVolumeInfoManager* volumeManager);
     VolumeIo(const VolumeIo& volumeIo);
-    VolumeIo(const VolumeIo& volumeIo, IArrayMgmt* arrayMgmt);
     ~VolumeIo(void) override;
 
     virtual VolumeIoSmartPtr Split(uint32_t sectors, bool removalFromTail);
@@ -106,7 +105,7 @@ private:
     VirtualBlkAddr vsa;
     uint64_t sectorRba;
     StripeId stripeId;
-    IArrayMgmt* arrayMgmt;
+    IVolumeInfoManager* volumeManager;
 
     bool _IsInvalidVolumeId(uint32_t inputVolumeId);
     virtual bool _IsInvalidLsidEntry(StripeAddr& inputLsidEntry);

--- a/src/io/frontend_io/read_completion_for_partial_write.cpp
+++ b/src/io/frontend_io/read_completion_for_partial_write.cpp
@@ -45,6 +45,7 @@
 #include "src/logger/logger.h"
 #include "src/spdk_wrapper/accel_engine_api.h"
 #include "src/spdk_wrapper/event_framework_api.h"
+#include "src/volume/volume_service.h"
 namespace pos
 {
 ReadCompletionForPartialWrite::ReadCompletionForPartialWrite(
@@ -122,8 +123,9 @@ ReadCompletionForPartialWrite::HandleCopyDone(void* argument)
                 volumeIo->SetCallback(splitCallback);
                 if (likely(copyParam->tested == false))
                 {
-                    IArrayInfo* arrayInfo = ArrayMgr()->GetInfo(volumeIo->GetArrayId())->arrayInfo;
-                    if (true == arrayInfo->IsWriteThroughEnabled())
+                    int arrayId = volumeIo->GetArrayId();
+                    bool wtEnabled = VolumeServiceSingleton::Instance()->GetVolumeManager(arrayId)->IsWriteThroughEnabled();
+                    if (true == wtEnabled)
                     {
                         WriteForParity writeForParity(volumeIo);
                         bool ret = writeForParity.Execute();

--- a/src/io/frontend_io/write_completion.cpp
+++ b/src/io/frontend_io/write_completion.cpp
@@ -55,17 +55,17 @@ WriteCompletion::WriteCompletion(VolumeIoSmartPtr input)
 : WriteCompletion(input,
       AllocatorServiceSingleton::Instance()->GetIWBStripeAllocator(input.get()->GetArrayId()),
       EventFrameworkApiSingleton::Instance()->IsReactorNow(),
-      ArrayMgr())
+      VolumeServiceSingleton::Instance()->GetVolumeManager(input.get()->GetArrayId()))
 {
 }
 
 WriteCompletion::WriteCompletion(VolumeIoSmartPtr input,
     IWBStripeAllocator* iWBStripeAllocator, bool isReactorNow,
-    IArrayMgmt* arrayMgr)
+    IVolumeInfoManager* iVolumeInfoManager)
 : Callback(isReactorNow, CallbackType_WriteCompletion),
   volumeIo(input),
   iWBStripeAllocator(iWBStripeAllocator),
-  arrayMgr(arrayMgr)
+  volumeManager(iVolumeInfoManager)
 {
 }
 
@@ -142,8 +142,7 @@ bool
 WriteCompletion::_RequestFlush(Stripe* stripe)
 {
     bool requestFlushSuccessful = true;
-    IArrayInfo* arrayInfo = arrayMgr->GetInfo(volumeIo->GetArrayId())->arrayInfo;
-    bool parityOnly = arrayInfo->IsWriteThroughEnabled();
+    bool parityOnly = volumeManager->IsWriteThroughEnabled();
     if (stripe->IsActiveFlushTarget() == true)
     {
         parityOnly = false;

--- a/src/io/frontend_io/write_completion.h
+++ b/src/io/frontend_io/write_completion.h
@@ -32,9 +32,9 @@
 
 #pragma once
 
-#include "src/array_mgmt/interface/i_array_mgmt.h"
 #include "src/bio/volume_io.h"
 #include "src/event_scheduler/callback.h"
+#include "src/volume/i_volume_info_manager.h"
 
 namespace pos
 {
@@ -47,7 +47,7 @@ class WriteCompletion : public Callback
 public:
     WriteCompletion(VolumeIoSmartPtr inputVolumeIo);
     WriteCompletion(VolumeIoSmartPtr inputVolumeIo,
-        IWBStripeAllocator* iWBStripeAllocator, bool isReactorNow, IArrayMgmt* arrayMgr);
+        IWBStripeAllocator* iWBStripeAllocator, bool isReactorNow, IVolumeInfoManager* volumeManager);
     ~WriteCompletion(void) override;
 
 private:
@@ -57,6 +57,6 @@ private:
 
     VolumeIoSmartPtr volumeIo;
     IWBStripeAllocator* iWBStripeAllocator;
-    IArrayMgmt* arrayMgr;
+    IVolumeInfoManager* volumeManager;
 };
 } // namespace pos

--- a/src/io/frontend_io/write_submission.h
+++ b/src/io/frontend_io/write_submission.h
@@ -45,6 +45,7 @@
 #include "src/io/general_io/io_controller.h"
 #include "src/lib/block_alignment.h"
 #include "src/spdk_wrapper/event_framework_api.h"
+#include "src/volume/i_volume_info_manager.h"
 
 namespace pos
 {
@@ -61,7 +62,7 @@ class WriteSubmission : public IOController, public Event
 public:
     explicit WriteSubmission(VolumeIoSmartPtr volumeIo);
     WriteSubmission(VolumeIoSmartPtr volumeIo, RBAStateManager* rbaStateManager,
-        IBlockAllocator* iBlockAllocator, FlowControl* flowControl, IArrayInfo* arrayInfo,
+        IBlockAllocator* iBlockAllocator, FlowControl* flowControl, IVolumeInfoManager* volumeManager,
         bool isReactorNow);
     ~WriteSubmission(void) override;
 
@@ -79,7 +80,7 @@ private:
     RBAStateManager* rbaStateManager;
     IBlockAllocator* iBlockAllocator;
     FlowControl* flowControl;
-    IArrayInfo* arrayInfo;
+    IVolumeInfoManager* volumeManager;
 
     void _SendVolumeIo(VolumeIoSmartPtr volumeIo);
     bool _ProcessOwnedWrite(void);

--- a/src/io/general_io/translator.h
+++ b/src/io/general_io/translator.h
@@ -37,7 +37,7 @@
 
 #include "src/allocator/i_wbstripe_allocator.h"
 #include "src/array/service/io_translator/io_translator.h"
-#include "src/array_models/interface/i_array_info.h"
+#include "src/volume/i_volume_info_manager.h"
 #include "src/include/address_type.h"
 #include "src/include/partition_type.h"
 #include "src/mapper/i_stripemap.h"
@@ -51,9 +51,9 @@ public:
     Translator(uint32_t volumeId, BlkAddr startRba, uint32_t blockCount,
         int arrayId, bool isRead = false, IVSAMap* iVSAMap = nullptr,
         IStripeMap* iStripeMap = nullptr, IWBStripeAllocator* iWBStripeAllocator = nullptr,
-        IIOTranslator* iTranslator = nullptr, IArrayInfo* arrayInfo = nullptr);
+        IIOTranslator* iTranslator = nullptr, IVolumeInfoManager* iVolumeManager= nullptr);
     Translator(uint32_t volumeId, BlkAddr rba, int arrayId, bool isRead);
-    Translator(const VirtualBlkAddr& vsa, int arrayId, StripeId userLsid = UNMAP_STRIPE, IArrayInfo* arrayInfo = nullptr);
+    Translator(const VirtualBlkAddr& vsa, int arrayId, StripeId userLsid = UNMAP_STRIPE);
     virtual ~Translator(void)
     {
     }
@@ -73,6 +73,7 @@ private:
     IStripeMap* iStripeMap{nullptr};
     IWBStripeAllocator* iWBStripeAllocator{nullptr};
     IIOTranslator* iTranslator{nullptr};
+    IVolumeInfoManager* iVolumeManager{nullptr};
     BlkAddr startRba;
     uint32_t blockCount;
     VsaArray vsaArray;
@@ -91,7 +92,6 @@ private:
     PartitionType _GetPartitionType(uint32_t blockIndex);
     int arrayId;
     StripeId userLsid;
-    IArrayInfo* arrayInfo;
 };
 
 } // namespace pos

--- a/src/volume/i_volume_info_manager.h
+++ b/src/volume/i_volume_info_manager.h
@@ -61,6 +61,7 @@ public:
     virtual VolumeBase* GetVolume(int volId) = 0;
 
     virtual std::string GetArrayName(void) = 0;
+    virtual bool IsWriteThroughEnabled(void) = 0;
 
     virtual int CheckVolumeValidity(std::string name) = 0;
     virtual int CheckVolumeValidity(int volId) = 0;

--- a/src/volume/volume_manager.cpp
+++ b/src/volume/volume_manager.cpp
@@ -90,7 +90,8 @@ VolumeManager::Init(void)
         TelemetryClientSingleton::Instance()->RegisterPublisher(tp);
     }
     result = VolumeServiceSingleton::Instance()->Register(arrayInfo->GetIndex(), this);
-
+    wtEnabled = arrayInfo->IsWriteThroughEnabled();
+ 
     _PublishTelemetryArrayUsage();
     return result;
 }
@@ -712,6 +713,12 @@ std::string
 VolumeManager::GetArrayName(void)
 {
     return arrayInfo->GetName();
+}
+
+bool
+VolumeManager::IsWriteThroughEnabled(void)
+{
+    return wtEnabled;
 }
 
 } // namespace pos

--- a/src/volume/volume_manager.h
+++ b/src/volume/volume_manager.h
@@ -100,6 +100,7 @@ public:
     int DecreasePendingIOCount(int volId, VolumeIoType volumeIoType, uint32_t ioCountCompleted = 1) override;
     VolumeBase* GetVolume(int volId) override;
     std::string GetArrayName(void) override;
+    bool IsWriteThroughEnabled(void) override;
 
     void StateChanged(StateContext* prev, StateContext* next) override;
 
@@ -126,6 +127,8 @@ private:
 
     std::mutex volumeEventLock;
     std::mutex volumeExceptionLock;
+
+    bool wtEnabled;
 };
 
 } // namespace pos

--- a/test/unit-tests/io/frontend_io/read_completion_for_partial_write_test.cpp
+++ b/test/unit-tests/io/frontend_io/read_completion_for_partial_write_test.cpp
@@ -2,13 +2,13 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "test/unit-tests/array_models/interface/i_array_info_mock.h"
 #include "test/unit-tests/bio/volume_io_mock.h"
 #include "test/unit-tests/event_scheduler/callback_mock.h"
 #include "test/unit-tests/allocator/i_wbstripe_allocator_mock.h"
 #include "test/unit-tests/io/general_io/translator_mock.h"
 #include "src/include/address_type.h"
 #include "src/include/smart_ptr_type.h"
+#include "test/unit-tests/volume/i_volume_info_manager_mock.h"
 
 using namespace std;
 using ::testing::_;
@@ -90,8 +90,7 @@ TEST(ReadCompletionForPartialWrite, ReadCompletionForPartialWrite_HandleCopyDone
     VolumeIoSmartPtr volumeIoOrigin(mockVolumeIoOrigin);
     StripeAddr stripeAddr = {.stripeLoc = IN_USER_AREA, .stripeId = 0};
     VirtualBlkAddr vsa = {.stripeId = 0, .offset = 0};
-    NiceMock<MockIArrayInfo>* iArrayInfo = new NiceMock<MockIArrayInfo>();
-    MockTranslator* translator = new NiceMock<MockTranslator>(vsa, volumeIo->GetArrayId(), iArrayInfo, UNMAP_STRIPE);
+    MockTranslator* translator = new NiceMock<MockTranslator>(vsa, volumeIo->GetArrayId(), UNMAP_STRIPE);
     CopyParameter* copyParameter = new CopyParameter(volumeIo, translator, true);
     BufferEntry bufferEntry((void *)0xff00, 1);
     PhysicalEntry physicalEntry;

--- a/test/unit-tests/io/frontend_io/read_submission_test.cpp
+++ b/test/unit-tests/io/frontend_io/read_submission_test.cpp
@@ -27,6 +27,7 @@
 #include "test/unit-tests/lib/block_alignment_mock.h"
 #include "test/unit-tests/mapper/i_stripemap_mock.h"
 #include "test/unit-tests/mapper/i_vsamap_mock.h"
+#include "test/unit-tests/volume/i_volume_info_manager_mock.h"
 
 using namespace pos;
 using namespace std;
@@ -53,9 +54,9 @@ TEST(ReadSubmission, ReadSubmission_Stack)
     NiceMock<MockIVSAMap> mockIVSAMap;
     NiceMock<MockIStripeMap> mockIStripeMap;
     NiceMock<MockIWBStripeAllocator> mockIWBStripeAllocator;
-    NiceMock<MockIArrayInfo> mockIArrayInfo;
+    NiceMock<MockIVolumeInfoManager> mockVolumeInfoManager;
 
-    MockTranslator* mockTranslator = new MockTranslator(1, blkAddr, 0, 0, true, &mockIVSAMap, &mockIStripeMap, &mockIWBStripeAllocator, nullptr, &mockIArrayInfo);
+    MockTranslator* mockTranslator = new MockTranslator(1, blkAddr, 0, 0, true, &mockIVSAMap, &mockIStripeMap, &mockIWBStripeAllocator, nullptr, &mockVolumeInfoManager);
 
     // When: Try to create new ReadSubmission object with 4 arguments
     ReadSubmission readSubmission{volumeIo, mockBlockAlignment, mockMerger, mockTranslator};
@@ -78,8 +79,9 @@ TEST(ReadSubmission, ReadSubmission_Heap)
     NiceMock<MockIVSAMap> mockIVSAMap;
     NiceMock<MockIStripeMap> mockIStripeMap;
     NiceMock<MockIWBStripeAllocator> mockIWBStripeAllocator;
-    NiceMock<MockIArrayInfo> mockIArrayInfo;
-    MockTranslator* mockTranslator = new MockTranslator(1, blkAddr, 0, 0, true, &mockIVSAMap, &mockIStripeMap, &mockIWBStripeAllocator, nullptr, &mockIArrayInfo);
+    NiceMock<MockIVolumeInfoManager> mockVolumeInfoManager;
+
+    MockTranslator* mockTranslator = new MockTranslator(1, blkAddr, 0, 0, true, &mockIVSAMap, &mockIStripeMap, &mockIWBStripeAllocator, nullptr, &mockVolumeInfoManager);
 
     // When: Try to create new ReadSubmission object with 4 arguments
     ReadSubmission* readSubmission = new ReadSubmission{volumeIo, mockBlockAlignment, mockMerger, mockTranslator};
@@ -106,8 +108,9 @@ TEST(ReadSubmission, Execute_SingleBlock)
     NiceMock<MockIVSAMap> mockIVSAMap;
     NiceMock<MockIStripeMap> mockIStripeMap;
     NiceMock<MockIWBStripeAllocator> mockIWBStripeAllocator;
-    NiceMock<MockIArrayInfo> mockIArrayInfo;
-    MockTranslator* mockTranslator = new MockTranslator(1, blkAddr, 0, 0, true, &mockIVSAMap, &mockIStripeMap, &mockIWBStripeAllocator, nullptr, &mockIArrayInfo);
+    NiceMock<MockIVolumeInfoManager> mockVolumeInfoManager;
+
+    MockTranslator* mockTranslator = new MockTranslator(1, blkAddr, 0, 0, true, &mockIVSAMap, &mockIStripeMap, &mockIWBStripeAllocator, nullptr, &mockVolumeInfoManager);
     ReadSubmission readSubmission{volumeIo, mockBlockAlignment, mockMerger, mockTranslator};
 
     ON_CALL(*mockBlockAlignment, GetBlockCount()).WillByDefault(Return(1));
@@ -157,8 +160,8 @@ TEST(ReadSubmission, Execute_MultiBlocks)
     NiceMock<MockIVSAMap> mockIVSAMap;
     NiceMock<MockIStripeMap> mockIStripeMap;
     NiceMock<MockIWBStripeAllocator> mockIWBStripeAllocator;
-    NiceMock<MockIArrayInfo> mockIArrayInfo;
-    MockTranslator* mockTranslator = new MockTranslator(1, blkAddr, 0, 0, true, &mockIVSAMap, &mockIStripeMap, &mockIWBStripeAllocator, nullptr, &mockIArrayInfo);
+    NiceMock<MockIVolumeInfoManager> mockVolumeInfoManager;
+    MockTranslator* mockTranslator = new MockTranslator(1, blkAddr, 0, 0, true, &mockIVSAMap, &mockIStripeMap, &mockIWBStripeAllocator, nullptr, &mockVolumeInfoManager);
     ReadSubmission readSubmission{volumeIo, mockBlockAlignment, mockMerger, mockTranslator};
 
     ON_CALL(*mockBlockAlignment, GetBlockCount()).WillByDefault(Return(2));

--- a/test/unit-tests/io/frontend_io/write_completion_test.cpp
+++ b/test/unit-tests/io/frontend_io/write_completion_test.cpp
@@ -11,6 +11,7 @@
 #include "test/unit-tests/io/general_io/rba_state_manager_mock.h"
 #include "test/unit-tests/event_scheduler/event_scheduler_mock.h"
 #include "test/unit-tests/mapper/i_reversemap_mock.h"
+#include "test/unit-tests/volume/i_volume_info_manager_mock.h"
 
 using namespace std;
 using ::testing::_;
@@ -48,7 +49,6 @@ TEST(WriteCompletion, WriteCompletion_OneArgument_Heap)
 TEST(WriteCompletion, WriteCompletion_FiveArgument_Stack)
 {
     //Given
-    NiceMock<MockIArrayMgmt> mockIArrayMgmt;
     VolumeIoSmartPtr volIo = VolumeIoSmartPtr(new NiceMock<MockVolumeIo>(nullptr, 1, 0));
     NiceMock<MockIWBStripeAllocator> mockIWBStripeAllocator;
 
@@ -76,7 +76,7 @@ TEST(WriteCompletion, _DoSpecificJob_NullStripe)
 {
     //Given
     bool actual;
-    NiceMock<MockIArrayMgmt> mockIArrayMgmt;
+    NiceMock<MockIVolumeInfoManager> mockVolumeInfoManager;
     auto mockVolIo = new NiceMock<MockVolumeIo>(nullptr, 1, 0);
     VolumeIoSmartPtr volIo = VolumeIoSmartPtr(mockVolIo);
     NiceMock<MockIWBStripeAllocator> mockIWBStripeAllocator;
@@ -91,7 +91,7 @@ TEST(WriteCompletion, _DoSpecificJob_NullStripe)
     //When: Execute WriteCompletion with null stripe
     ON_CALL(mockIWBStripeAllocator, GetStripe).WillByDefault(Return(nullptr));
 
-    WriteCompletion writeCompletion(volIo, &mockIWBStripeAllocator, false, &mockIArrayMgmt);
+    WriteCompletion writeCompletion(volIo, &mockIWBStripeAllocator, false, &mockVolumeInfoManager);
     actual = writeCompletion.Execute();
 
     //Then: WriteCompletion should return success
@@ -102,8 +102,7 @@ TEST(WriteCompletion, _RequestFlush_DummyStripe)
 {
     //Given
     bool actual;
-    NiceMock<MockIArrayInfo> mockIArrayInfo;
-    NiceMock<MockIArrayMgmt> mockIArrayMgmt;
+    NiceMock<MockIVolumeInfoManager> mockVolumeInfoManager;
     auto mockVolIo = new NiceMock<MockVolumeIo>(nullptr, 1, 0);
     VolumeIoSmartPtr volIo = VolumeIoSmartPtr(mockVolIo);
     NiceMock<MockIWBStripeAllocator> mockIWBStripeAllocator;
@@ -113,17 +112,15 @@ TEST(WriteCompletion, _RequestFlush_DummyStripe)
     Stripe stripe(&rev, true, 1);
     VirtualBlkAddr startVsa;
     int arrayId = 0;
-    ComponentsInfo info{&mockIArrayInfo, nullptr};
     ON_CALL(rev, Flush).WillByDefault(Return(0));
     ON_CALL(*mockVolIo, GetLsidEntry()).WillByDefault(ReturnRef(stripeAddr));
     ON_CALL(*mockVolIo, GetVsa()).WillByDefault(ReturnRef(startVsa));
-    ON_CALL(mockIArrayMgmt, GetInfo(arrayId)).WillByDefault(Return(&info));
-    ON_CALL(mockIArrayInfo, IsWriteThroughEnabled()).WillByDefault(Return(false));
+    ON_CALL(mockVolumeInfoManager, IsWriteThroughEnabled()).WillByDefault(Return(false));
 
     //When: Execute WriteCompletion with dummy stripe
     ON_CALL(mockIWBStripeAllocator, GetStripe).WillByDefault(Return(&stripe));
 
-    WriteCompletion writeCompletion(volIo, &mockIWBStripeAllocator, false, &mockIArrayMgmt);
+    WriteCompletion writeCompletion(volIo, &mockIWBStripeAllocator, false, &mockVolumeInfoManager);
     actual = writeCompletion.Execute();
 
     //Then: WriteCompletion should return success
@@ -134,8 +131,7 @@ TEST(WriteCompletion, _ReqeustFlush_FlushSuccess)
 {
     //Given
     bool actual;
-    NiceMock<MockIArrayInfo> mockIArrayInfo;
-    NiceMock<MockIArrayMgmt> mockIArrayMgmt;
+    NiceMock<MockIVolumeInfoManager> mockVolumeInfoManager;
     auto mockVolIo = new NiceMock<MockVolumeIo>(nullptr, 1, 0);
     VolumeIoSmartPtr volIo = VolumeIoSmartPtr(mockVolIo);
     NiceMock<MockIWBStripeAllocator> mockIWBStripeAllocator;
@@ -144,7 +140,6 @@ TEST(WriteCompletion, _ReqeustFlush_FlushSuccess)
     StripeAddr stripeAddr;
     VirtualBlkAddr startVsa;
     int arrayId = 0;
-    ComponentsInfo info{&mockIArrayInfo, nullptr};
 
     ON_CALL(*mockVolIo, GetLsidEntry()).WillByDefault(ReturnRef(stripeAddr));
     ON_CALL(*mockVolIo, GetVsa()).WillByDefault(ReturnRef(startVsa));
@@ -154,9 +149,8 @@ TEST(WriteCompletion, _ReqeustFlush_FlushSuccess)
     ON_CALL(mockStripe, Flush(_)).WillByDefault(Return(0));
     ON_CALL(mockStripe, IsActiveFlushTarget).WillByDefault(Return(true));
     ON_CALL(mockIWBStripeAllocator, GetStripe).WillByDefault(Return(&mockStripe));
-    ON_CALL(mockIArrayMgmt, GetInfo(arrayId)).WillByDefault(Return(&info));
-    ON_CALL(mockIArrayInfo, IsWriteThroughEnabled()).WillByDefault(Return(false));
-    WriteCompletion writeCompletion(volIo, &mockIWBStripeAllocator, false, &mockIArrayMgmt);
+    ON_CALL(mockVolumeInfoManager, IsWriteThroughEnabled()).WillByDefault(Return(false));
+    WriteCompletion writeCompletion(volIo, &mockIWBStripeAllocator, false, &mockVolumeInfoManager);
     actual = writeCompletion.Execute();
 
     //Then: WriteCompletion should return success
@@ -167,8 +161,7 @@ TEST(WriteCompletion, _RequestFlush_FlushError)
 {
     //Given
     bool actual;
-    NiceMock<MockIArrayInfo> mockIArrayInfo;
-    NiceMock<MockIArrayMgmt> mockIArrayMgmt;
+    NiceMock<MockIVolumeInfoManager> mockVolumeInfoManager;
     auto mockVolIo = new NiceMock<MockVolumeIo>(nullptr, 1, 0);
     VolumeIoSmartPtr volIo = VolumeIoSmartPtr(mockVolIo);
     NiceMock<MockIWBStripeAllocator> mockIWBStripeAllocator;
@@ -179,7 +172,6 @@ TEST(WriteCompletion, _RequestFlush_FlushError)
     VirtualBlkAddr startVsa;
     StripeId stripeId = 1;
     int arrayId = 0;
-    ComponentsInfo info{&mockIArrayInfo, nullptr};
 
     ON_CALL(*mockVolIo, GetLsidEntry()).WillByDefault(ReturnRef(stripeAddr));
     ON_CALL(*mockVolIo, GetVsa()).WillByDefault(ReturnRef(startVsa));
@@ -188,9 +180,8 @@ TEST(WriteCompletion, _RequestFlush_FlushError)
     ON_CALL(mockStripe, DecreseBlksRemaining(_)).WillByDefault(Return(0));
     ON_CALL(mockStripe, Flush(_)).WillByDefault(Return(-1));
     ON_CALL(mockIWBStripeAllocator, GetStripe).WillByDefault(Return(&mockStripe));
-    ON_CALL(mockIArrayMgmt, GetInfo(arrayId)).WillByDefault(Return(&info));
-    ON_CALL(mockIArrayInfo, IsWriteThroughEnabled()).WillByDefault(Return(false));
-    WriteCompletion writeCompletion(volIo, &mockIWBStripeAllocator, false, &mockIArrayMgmt);
+    ON_CALL(mockVolumeInfoManager, IsWriteThroughEnabled()).WillByDefault(Return(false));
+    WriteCompletion writeCompletion(volIo, &mockIWBStripeAllocator, false, &mockVolumeInfoManager);
     actual = writeCompletion.Execute();
 
     //Then: WriteCompletion should return success

--- a/test/unit-tests/io/frontend_io/write_submission_test.cpp
+++ b/test/unit-tests/io/frontend_io/write_submission_test.cpp
@@ -13,6 +13,7 @@
 #include "test/unit-tests/gc/flow_control/flow_control_mock.h"
 #include "test/unit-tests/io/general_io/rba_state_manager_mock.h"
 #include "test/unit-tests/array_models/interface/i_array_info_mock.h"
+#include "test/unit-tests/volume/i_volume_info_manager_mock.h"
 
 using namespace std;
 using ::testing::_;
@@ -37,11 +38,11 @@ TEST(WriteSubmission, WriteSubmission_Stack)
     NiceMock<MockRBAStateManager> mockRBAStateManager(arr_name, 0);
     NiceMock<MockIBlockAllocator> mockIBlockAllocator;
     NiceMock<MockFlowControl> mockFlowControl(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
-    NiceMock<MockIArrayInfo> mockArrayInfo;
+    NiceMock<MockIVolumeInfoManager> mockVolumeManager;
 
     // when
     WriteSubmission writeSubmission(volumeIo, &mockRBAStateManager, &mockIBlockAllocator,
-        &mockFlowControl, &mockArrayInfo, false);
+        &mockFlowControl, &mockVolumeManager, false);
 
     // Then : do noting
 }
@@ -60,11 +61,11 @@ TEST(WriteSubmission, WriteSubmission_Heap)
     NiceMock<MockRBAStateManager> mockRBAStateManager(arr_name, 0);
     NiceMock<MockIBlockAllocator> mockIBlockAllocator;
     NiceMock<MockFlowControl> mockFlowControl(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
-    NiceMock<MockIArrayInfo> mockArrayInfo;
+    NiceMock<MockIVolumeInfoManager> mockVolumeManager;
 
     // when : create write submission
     WriteSubmission* writeSubmission = new WriteSubmission(volumeIo, &mockRBAStateManager,
-        &mockIBlockAllocator, &mockFlowControl, &mockArrayInfo, false);
+        &mockIBlockAllocator, &mockFlowControl, &mockVolumeManager, false);
 
     // Then : delete write submission
     delete writeSubmission;
@@ -84,11 +85,11 @@ TEST(WriteSubmission, Execute_SingleBlock_ownershipFail)
     NiceMock<MockRBAStateManager> mockRBAStateManager("", 0);
     NiceMock<MockIBlockAllocator> mockIBlockAllocator;
     NiceMock<MockFlowControl> mockFlowControl(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
-    NiceMock<MockIArrayInfo> mockArrayInfo;
+    NiceMock<MockIVolumeInfoManager> mockVolumeManager;
 
     // when
     WriteSubmission writeSubmission(volumeIo, &mockRBAStateManager, &mockIBlockAllocator,
-        &mockFlowControl, &mockArrayInfo, false);
+        &mockFlowControl, &mockVolumeManager, false);
 
     ON_CALL(mockFlowControl, GetToken(_, _)).WillByDefault(Return((512 >> SECTOR_SIZE_SHIFT) * Ubio::BYTES_PER_UNIT));
     ON_CALL(mockRBAStateManager, BulkAcquireOwnership(_, _, _)).WillByDefault(Return(false));
@@ -111,8 +112,8 @@ TEST(WriteSubmission, Execute_SingleBlock)
     NiceMock<MockRBAStateManager> mockRBAStateManager("", 0);
     NiceMock<MockIBlockAllocator> mockIBlockAllocator;
     NiceMock<MockFlowControl> mockFlowControl(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
-    NiceMock<MockIArrayInfo> mockArrayInfo;
-    ON_CALL(mockArrayInfo, IsWriteThroughEnabled()).WillByDefault(Return(false));
+    NiceMock<MockIVolumeInfoManager> mockVolumeManager;
+    ON_CALL(mockVolumeManager, IsWriteThroughEnabled()).WillByDefault(Return(false));
 
     NiceMock<MockVolumeIo>* mockVolumeIo = new NiceMock<MockVolumeIo>(nullptr, 0, 0);
     ON_CALL(*mockVolumeIo, GetArrayId()).WillByDefault(Return(0));
@@ -126,7 +127,7 @@ TEST(WriteSubmission, Execute_SingleBlock)
 
     // when
     WriteSubmission writeSubmission(volumeIo, &mockRBAStateManager, &mockIBlockAllocator,
-        &mockFlowControl, &mockArrayInfo, false);
+        &mockFlowControl, &mockVolumeManager, false);
 
     ON_CALL(mockFlowControl, GetToken(_, _)).WillByDefault(Return((512 >> SECTOR_SIZE_SHIFT) * Ubio::BYTES_PER_UNIT));
     ON_CALL(mockRBAStateManager, BulkAcquireOwnership(_, _, _)).WillByDefault(Return(true));
@@ -150,7 +151,7 @@ TEST(WriteSubmission, Execute_AlgnedMultiBlock)
     NiceMock<MockRBAStateManager> mockRBAStateManager(arr_name, 0);
     NiceMock<MockIBlockAllocator> mockIBlockAllocator;
     NiceMock<MockFlowControl> mockFlowControl(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
-    NiceMock<MockIArrayInfo> mockArrayInfo;
+    NiceMock<MockIVolumeInfoManager> mockVolumeManager;
 
     VolumeIoSmartPtr mockVolumeIo(new NiceMock<MockVolumeIo>(nullptr, 0, 0));
     CallbackSmartPtr callback(new NiceMock<MockCallback>(true));
@@ -161,7 +162,7 @@ TEST(WriteSubmission, Execute_AlgnedMultiBlock)
 
     // when
     WriteSubmission writeSubmission(mockVolumeIo, &mockRBAStateManager, &mockIBlockAllocator,
-        &mockFlowControl, &mockArrayInfo, false);
+        &mockFlowControl, &mockVolumeManager, false);
 
     ON_CALL(mockFlowControl, GetToken(_, _)).WillByDefault(Return((512 >> SECTOR_SIZE_SHIFT) * Ubio::BYTES_PER_UNIT));
     ON_CALL(mockRBAStateManager, BulkAcquireOwnership(_, _, _)).WillByDefault(Return(true));
@@ -185,7 +186,7 @@ TEST(WriteSubmission, Execute_MisAlgnedMultiBlock)
     NiceMock<MockRBAStateManager> mockRBAStateManager(arr_name, 0);
     NiceMock<MockIBlockAllocator> mockIBlockAllocator;
     NiceMock<MockFlowControl> mockFlowControl(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
-    NiceMock<MockIArrayInfo> mockArrayInfo;
+    NiceMock<MockIVolumeInfoManager> mockVolumeManager;
 
     VolumeIoSmartPtr mockVolumeIo(new NiceMock<MockVolumeIo>(nullptr, 0, 0));
     CallbackSmartPtr callback(new NiceMock<MockCallback>(true));
@@ -196,7 +197,7 @@ TEST(WriteSubmission, Execute_MisAlgnedMultiBlock)
 
     // when
     WriteSubmission writeSubmission(mockVolumeIo, &mockRBAStateManager, &mockIBlockAllocator,
-        &mockFlowControl, &mockArrayInfo, false);
+        &mockFlowControl, &mockVolumeManager, false);
 
     ON_CALL(mockFlowControl, GetToken(_, _)).WillByDefault(Return((512 >> SECTOR_SIZE_SHIFT) * Ubio::BYTES_PER_UNIT));
     ON_CALL(mockRBAStateManager, BulkAcquireOwnership(_, _, _)).WillByDefault(Return(true));

--- a/test/unit-tests/io/general_io/translator_test.cpp
+++ b/test/unit-tests/io/general_io/translator_test.cpp
@@ -7,11 +7,10 @@
 #include "test/unit-tests/allocator/i_wbstripe_allocator_mock.h"
 #include "test/unit-tests/allocator/stripe/stripe_mock.h"
 #include "test/unit-tests/array/service/io_translator/i_io_translator_mock.h"
-#include "test/unit-tests/array_models/interface/i_array_info_mock.h"
-#include "test/unit-tests/array_mgmt/interface/i_array_mgmt_mock.h"
 #include "test/unit-tests/include/i_array_device_mock.h"
 #include "test/unit-tests/mapper/i_stripemap_mock.h"
 #include "test/unit-tests/mapper/i_vsamap_mock.h"
+#include "test/unit-tests/volume/i_volume_info_manager_mock.h"
 
 using namespace pos;
 using namespace std;
@@ -66,7 +65,6 @@ public:
             dst = tmpPWEs;
             return 0;
         });
-        mockIArrayInfo = new NiceMock<MockIArrayInfo>();
     }
 
     virtual void
@@ -76,7 +74,6 @@ public:
         delete mockIStripeMap;
         delete mockWBAllocator;
         delete mockITranslator;
-        delete mockIArrayInfo;
     }
 
 protected:
@@ -88,22 +85,22 @@ protected:
     NiceMock<MockIStripeMap>* mockIStripeMap;
     NiceMock<MockIWBStripeAllocator>* mockWBAllocator;
     NiceMock<MockIIOTranslator>* mockITranslator;
-    NiceMock<MockIArrayInfo>* mockIArrayInfo;
+    NiceMock<MockIVolumeInfoManager> mockVolumeInfoManager;
 };
 
 TEST_F(TranslatorTestFixture, Translator_Constructor_EightArguments)
 {
     //When: create translator for single block (stack)
-    Translator translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, mockIArrayInfo);
+    Translator translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, &mockVolumeInfoManager);
 
     //Then: do nothing
 
     //When: create translator for mulitple blocks
-    Translator translator2(0, 0, 2, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, mockIArrayInfo);
+    Translator translator2(0, 0, 2, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, &mockVolumeInfoManager);
     //Then: do nothing
 
     //When: create translator (heap)
-    Translator* pTranslator = new Translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, mockIArrayInfo);
+    Translator* pTranslator = new Translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, &mockVolumeInfoManager);
     delete pTranslator;
     //Then: do nothing
 }
@@ -111,7 +108,7 @@ TEST_F(TranslatorTestFixture, Translator_Constructor_EightArguments)
 TEST_F(TranslatorTestFixture, Translator_Constructor_TwoArguments)
 {
     //When: create translator (stack)
-    Translator translator(vsa, 0, UNMAP_STRIPE, mockIArrayInfo);
+    Translator translator(vsa, 0, UNMAP_STRIPE);
 
     //Then: do nothing
 
@@ -119,7 +116,7 @@ TEST_F(TranslatorTestFixture, Translator_Constructor_TwoArguments)
     MapperServiceSingleton::Instance()->RegisterMapper(arrayName, arrayId, nullptr, mockIStripeMap, nullptr, nullptr, nullptr);
 
     //When: create translator (heap)
-    Translator* pTranslator = new Translator(vsa, 0, UNMAP_STRIPE, mockIArrayInfo);
+    Translator* pTranslator = new Translator(vsa, 0, UNMAP_STRIPE);
     delete pTranslator;
 
     //Then: do nothing
@@ -132,13 +129,13 @@ TEST_F(TranslatorTestFixture, Translator_Constructor_InvalidVolumeIdException)
 {
     //When: create translator with invalid volumeId
     //Then: exception is thrown
-    EXPECT_THROW(Translator translator(MAX_VOLUME_COUNT, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, mockIArrayInfo), POS_EVENT_ID);
+    EXPECT_THROW(Translator translator(MAX_VOLUME_COUNT, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, &mockVolumeInfoManager), POS_EVENT_ID);
 }
 
 TEST_F(TranslatorTestFixture, GetVsa)
 {
     //When: translate to a mapped VSA
-    Translator translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, mockIArrayInfo);
+    Translator translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, &mockVolumeInfoManager);
     VirtualBlkAddr actual = translator.GetVsa(0);
 
     //Then: return a valid vsa
@@ -151,7 +148,7 @@ TEST_F(TranslatorTestFixture, GetVsa)
     EXPECT_EQ(actual, UNMAP_VSA);
 
     //When: translate to an unmapped VSA
-    Translator translator2(0, 2, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, mockIArrayInfo);
+    Translator translator2(0, 2, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, &mockVolumeInfoManager);
     actual = translator2.GetVsa(0);
 
     //Then: return an unmapped VSA
@@ -161,7 +158,7 @@ TEST_F(TranslatorTestFixture, GetVsa)
 TEST_F(TranslatorTestFixture, GetLsidEntry)
 {
     //When: translate to a mapped VSA and get lsid entry
-    Translator translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, mockIArrayInfo);
+    Translator translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, &mockVolumeInfoManager);
 
     StripeAddr actual = translator.GetLsidEntry(0);
 
@@ -180,8 +177,8 @@ TEST_F(TranslatorTestFixture, GetLsidEntry)
 TEST_F(TranslatorTestFixture, GetPba)
 {
     //When: get a pba of valid range
-    ON_CALL(*mockIArrayInfo, IsWriteThroughEnabled()).WillByDefault(Return(false));
-    Translator translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, mockIArrayInfo);
+    ON_CALL(mockVolumeInfoManager, IsWriteThroughEnabled()).WillByDefault(Return(false));
+    Translator translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, &mockVolumeInfoManager);
     PhysicalBlkAddr pba = translator.GetPba();
     PhysicalBlkAddr pba0 = translator.GetPba(0);
 
@@ -190,7 +187,7 @@ TEST_F(TranslatorTestFixture, GetPba)
     EXPECT_EQ(pba.arrayDev, pba0.arrayDev);
 
     //When: get a pba of unmapped LSA
-    Translator translator2(0, 2, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, mockIArrayInfo);
+    Translator translator2(0, 2, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, &mockVolumeInfoManager);
     pba = translator2.GetPba();
 
     //Then: return a default pba
@@ -222,8 +219,8 @@ TEST_F(TranslatorTestFixture, GetPba)
 TEST_F(TranslatorTestFixture, GetPhysicalEntries)
 {
     //When: get physical entries
-    ON_CALL(*mockIArrayInfo, IsWriteThroughEnabled()).WillByDefault(Return(false));
-    Translator translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, mockIArrayInfo);
+    ON_CALL(mockVolumeInfoManager, IsWriteThroughEnabled()).WillByDefault(Return(false));
+    Translator translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, &mockVolumeInfoManager);
     list<PhysicalEntry> actual = translator.GetPhysicalEntries(nullptr, 0);
 
     //Then: return a phyiscal entry
@@ -240,19 +237,19 @@ TEST_F(TranslatorTestFixture, GetPhysicalEntries)
 TEST_F(TranslatorTestFixture, IsMapped)
 {
     //When: translate to a mapped VSA
-    Translator translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, mockIArrayInfo);
+    Translator translator(0, 0, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, &mockVolumeInfoManager);
 
     //Then: IsMapped returns true
     EXPECT_TRUE(translator.IsMapped());
 
     //When: translate to an unmapped VSA
-    Translator translator2(0, 2, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, mockIArrayInfo);
+    Translator translator2(0, 2, 1, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, &mockVolumeInfoManager);
 
     //Then: IsMapped returns false
     EXPECT_FALSE(translator2.IsMapped());
 
     //When: translate muliple blocks
-    Translator translator3(0, 0, 2, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, mockIArrayInfo);
+    Translator translator3(0, 0, 2, 0, true, mockIVSAMap, mockIStripeMap, mockWBAllocator, mockITranslator, &mockVolumeInfoManager);
 
     //Then: IsMapped throws an exception
     EXPECT_THROW(translator3.IsMapped(), POS_EVENT_ID);

--- a/test/unit-tests/volume/i_volume_info_manager_mock.h
+++ b/test/unit-tests/volume/i_volume_info_manager_mock.h
@@ -26,6 +26,7 @@ public:
     MOCK_METHOD(std::string, GetStatusStr, (VolumeStatus status), (override));
     MOCK_METHOD(VolumeBase*, GetVolume, (int volId), (override));
     MOCK_METHOD(std::string, GetArrayName, (), (override));
+    MOCK_METHOD(bool, IsWriteThroughEnabled, (), (override));
     MOCK_METHOD(int, CancelVolumeReplay, (int volId), (override));
 };
 


### PR DESCRIPTION
IO Read/Write 과정에서 WT 여부를 알기 위해 Array의 GetInfo를 호출하는 부분이 있는데 GetInfo를 할 때마다 Lock을 잡게 되면서 해당 lock이 cpu의 30% 이상을 점유하게 되어 I/O path 상에 있는 GenInfo() 를 모두 제거 하였습니다.

WT enable여부는 array가 mount되는 시점에 volume manager 초기화되는데 이 부분에서 array의 wt 정보를 저장하고 io path에서는 volume manager를 통해 저장된 wt 정보를 읽는 형태로 수정하였습니다. 


Removed calling Array GetInfo() during io to avoid the impact of array lock

Signed-off-by: syeon.shin <syeon.shin@samsung.com>