### PR TITLE
[AWIBOF-7399] Add burst filter to logger

### DIFF
--- a/config/pos.conf
+++ b/config/pos.conf
@@ -19,7 +19,9 @@
         "logfile_size_in_mb": 50,
         "logfile_rotation_count" : 20,
         "min_allowable_log_level" : "info",
-        "enable_structured_logging" : false
+        "enable_structured_logging" : false,
+        "enable_burst_filter" : true,
+        "burst_filter_window_size" : 1000
    },
    "telemetry": {
         "enable_selective_publication" : true,

--- a/src/logger/configuration.cpp
+++ b/src/logger/configuration.cpp
@@ -36,6 +36,8 @@
 
 #include "spdlog/spdlog.h"
 #include "src/include/pos_event_id.h"
+#define DEFAULT_BURST_FILTER_WINDOW_SIZE 1000
+
 using namespace pos;
 namespace pos_logger
 {
@@ -100,4 +102,34 @@ Configuration::IsStrLoggingEnabled()
     }
     return ENABLE_STRUCTURED_LOGGING;
 }
+
+bool
+Configuration::IsBurstFilterEnabled()
+{
+    int SUCCESS = EID(SUCCESS);
+    bool enable_burst_filter = false;
+    int ret = ConfigManagerSingleton::Instance()->GetValue("logger", "enable_burst_filter",
+        &enable_burst_filter, ConfigType::CONFIG_TYPE_BOOL);
+    if (ret == SUCCESS)
+    {
+        return enable_burst_filter;
+    }
+    return ENABLE_BURST_FILTER;
+}
+
+uint32_t
+Configuration::GetBurstFilterWindowSize()
+{
+    int SUCCESS = EID(SUCCESS);
+    uint32_t windowSize = 0;
+    int ret = ConfigManagerSingleton::Instance()->GetValue("logger", "burst_filter_window_size",
+        &windowSize, ConfigType::CONFIG_TYPE_UINT32);
+    if (ret == SUCCESS)
+    {
+        return windowSize;
+    }
+
+    return DEFAULT_BURST_FILTER_WINDOW_SIZE;
+}
+
 } // namespace pos_logger

--- a/src/logger/configuration.h
+++ b/src/logger/configuration.h
@@ -46,6 +46,8 @@ public:
     uint32_t NumOfLogFilesForRotation();
     string LogLevel();
     bool IsStrLoggingEnabled();
+    bool IsBurstFilterEnabled();
+    uint32_t GetBurstFilterWindowSize();
 
 private:
     const uint32_t SIZE_MB = 50;
@@ -58,5 +60,6 @@ private:
     // TODO (mj): The default value of STRUCTURED_LOGGING will be
     // TRUE after implementing structured logging functionality.
     const bool ENABLE_STRUCTURED_LOGGING = false;
+    const bool ENABLE_BURST_FILTER = false;
 };
 } // namespace pos_logger

--- a/src/logger/logger.h
+++ b/src/logger/logger.h
@@ -109,6 +109,8 @@ public:
 #ifndef POS_UT_SUPPRESS_LOGMSG
         if (ShouldFilter(lvl, eventId) == false)
         {
+            loggerMtx.lock();
+
             std::string currMsg = "";
             try
             {
@@ -129,10 +131,14 @@ public:
                     {
                         _Log(loc, lvl, prevEventId, prevMsg, repeatCount);
                         repeatCount = 0;
+
+                        loggerMtx.unlock();
                         return;
                     }
             
                     repeatCount++;
+
+                    loggerMtx.unlock();
                     return;
                 }
 
@@ -146,7 +152,9 @@ public:
                 prevMsg = currMsg;
             }
 
-            _Log(loc, lvl, eventId, currMsg, 0);            
+            _Log(loc, lvl, eventId, currMsg, 0);
+
+            loggerMtx.unlock();          
         }
 #endif
     }
@@ -277,6 +285,7 @@ private:
     int prevEventId = NO_PREV_EVENT;
     std::string prevMsg;
     uint32_t repeatCount = 0;
+    mutex loggerMtx;
     // LCOV_EXCL_STOP
 };
 

--- a/src/logger/logger.h
+++ b/src/logger/logger.h
@@ -109,9 +109,10 @@ public:
 #ifndef POS_UT_SUPPRESS_LOGMSG
         if (ShouldFilter(lvl, eventId) == false)
         {
-            loggerMtx.lock();
-
+            // We won't log this event when its ID and message are
+            // the same as the previous ones.
             std::string currMsg = fmt::format(fmt, args...);
+
             if (preferences.IsBurstFilterEnabled())
             {
                 if (IsSameLog(eventId, currMsg, prevEventId, prevMsg))
@@ -120,14 +121,10 @@ public:
                     {
                         _Log(loc, lvl, prevEventId, prevMsg, repeatCount);
                         repeatCount = 0;
-
-                        loggerMtx.unlock();
                         return;
                     }
             
                     repeatCount++;
-
-                    loggerMtx.unlock();
                     return;
                 }
 
@@ -141,9 +138,7 @@ public:
                 prevMsg = currMsg;
             }
 
