### PR TITLE
[AWIBOF-7471] fix assert of metafs

### DIFF
--- a/src/metafs/common/meta_file_util.cpp
+++ b/src/metafs/common/meta_file_util.cpp
@@ -49,7 +49,7 @@ const MetaFsVolumeToMedia MetaFileUtil::VOLUME_TO_MEDIA[] =
         {MetaVolumeType::NvRamVolume, MetaStorageType::NVRAM},
         {MetaVolumeType::JournalVolume, MetaStorageType::JOURNAL_SSD}};
 
-std::unordered_map<MetaVolumeType, std::string> MetaFileUtil::VOLUME_NAME =
+const std::unordered_map<MetaVolumeType, std::string> MetaFileUtil::VOLUME_NAME =
     {
         {MetaVolumeType::SsdVolume, "SSD"},
         {MetaVolumeType::NvRamVolume, "NVRAM/NVDIMM"},
@@ -63,23 +63,27 @@ MetaFileUtil::GetHashKeyFromFileName(const std::string& fileName)
 }
 
 MetaStorageType
-MetaFileUtil::ConvertToMediaType(MetaVolumeType volume)
+MetaFileUtil::ConvertToMediaType(const MetaVolumeType volume)
 {
     return VOLUME_TO_MEDIA[(uint32_t)volume].media;
 }
 
 std::string
-MetaFileUtil::ConvertToMediaTypeName(MetaVolumeType volume)
+MetaFileUtil::ConvertToMediaTypeName(const MetaVolumeType volume)
 {
-    if (VOLUME_NAME.find(volume) == VOLUME_NAME.end())
+    auto result = VOLUME_NAME.find(volume);
+    if (result == VOLUME_NAME.end())
     {
         return UNKNOWN_VOLUME_NAME;
     }
-    return VOLUME_NAME[volume];
+    else
+    {
+        return result->second;
+    }
 }
 
 MetaVolumeType
-MetaFileUtil::ConvertToVolumeType(MetaStorageType media)
+MetaFileUtil::ConvertToVolumeType(const MetaStorageType media)
 {
     return MEDIA_TO_VOLUME[(uint32_t)media].volumeType;
 }

--- a/src/metafs/common/meta_file_util.cpp
+++ b/src/metafs/common/meta_file_util.cpp
@@ -49,6 +49,13 @@ const MetaFsVolumeToMedia MetaFileUtil::VOLUME_TO_MEDIA[] =
         {MetaVolumeType::NvRamVolume, MetaStorageType::NVRAM},
         {MetaVolumeType::JournalVolume, MetaStorageType::JOURNAL_SSD}};
 
+std::unordered_map<MetaVolumeType, std::string> MetaFileUtil::VOLUME_NAME =
+    {
+        {MetaVolumeType::SsdVolume, "SSD"},
+        {MetaVolumeType::NvRamVolume, "NVRAM/NVDIMM"},
+        {MetaVolumeType::JournalVolume, "Journal SSD"}};
+const std::string MetaFileUtil::UNKNOWN_VOLUME_NAME = "Unknown Volume";
+
 StringHashType
 MetaFileUtil::GetHashKeyFromFileName(const std::string& fileName)
 {
@@ -64,23 +71,11 @@ MetaFileUtil::ConvertToMediaType(MetaVolumeType volume)
 std::string
 MetaFileUtil::ConvertToMediaTypeName(MetaVolumeType volume)
 {
-    switch (volume)
+    if (VOLUME_NAME.find(volume) == VOLUME_NAME.end())
     {
-        case MetaVolumeType::SsdVolume:
-        {
-            return std::string("SSD array");
-        }
-        break;
-        case MetaVolumeType::NvRamVolume:
-        {
-            return std::string("NVRAM/NVDIMM");
-        }
-        break;
-        default:
-        {
-            assert(false);
-        }
+        return UNKNOWN_VOLUME_NAME;
     }
+    return VOLUME_NAME[volume];
 }
 
 MetaVolumeType

--- a/src/metafs/common/meta_file_util.h
+++ b/src/metafs/common/meta_file_util.h
@@ -62,9 +62,9 @@ class MetaFileUtil
 {
 public:
     static StringHashType GetHashKeyFromFileName(const std::string& fileName);
-    static MetaStorageType ConvertToMediaType(MetaVolumeType volume);
-    static std::string ConvertToMediaTypeName(MetaVolumeType volume);
-    static MetaVolumeType ConvertToVolumeType(MetaStorageType media);
+    static MetaStorageType ConvertToMediaType(const MetaVolumeType volume);
+    static std::string ConvertToMediaTypeName(const MetaVolumeType volume);
+    static MetaVolumeType ConvertToVolumeType(const MetaStorageType media);
     static uint64_t GetEpochSignature(std::time_t t = std::time(0));
 
     static const std::string UNKNOWN_VOLUME_NAME;
@@ -72,6 +72,6 @@ public:
 private:
     static const MetaFsMediaToVolume MEDIA_TO_VOLUME[(uint32_t)MetaStorageType::Max];
     static const MetaFsVolumeToMedia VOLUME_TO_MEDIA[(uint32_t)MetaVolumeType::Max];
-    static std::unordered_map<MetaVolumeType, std::string> VOLUME_NAME;
+    static const std::unordered_map<MetaVolumeType, std::string> VOLUME_NAME;
 };
 } // namespace pos

