### PR TITLE
[SHPOS-923] Fix buffer size and array index access during RAID6 decoding

### DIFF
--- a/src/array/ft/raid6.h
+++ b/src/array/ft/raid6.h
@@ -73,7 +73,7 @@ private:
     BufferEntry _AllocChunk();
     void _ComputePQParities(list<BufferEntry>& dst, const list<BufferEntry>& src);
     void _MakeEncodingGFTable();
-    void _MakeDecodingGFTable(uint32_t rebuildCnt, vector<uint32_t> excluded, unsigned char* g_tbls_rebuild);
+    void _MakeDecodingGFTable(vector<uint32_t> excluded, unsigned char* g_tbls_rebuild);
 #if USE_RAID6_DECODE_CACHING
     uint32_t _MakeKeyforGFMap(vector<uint32_t>& excluded);
 #endif


### PR DESCRIPTION

Fix buffer size and array index access of Galois field matrix generation during RAID6 decoding.

Signed-off-by: jh34.hong <jh34.hong@samsung.com>