### PR TITLE
[AWIBOF-7505] remove error log and add check urgent before locking rba

### DIFF
--- a/src/allocator/block_manager/block_manager.cpp
+++ b/src/allocator/block_manager/block_manager.cpp
@@ -142,6 +142,12 @@ BlockManager::PermitUserBlkAlloc(void)
 }
 
 bool
+BlockManager::IsProhibitedUserBlkAlloc(void)
+{
+    return allocStatus->IsProhibitedUserBlockAllocation();
+}
+
+bool
 BlockManager::BlockAllocating(uint32_t volumeId)
 {
     return allocStatus->TryProhibitBlockAllocation(volumeId);

--- a/src/allocator/block_manager/block_manager.cpp
+++ b/src/allocator/block_manager/block_manager.cpp
@@ -106,7 +106,6 @@ BlockManager::AllocateGcDestStripe(uint32_t volumeId)
     StripeId arrayLsid = _AllocateSsdStripe();
     if (IsUnMapStripe(arrayLsid))
     {
-        POS_TRACE_ERROR(EID(ALLOCATOR_CANNOT_ALLOCATE_STRIPE), "failed to allocate gc stripe!");
         return nullptr;
     }
 

--- a/src/allocator/block_manager/block_manager.h
+++ b/src/allocator/block_manager/block_manager.h
@@ -60,6 +60,7 @@ public:
     virtual Stripe* AllocateGcDestStripe(uint32_t volumeId);
     virtual void ProhibitUserBlkAlloc(void) override;
     virtual void PermitUserBlkAlloc(void) override;
+    virtual bool IsProhibitedUserBlkAlloc(void) override;
 
     virtual bool BlockAllocating(uint32_t volumeId) override;
     virtual void UnblockAllocating(uint32_t volumeId) override;

--- a/src/allocator/context_manager/block_allocation_status.cpp
+++ b/src/allocator/context_manager/block_allocation_status.cpp
@@ -92,6 +92,12 @@ BlockAllocationStatus::ProhibitUserBlockAllocation(void)
     userBlkAllocProhibited = true;
 }
 
+bool
+BlockAllocationStatus::IsProhibitedUserBlockAllocation(void)
+{
+    return userBlkAllocProhibited;
+}
+
 void
 BlockAllocationStatus::ProhibitBlockAllocation(void)
 {

--- a/src/allocator/context_manager/block_allocation_status.h
+++ b/src/allocator/context_manager/block_allocation_status.h
@@ -54,6 +54,7 @@ public:
     virtual void PermitBlockAllocation(int volumeId);
 
     virtual void ProhibitUserBlockAllocation(void);
+    virtual bool IsProhibitedUserBlockAllocation(void);
     virtual void ProhibitBlockAllocation(void);
 
     virtual bool TryProhibitBlockAllocation(int volumeId);

--- a/src/allocator/i_block_allocator.h
+++ b/src/allocator/i_block_allocator.h
@@ -47,6 +47,7 @@ public:
 
     virtual void ProhibitUserBlkAlloc(void) = 0;
     virtual void PermitUserBlkAlloc(void) = 0;
+    virtual bool IsProhibitedUserBlkAlloc(void) = 0;
 
     virtual bool BlockAllocating(uint32_t volumeId) = 0;
     virtual void UnblockAllocating(uint32_t volumeId) = 0;

--- a/src/event_scheduler/callback.cpp
+++ b/src/event_scheduler/callback.cpp
@@ -105,11 +105,6 @@ Callback::~Callback(void)
     airlog("Callback_Destructor", "internal", type, 1);
     if (unlikely(executed == false))
     {
-        POS_EVENT_ID eventId = EID(CALLBACK_DESTROY_WITHOUT_EXECUTED);
-        POS_TRACE_WARN(
-            eventId,
-            "Callback destroy without executed : {}",
-            static_cast<uint32_t>(type));
         DumpBuffer buffer(this, sizeof(Callback), &dumpCallbackError);
         dumpCallbackError.AddDump(buffer, 0);
     }

--- a/src/io/backend_io/stripe_map_update_request.cpp
+++ b/src/io/backend_io/stripe_map_update_request.cpp
@@ -137,19 +137,13 @@ StripeMapUpdateRequest::_DoSpecificJob(void)
     }
 
     eventId = EID(NFLSH_STRIPE_DEBUG_UPDATE);
