### PR TITLE
[AWIBOF-7372] minimize lock overhead for buffer pool

### DIFF
--- a/src/array/rebuild/rebuild_method.cpp
+++ b/src/array/rebuild/rebuild_method.cpp
@@ -48,21 +48,11 @@ RebuildMethod::~RebuildMethod(void)
 {
     if (srcBuffer != nullptr)
     {
-        if (srcBuffer->IsFull() == false)
-        {
-            POS_TRACE_ERROR(EID(REBUILD_BUFFER_WARN),
-                "Some buffers in srcBuffer were not returned but deleted.");
-        }
         mm->DeleteBufferPool(srcBuffer);
         srcBuffer = nullptr;
     }
     if (dstBuffer != nullptr)
     {
-        if (dstBuffer->IsFull() == false)
-        {
-            POS_TRACE_ERROR(EID(REBUILD_BUFFER_WARN),
-                "Some buffers in dstBuffer were not returned but deleted.");
-        }
         mm->DeleteBufferPool(dstBuffer);
         dstBuffer = nullptr;
     }

--- a/src/include/array_config.h
+++ b/src/include/array_config.h
@@ -67,7 +67,7 @@ public:
     static const uint32_t REBUILD_CHUNK_SIZE_BYTE = BLOCKS_PER_CHUNK * BLOCK_SIZE_BYTE;
     static const uint32_t MAX_CHUNK_CNT = 32;
 
-    static const uint32_t GC_BUFFER_COUNT = STRIPES_PER_SEGMENT;
+    static const uint32_t GC_BUFFER_COUNT = STRIPES_PER_SEGMENT * 2;
 };
 
 } // namespace pos

--- a/src/resource_manager/buffer_pool.cpp
+++ b/src/resource_manager/buffer_pool.cpp
@@ -52,8 +52,7 @@ BufferPool::BufferPool(const BufferInfo info,
             "Faild to get hugepageAllocator");
         return;
     }
-
-    if (_Alloc() == false)
+    if (_Init() == false)
     {
         _Clear();
     }
@@ -68,29 +67,50 @@ BufferPool::~BufferPool(void)
     _Clear();
 }
 
-void
-BufferPool::_Clear()
+void*
+BufferPool::TryGetBuffer(void)
 {
-    unique_lock<mutex> lock(freeBufferLock);
-    freeBuffers.clear();
-    freeBufferSize = 0;
-    initSize = 0;
-    while (allocatedHugepages.size() != 0)
+    unique_lock<mutex> lock(consumerLock);
+    if (consumerPool->empty())
     {
-        void* mem = allocatedHugepages.front();
-        if(mem != nullptr)
+        if (producerPool->size() > swapSize)
         {
-            hugepageAllocator->Free(mem);
+            producerLock.lock();
+            _Swap();
+            producerLock.unlock();
         }
-        allocatedHugepages.pop_front();
+        else
+        {
+            return nullptr;
+        }
     }
-    isAllocated = false;
+    void* buffer = nullptr;
+    buffer = consumerPool->front();
+    consumerPool->pop_front();
+    return buffer;
+}
+
+void
+BufferPool::ReturnBuffer(void* buffer)
+{
+    if (buffer == nullptr)
+    {
+        POS_TRACE_WARN(EID(RESOURCE_MANAGER_DEBUG_MSG),
+            "Failed to return buffer. Buffer is Null");
+        return;
+    }
+
+    unique_lock<mutex> lock(producerLock);
+    producerPool->push_back(buffer);
 }
 
 bool
-BufferPool::_Alloc(void)
+BufferPool::_Init(void)
 {
-    unique_lock<mutex> lock(freeBufferLock);
+    unique_lock<mutex> lock1(consumerLock);
+    unique_lock<mutex> lock2(producerLock);
+    bufferList1.clear();
+    bufferList2.clear();
     uint32_t remainBufferCount = 0;
     uint8_t* buffer = 0;
     // 2MB allocation for avoiding buddy allocation overhead
@@ -117,42 +137,47 @@ BufferPool::_Alloc(void)
             allocatedHugepages.push_back(buffer);
         }
 
-        freeBuffers.push_back(buffer);
+        bufferList1.push_back(buffer);
         buffer += BUFFER_INFO.size;
         remainBufferCount--;
     }
-    freeBufferSize = initSize = freeBuffers.size();
+    swapSize = (size_t)((bufferList1.size() * SWAP_THRESHOLD_PERCENT) / 100);
+    consumerPool = &bufferList1;
+    producerPool = &bufferList2;
+    POS_TRACE_INFO(EID(RESOURCE_MANAGER_DEBUG_MSG),
+        "BufferPool initialized, size:{}, swapSize:{}, owner:{}", bufferList1.size(), swapSize, BUFFER_INFO.owner);
     return true;
 }
 