--- a/src/metafs/common/meta_file_util.h
+++ b/src/metafs/common/meta_file_util.h
@@ -35,6 +35,7 @@
 #include <string.h>
 
 #include <string>
+#include <unordered_map>
 
 #include "meta_storage_specific.h"
 #include "meta_volume_type.h"
@@ -66,8 +67,11 @@ public:
     static MetaVolumeType ConvertToVolumeType(MetaStorageType media);
     static uint64_t GetEpochSignature(std::time_t t = std::time(0));
 
+    static const std::string UNKNOWN_VOLUME_NAME;
+
 private:
     static const MetaFsMediaToVolume MEDIA_TO_VOLUME[(uint32_t)MetaStorageType::Max];
     static const MetaFsVolumeToMedia VOLUME_TO_MEDIA[(uint32_t)MetaVolumeType::Max];
+    static std::unordered_map<MetaVolumeType, std::string> VOLUME_NAME;
 };
 } // namespace pos

--- a/test/unit-tests/metafs/common/meta_file_util_test.cpp
+++ b/test/unit-tests/metafs/common/meta_file_util_test.cpp
@@ -68,17 +68,6 @@ TEST(MetaFileUtil, Convert_StorageOpt_To_MetaStorageType)
     EXPECT_EQ(storageType, MetaStorageType::SSD);
 }
 
-TEST(MetaFileUtil, Convert_MetaVolumeType_To_String)
-{
-    std::string result = "";
-
-    result = MetaFileUtil::ConvertToMediaTypeName(MetaVolumeType::NvRamVolume);
-    EXPECT_EQ(result, std::string("NVRAM/NVDIMM"));
-
-    result = MetaFileUtil::ConvertToMediaTypeName(MetaVolumeType::SsdVolume);
-    EXPECT_EQ(result, std::string("SSD array"));
-}
-
 TEST(MetaFileUtil, Convert_MetaStorageType_To_MetaVolumeType)
 {
     MetaVolumeType volumeType = MetaVolumeType::Max;
@@ -111,4 +100,16 @@ TEST(MetaFileUtil, Check_EpochSignature)
     std::cout << result << std::endl;
     EXPECT_NE(0, result);
 }
+
+TEST(MetaFileUtil, ConvertToMediaTypeName_testIfMetaVolumeTypesMatcheToTheirNames)
+{
+    for (int i = 0; i < (int)MetaVolumeType::Max; i++)
+    {
+        EXPECT_NE(MetaFileUtil::UNKNOWN_VOLUME_NAME,
+            MetaFileUtil::ConvertToMediaTypeName((MetaVolumeType)i));
+    }
+    EXPECT_EQ(MetaFileUtil::UNKNOWN_VOLUME_NAME,
+            MetaFileUtil::ConvertToMediaTypeName(MetaVolumeType::Max));
+}
+
 } // namespace pos

--- a/test/unit-tests/metafs/common/meta_file_util_test.cpp
+++ b/test/unit-tests/metafs/common/meta_file_util_test.cpp
@@ -103,10 +103,16 @@ TEST(MetaFileUtil, Check_EpochSignature)
 
 TEST(MetaFileUtil, ConvertToMediaTypeName_testIfMetaVolumeTypesMatcheToTheirNames)
 {
+    std::unordered_map<MetaVolumeType, std::string> expectedResult =
+    {
+        {MetaVolumeType::SsdVolume, "SSD"},
+        {MetaVolumeType::NvRamVolume, "NVRAM/NVDIMM"},
+        {MetaVolumeType::JournalVolume, "Journal SSD"}};
+
     for (int i = 0; i < (int)MetaVolumeType::Max; i++)
     {
-        EXPECT_NE(MetaFileUtil::UNKNOWN_VOLUME_NAME,
-            MetaFileUtil::ConvertToMediaTypeName((MetaVolumeType)i));
+        MetaVolumeType type = (MetaVolumeType)i;
+        EXPECT_EQ(expectedResult[type], MetaFileUtil::ConvertToMediaTypeName(type));
     }
     EXPECT_EQ(MetaFileUtil::UNKNOWN_VOLUME_NAME,
             MetaFileUtil::ConvertToMediaTypeName(MetaVolumeType::Max));


### PR DESCRIPTION
- if mfs_dump_files_list wbt command is issued with volume type 2, the crash will be occured
- changed the converting method between volume types and their names

Signed-off-by: munseop.lim <munseop.lim@samsung.com>