-    POS_TRACE_DEBUG_IN_MEMORY(ModuleInDebugLogDump::IO_FLUSH, eventId, "Stripe Map Update Request : stripe.vsid : {}",
-        stripe->GetVsid());
 
     int result = iMetaUpdater->UpdateStripeMap(stripe, completionEvent);
     if (unlikely(EID(SUCCESS) != result))
     {
         // TODO (dh.ihm) Need to make fatal error (ret < 0) handle path.
-        POS_EVENT_ID eventId =
-            EID(NFLSH_EVENT_MAP_UPDATE_FAILED);
-        std::stringstream message;
-        message << "FlushCompletion for vsid: " << stripe->GetVsid() << ", wbLsid: " << stripe->GetWbLsid() << ", userAreaLsid: " << stripe->GetUserLsid();
-        POS_TRACE_ERROR(static_cast<int>(eventId),
-            "Failed to update map: {}", message.str());
+        POS_TRACE_DEBUG_IN_MEMORY(ModuleInDebugLogDump::IO_FLUSH, eventId, "Try Stripe Map flush again : stripe.vsid : {}",
+            stripe->GetVsid());
 
         return false;
     }

--- a/src/io/frontend_io/write_submission.cpp
+++ b/src/io/frontend_io/write_submission.cpp
@@ -112,6 +112,10 @@ WriteSubmission::Execute(void)
 {
     try
     {
+        if (iBlockAllocator->IsProhibitedUserBlkAlloc() == true)
+        {
+            return false;
+        }
         int token = flowControl->GetToken(FlowControlType::USER, blockCount);
         if (0 >= token)
         {

--- a/test/unit-tests/allocator/block_manager/block_manager_mock.h
+++ b/test/unit-tests/allocator/block_manager/block_manager_mock.h
@@ -17,6 +17,7 @@ public:
     MOCK_METHOD((std::pair<VirtualBlks, StripeId>), AllocateWriteBufferBlks, (uint32_t volumeId, uint32_t numBlks), (override));
     MOCK_METHOD(Stripe*, AllocateGcDestStripe, (uint32_t volumeId), (override));
     MOCK_METHOD(void, ProhibitUserBlkAlloc, (), (override));
+    MOCK_METHOD(bool, IsProhibitedUserBlkAlloc, (), (override));
     MOCK_METHOD(void, PermitUserBlkAlloc, (), (override));
     MOCK_METHOD(bool, BlockAllocating, (uint32_t volumeId), (override));
     MOCK_METHOD(void, UnblockAllocating, (uint32_t volumeId), (override));

--- a/test/unit-tests/allocator/i_block_allocator_mock.h
+++ b/test/unit-tests/allocator/i_block_allocator_mock.h
@@ -16,6 +16,7 @@ public:
     MOCK_METHOD((std::pair<VirtualBlks, StripeId>), AllocateWriteBufferBlks, (uint32_t volumeId, uint32_t numBlks), (override));
     MOCK_METHOD(Stripe*, AllocateGcDestStripe, (uint32_t volumeId), (override));
     MOCK_METHOD(void, ProhibitUserBlkAlloc, (), (override));
+    MOCK_METHOD(bool, IsProhibitedUserBlkAlloc, (), (override));
     MOCK_METHOD(void, PermitUserBlkAlloc, (), (override));
     MOCK_METHOD(bool, BlockAllocating, (uint32_t volumeId), (override));
     MOCK_METHOD(void, UnblockAllocating, (uint32_t volumeId), (override));


### PR DESCRIPTION
1) Remove Error Log to reduce GC overhead
2) Check Urgent state before locking rba in write submission