-            _Log(loc, lvl, eventId, currMsg, 0);
-
-            loggerMtx.unlock();          
+            _Log(loc, lvl, eventId, currMsg, 0);            
         }
 #endif
     }
@@ -274,7 +269,6 @@ private:
     int prevEventId = NO_PREV_EVENT;
     std::string prevMsg;
     uint32_t repeatCount = 0;
-    mutex loggerMtx;
     // LCOV_EXCL_STOP
 };
 

--- a/src/logger/logger.h
+++ b/src/logger/logger.h
@@ -109,10 +109,18 @@ public:
 #ifndef POS_UT_SUPPRESS_LOGMSG
         if (ShouldFilter(lvl, eventId) == false)
         {
-            // We won't log this event when its ID and message are
-            // the same as the previous ones.
-            std::string currMsg = fmt::format(fmt, args...);
+            std::string currMsg = "";
+            try
+            {
+                currMsg = fmt::format(fmt, args...);
+            }
+            catch(const std::exception& e)
+            {
+                // Proceed when an exception occurs in fmt::format()
+            }           
 
+            // BurstFilter: we won't log this event when its ID and message are
+            // the same as the previous ones.
             if (preferences.IsBurstFilterEnabled())
             {
                 if (IsSameLog(eventId, currMsg, prevEventId, prevMsg))

--- a/src/logger/logger.h
+++ b/src/logger/logger.h
@@ -54,6 +54,7 @@
 #include "src/lib/singleton.h"
 
 #define POS_EVENT_FILE_PATH "/etc/pos/pos_event.yaml"
+#define NO_PREV_EVENT -1
 
 using namespace std;
 
@@ -88,7 +89,7 @@ public:
         int id, spdlog::string_view_t fmt, const Args&... args)
     {
 #ifndef POS_UT_SUPPRESS_LOGMSG
-        if (ShouldLog(lvl, id))
+        if (ShouldFilter(lvl, id) == false)
         {
             uint32_t moduleId = static_cast<uint32_t>(module);
             fmt::memory_buffer buf;
@@ -106,47 +107,28 @@ public:
         int eventId, spdlog::string_view_t fmt, const Args&... args)
     {
 #ifndef POS_UT_SUPPRESS_LOGMSG
-        if (ShouldLog(lvl, eventId))
+        if (ShouldFilter(lvl, eventId) == false)
         {
-            auto event_info = eventManager.GetEventInfo();
-            auto it = event_info->find(eventId);
-            try
+            // We won't log this event when its ID and message are
+            // the same as the previous ones.
+            std::string currMsg = fmt::format(fmt, args...);
+            if (IsSameLog(eventId, currMsg, prevEventId, prevMsg))
             {
-                if (it == event_info->end())
-                {
-                    // TODO (mj): currently, we print raw message
-                    // when there is no information about the event in PosEventInfo.
-                    // A method is required to enforce to add event information to
-                    // PoSEventInfo.(e.g., invoking a compile error if eventId does not
-                    // match with PosEventInfo)
-                    logger->iboflog_sink(loc, lvl, eventId,
-                        fmt::format(
-                            preferences.IsStrLoggingEnabled() ? "\"event_name:\":\"\",\"message\":\"{}\",\"cause\":\"\",\"solution\":\"\",\"variables\":\"\"" : "\tN/A - {} (cause: N/A, solution: N/A, variables: N/A)",
-                            fmt),
-                        args...);
-                }
-                else
-                {
-                    logger->iboflog_sink(loc, lvl, eventId,
-                        fmt::format(
-                            preferences.IsStrLoggingEnabled() ? "\"event_name:\":\"{}\",\"message\":\"{}\",\"cause\":\"{}\",\"solution\":\"{}\",\"variables\":\"{}\"" : "\t{} - {} (cause: {}, solution: {}, variables: {})",
-                            it->second.GetEventName(), it->second.GetMessage(),
-                            it->second.GetCause(), it->second.GetSolution(),
-                            fmt),
-                        args...);
-                }
+                repeatCount++;
+                return;
             }
-            catch (const std::exception& e)
+
+            // Log the previous event if there was a repetition.
+            if (repeatCount > 0)
             {
-                try
-                {
-                    logger->iboflog_sink(loc, lvl, eventId, fmt::format("\"exception\":\"{}\",\"message\":\"{}\"", e.what(), fmt), args...);
-                }
-                catch (const std::exception& e)
-                {
-                    logger->iboflog_sink(loc, lvl, eventId, "expection has occured while parsing the event log: " + std::string(e.what()));
-                }
+                _Log(loc, lvl, prevEventId, prevMsg, repeatCount);
+                repeatCount = 0;
             }
+            
+            prevEventId = eventId;
+            prevMsg = currMsg;
+
+            _Log(loc, lvl, eventId, currMsg, 0);            
         }
 #endif
     }
@@ -186,17 +168,97 @@ public:
         return preferences.LogDir();
     }
 
-    bool ShouldLog(spdlog::level::level_enum lvl, int id)
+    bool ShouldFilter(spdlog::level::level_enum lvl, int id)
     {
-        return preferences.ShouldLog(lvl, id);
+        return !preferences.ShouldLog(lvl, id);
+    }
+
+    bool IsSameLog(int event1Id, std::string event1Msg, int event2Id, std::string event2Msg)
+    {
+        if ((event1Id == event2Id) && (event1Msg == event2Msg))
+        {
+            return true;
+        }
+
+        return false;
     }
 
 private:
+    std::string _ReplaceAll(std::string str, const std::string& from, const std::string& to) {
+        size_t startPos = 0;
+        while((startPos = str.find(from, startPos)) != std::string::npos) {
+            str.replace(startPos, from.length(), to);
+            startPos += to.length();
+        }
+        return str;
+    }
+
+    // Replace special characters that may cause problems in iboflog_sink()
+    std::string _ReplaceSpecialChars(std::string msg)
+    {
+        std::string newMsg = msg;
+
+        newMsg = _ReplaceAll(newMsg, "{", "{{");
+        newMsg = _ReplaceAll(newMsg, "}", "}}");
+
+        return newMsg;
+    }
+
+    void _Log(spdlog::source_loc loc, spdlog::level::level_enum lvl, int eventId,
+    std::string msg, int repeatCount)
+    {
+        auto event_info = eventManager.GetEventInfo();
+        auto it = event_info->find(eventId);
+        try
+        {
+            msg = _ReplaceSpecialChars(msg);
+            
+            if (it == event_info->end())
+            {                
+                // TODO (mj): currently, we print raw message
+                // when there is no information about the event in PosEventInfo.
+                // A method is required to enforce to add event information to
+                // PoSEventInfo.(e.g., invoking a compile error if eventId does not
+                // match with PosEventInfo)
+                logger->iboflog_sink(loc, lvl, eventId,
+                    fmt::format(
+                        preferences.IsStrLoggingEnabled() ?
+                            "\"event_name:\":\"\",\"message\":\"{}\",\"cause\":\"\",\"solution\":\"\",\"variables\":\"\",\"repetition\":{}"
+                            : "\tN/A - {} (cause: N/A, solution: N/A, variables: N/A, repetition: {})",
+                        msg, repeatCount));
+            }
+            else
+            {
+                logger->iboflog_sink(loc, lvl, eventId,
+                    fmt::format(
+                        preferences.IsStrLoggingEnabled() ?
+                            "\"event_name:\":\"{}\",\"message\":\"{}\",\"cause\":\"{}\",\"solution\":\"{}\",\"variables\":\"{}\",\"repetition\":{}"
+                            : "\t{} - {} (cause: {}, solution: {}, variables: {}, repetition: {})",
+                        it->second.GetEventName(), it->second.GetMessage(),
+                        it->second.GetCause(), it->second.GetSolution(),
+                        msg, repeatCount));
+            }
+        }
+        catch (const std::exception& e)
+        {
+            try
+            {
+                logger->iboflog_sink(loc, lvl, eventId, fmt::format("\"exception\":\"{}\",\"message\":\"{}\"", e.what(), msg));
+            }
+            catch (const std::exception& e)
+            {
+                logger->iboflog_sink(loc, lvl, eventId, "expection has occured while parsing the event log: " + std::string(e.what()));
+            }
+        }
+    }
     const uint32_t MAX_LOGGER_DUMP_SIZE = 1 * 1024 * 1024;
     const uint32_t AVG_LINE = 80;
     DumpModule<DumpBuffer>* dumpModule[static_cast<uint32_t>(ModuleInDebugLogDump::MAX_SIZE)];
     shared_ptr<spdlog::logger> logger;
     pos_logger::Preferences preferences;
+    int prevEventId = NO_PREV_EVENT;
+    std::string prevMsg;
+    unsigned int repeatCount = 0;
     // LCOV_EXCL_STOP
 };
 