-void*
-BufferPool::TryGetBuffer(void)
+void
+BufferPool::_Clear()
 {
-    unique_lock<mutex> lock(freeBufferLock);
-
-    if (freeBuffers.empty())
+    unique_lock<mutex> lock1(consumerLock);
+    unique_lock<mutex> lock2(producerLock);
+    consumerPool = nullptr;
+    producerPool = nullptr;
+    bufferList1.clear();
+    bufferList2.clear();
+    while (allocatedHugepages.size() != 0)
     {
-        return nullptr;
+        void* mem = allocatedHugepages.front();
+        if(mem != nullptr)
+        {
+            hugepageAllocator->Free(mem);
+        }
+        allocatedHugepages.pop_front();
     }
-
-    void* buffer = nullptr;
-    buffer = freeBuffers.front();
-    freeBuffers.pop_front();
-    freeBufferSize--;
-    return buffer;
+    isAllocated = false;
 }
 
 void
-BufferPool::ReturnBuffer(void* buffer)
+BufferPool::_Swap(void)
 {
-    if (buffer == nullptr)
-    {
-        POS_TRACE_WARN(EID(RESOURCE_MANAGER_DEBUG_MSG),
-            "Failed to return buffer. Buffer is Null");
-        return;
-    }
-
-    unique_lock<mutex> lock(freeBufferLock);
-    freeBuffers.push_back(buffer);
-    freeBufferSize++;
+    // This method must be performed in a thread-safe state.
+    std::list<void*>* temp;
+    temp = consumerPool;
+    consumerPool = producerPool;
+    producerPool = temp;
+    POS_TRACE_INFO(EID(RESOURCE_MANAGER_DEBUG_MSG),
+        "Bufferpool swapped, size:{}, owner:{}", consumerPool->size(), BUFFER_INFO.owner);
 }

--- a/src/resource_manager/buffer_pool.h
+++ b/src/resource_manager/buffer_pool.h
@@ -53,26 +53,31 @@ public:
         HugepageAllocator* hugepageAllocator =
             HugepageAllocatorSingleton::Instance());
     virtual ~BufferPool(void);
-
     virtual void* TryGetBuffer(void);
     virtual void ReturnBuffer(void*);
-    virtual bool IsFull(void) { return freeBufferSize == initSize; }
     virtual bool IsAllocated(void) { return isAllocated; }
     std::string GetOwner(void) { return BUFFER_INFO.owner; }
+
 private:
-    bool _Alloc(void);
+    bool _Init(void);
     void _Clear(void);
+    void _Swap(void);
 
     const BufferInfo BUFFER_INFO;
     const uint32_t SOCKET;
 
-    std::mutex freeBufferLock;
-    std::list<void*> freeBuffers;
+    HugepageAllocator* hugepageAllocator = nullptr;
     std::list<void*> allocatedHugepages;
-    uint32_t freeBufferSize = 0;
-    uint32_t initSize = 0;
+    std::list<void*>* consumerPool = nullptr;
+    std::list<void*>* producerPool = nullptr;
+    std::list<void*> bufferList1;
+    std::list<void*> bufferList2;
+
+    std::mutex consumerLock;
+    std::mutex producerLock;
     bool isAllocated = false;
-    HugepageAllocator* hugepageAllocator;
+    size_t swapSize;
+    const static size_t SWAP_THRESHOLD_PERCENT = 25;
 };
 
 } // namespace pos

--- a/test/unit-tests/resource_manager/buffer_pool_mock.h
+++ b/test/unit-tests/resource_manager/buffer_pool_mock.h
@@ -45,7 +45,6 @@ public:
     using BufferPool::BufferPool;
     MOCK_METHOD(void*, TryGetBuffer, (), (override));
     MOCK_METHOD(void, ReturnBuffer, (void*), (override));
-    MOCK_METHOD(bool, IsFull, (), (override));
 };
 
 } // namespace pos


### PR DESCRIPTION
minimize lock overhead by separating production and consumption data structure of buffer pool

소비용 buffer pool list와 생산용 buffer pool list를 따로두고,
기존의 생산 소비에 동일한 lock을 사용함으로 인해 발생하는 lock overhead를 줄임, 
소비 pool list가 소진되면 생산 pool list와 swap함. (threshold두어 어느정도 생산 pool list에 채워졌을때만 swap 하도록 하여 빈번한 swap오버헤드 줄임)

+ 불필요한 method 제거
+ GC Bufferpool 2배 증가

Signed-off-by: minjoon.ahn <minjoon.ahn@samsung.com>