--- a/src/logger/preferences.cpp
+++ b/src/logger/preferences.cpp
@@ -46,6 +46,8 @@ Preferences::Preferences()
     logRotation = conf.NumOfLogFilesForRotation();
     logLevel = StringToLogLevel(conf.LogLevel());
     EnableStructuredLogging = conf.IsStrLoggingEnabled();
+    EnableBurstFilter = conf.IsBurstFilterEnabled();
+    burstFilterWindowSize = conf.GetBurstFilterWindowSize();
 
     ApplyFilter();
 }

--- a/src/logger/preferences.h
+++ b/src/logger/preferences.h
@@ -37,6 +37,8 @@
 #include "spdlog/spdlog.h"
 #include "src/helper/json/json_helper.h"
 
+#define DEFAULT_BURST_FILTER_WINDOW_SIZE 1000
+
 using namespace std;
 namespace pos_logger
 {
@@ -104,6 +106,9 @@ public:
     bool ShouldLog(spdlog::level::level_enum lvl, int id);
     string LogLevelToString(spdlog::level::level_enum lvl);
     spdlog::level::level_enum StringToLogLevel(string lvl);
+    bool IsBurstFilterEnabled() { return EnableBurstFilter; }
+    uint32_t GetBurstFilterWindowSize() { return burstFilterWindowSize; }
+    void SetBurstFilterWindowSize(uint32_t size) { burstFilterWindowSize = size; } 
 
 private:
     const string LOG_PATH = "/var/log/pos/";
@@ -119,5 +124,7 @@ private:
     spdlog::level::level_enum logLevel;
     Filter filter;
     bool EnableStructuredLogging;
+    bool EnableBurstFilter;
+    uint32_t burstFilterWindowSize = DEFAULT_BURST_FILTER_WINDOW_SIZE;
 };
 } // namespace pos_logger

--- a/src/metafs/metafs_service.cpp
+++ b/src/metafs/metafs_service.cpp
@@ -189,7 +189,7 @@ MetaFsService::_CreateScheduler(const uint32_t totalCoreCount,
 
             int numaId = needToIgnoreNuma ? 0 : _GetNumaId(coreId);
             POS_TRACE_INFO(EID(MFS_INFO_MESSAGE),
-                "MetaScheduler #{} is created, coreId: {}, numaId: [}",
+                "MetaScheduler #{} is created, coreId: {}, numaId: {}",
                 numOfSchedulersCreated, coreId, numaId);
 
             if (ioScheduler_.find(numaId) == ioScheduler_.end())

--- a/test/unit-tests/logger/logger_test.cpp
+++ b/test/unit-tests/logger/logger_test.cpp
@@ -142,7 +142,7 @@ TEST(Logger, ApplyFilter_testIfFilterIsAppliedWellByGetPreferencesAfterApplyingT
 }
 
 
-TEST(Logger, ShouldLog_testIfFilterIsApplied)
+TEST(Logger, ShouldFilter_testIfFilterIsApplied)
 {
     // Backup existing filter
     string filterPath = "/var/log/pos/filter";
@@ -170,11 +170,11 @@ TEST(Logger, ShouldLog_testIfFilterIsApplied)
     rename(filterBackup.c_str(), filterPath.c_str());
 
     // Then
-    bool include = logger->ShouldLog(spdlog::level::info, 1005);
-    bool exclude = logger->ShouldLog(spdlog::level::info, 3000);
+    bool include = logger->ShouldFilter(spdlog::level::info, 1005);
+    bool exclude = logger->ShouldFilter(spdlog::level::info, 3000);
 
-    ASSERT_EQ(include, true);
-    ASSERT_EQ(exclude, false);
+    ASSERT_EQ(include, false);
+    ASSERT_EQ(exclude, true);
 }
 
 TEST(ChangeLogger, LoggingStateChangeConditionally_testIfLoggerWillNotPrintAnyLogWhenCurrentStateIsTheSame)


### PR DESCRIPTION
Add BurstFilter to logger.

**Background**
Previously, although a number of the same events occur, the old logger logged all the duplicated events.
This was problematic because the huge number of event logs severely degraded the readability of the log.

To mitigate the problem, this commit implements BurstFilter.

**BurstFilter**
When the same events occur repeatedly, the new logger with BurstFilter does not log the event. Instead, it stores the event's ID, message, and the repetition count.

The duplicated events are logged to the file when
- A new (different) event occurs
- The number of duplicated events becomes greater than BurstFilter window size

Add enable_burst_filter and burst_filter_window_size to pos.conf