### PR TITLE
fixed an exception due to invalid volume id when performing GC strip force flush

### DIFF
--- a/config/publication_list_default.yaml
+++ b/config/publication_list_default.yaml
@@ -36,6 +36,9 @@ metrics_to_publish:
   write_avg_lat_volume:
   write_iops_volume:
   write_bps_volume:
-  gc_total_processing_count:
-  gc_flushing_count:
-  gc_updating_count:
+  gc_stripe_count_requested:
+  gc_stripe_count_completed:
+  gc_stripe_count_flush_requested:
+  gc_stripe_count_flush_completed:
+  gc_stripe_count_map_update_requested:
+  gc_stripe_count_map_update_completed:

--- a/config/publication_list_default.yaml
+++ b/config/publication_list_default.yaml
@@ -36,3 +36,6 @@ metrics_to_publish:
   write_avg_lat_volume:
   write_iops_volume:
   write_bps_volume:
+  gc_total_processing_count:
+  gc_flushing_count:
+  gc_updating_count:

--- a/config/publication_list_default.yaml
+++ b/config/publication_list_default.yaml
@@ -42,3 +42,4 @@ metrics_to_publish:
   gc_stripe_count_flush_completed:
   gc_stripe_count_map_update_requested:
   gc_stripe_count_map_update_completed:
+  gc_stripe_count_force_flush_requested:

--- a/src/allocator/allocator.cpp
+++ b/src/allocator/allocator.cpp
@@ -528,27 +528,31 @@ Allocator::_SetGCThreshold(void)
             "retNormalRatio:{}, retNormalLb:{}, retUrgentRatio:{}, retUrgentLb:{}",
             retNormalRatio, retNormalLb, retUrgentRatio, retUrgentLb);
     }
-    POS_TRACE_INFO(EID(GC_THREHOLD_SETTING_PRINT), "normal_gc_ratio:{}, urgent_gc_ratio:{}, normal_gc_lb:{}, urgent_gc_lb:{}",
-        normal_gc_ratio, urgent_gc_ratio, normal_gc_lb, urgent_gc_lb);
-
     const PartitionLogicalSize* dataPartitionSize = iArrayInfo->GetSizeInfo(PartitionType::USER_DATA);
+    uint32_t baseCapacity = 0;
+    bool lbBounded = false;
     if (dataPartitionSize != nullptr)
     {
-        uint32_t normalGcThreshold = (uint32_t)(dataPartitionSize->totalSegments * normal_gc_ratio / 100);
+        baseCapacity = dataPartitionSize->totalSegments;
+        normalGcThreshold = (uint32_t)(baseCapacity * normal_gc_ratio / 100);
         if (normalGcThreshold < normal_gc_lb)
         {
             normalGcThreshold = normal_gc_lb;
+            lbBounded = true;
         }
-        uint32_t urgentGcThreshold = (uint32_t)(normalGcThreshold * urgent_gc_ratio / 100);
+        urgentGcThreshold = (uint32_t)(normalGcThreshold * urgent_gc_ratio / 100);
         if (urgentGcThreshold < urgent_gc_lb)
         {
             urgentGcThreshold = urgent_gc_lb;
+            lbBounded = true;
         }
     }
     else
     {
         POS_TRACE_ERROR(EID(GC_THRESHOLD_SETTING_ERROR_INVALID_ARRAY_SIZE), "");
     }
+    POS_TRACE_INFO(EID(GC_THREHOLD_SETTING_PRINT), "normal_gc_ratio:{}, urgent_gc_ratio:{}, normal_gc_lb:{}, urgent_gc_lb:{}, base_capa:{}, normal_threshold:{}, urgent_threshold:{}, is_lower_bounded:{}",
+        normal_gc_ratio, urgent_gc_ratio, normal_gc_lb, urgent_gc_lb, baseCapacity, normalGcThreshold, urgentGcThreshold, lbBounded);
     SetNormalGcThreshold(normalGcThreshold);
     SetUrgentThreshold(urgentGcThreshold);
 }

--- a/src/gc/copier_meta.cpp
+++ b/src/gc/copier_meta.cpp
@@ -109,10 +109,11 @@ CopierMeta::~CopierMeta(void)
     }
 }
 
-void*
-CopierMeta::GetBuffer(StripeId stripeId)
+void
+CopierMeta::GetBuffers(uint32_t count, std::vector<void*>* retBuffers)
 {
-    return gcBufferPool->TryGetBuffer();
+    uint32_t minAcqCount = 1;
+    gcBufferPool->TryGetBuffers(count, retBuffers, minAcqCount);
 }
 
 void

--- a/src/gc/copier_meta.h
+++ b/src/gc/copier_meta.h
@@ -61,7 +61,7 @@ public:
 
     virtual ~CopierMeta(void);
 
-    virtual void* GetBuffer(StripeId stripeId);
+    virtual void GetBuffers(uint32_t count, std::vector<void*>* retBuffers);
     virtual void ReturnBuffer(StripeId stripeId, void* buffer);
 
     virtual void SetStartCopyStripes(void);

--- a/src/gc/copier_read_completion.cpp
+++ b/src/gc/copier_read_completion.cpp
@@ -95,7 +95,7 @@ CopierReadCompletion::_DoSpecificJob(void)
     assert(volId != UINT32_MAX);
     if (gcStripeManager->TryFlushLock(volId) == false)
     {
-        POS_TRACE_DEBUG(EID(GC_NORMAL_FLUSH_TRYLOCK_FAILED), "vol_id:{}", volId);
+        POS_TRACE_DEBUG(EID(GC_NORMAL_FLUSH_TRYLOCK_FAILED), "array_id:{}, vol_id:{}", meta->GetArrayIndex(), volId);
         return false;
     }
     uint32_t remainCnt = blkCnt - allocatedCnt;

--- a/src/gc/flow_control/flow_control.cpp
+++ b/src/gc/flow_control/flow_control.cpp
@@ -263,10 +263,11 @@ FlowControl::_RefillToken(FlowControlType type)
     uint32_t userToken;
     uint32_t gcToken;
 
+    uint32_t arrayId = arrayInfo->GetIndex();
     std::tie(userToken, gcToken) = _DistributeToken();
     POS_TRACE_INFO(EID(FLOW_CONTROL_TOKEN_DISTRIBUTED),
-        "userToken:{}, gcToken:{}, userBucket:{}, gcBucket:{}",
-        userToken, gcToken, bucket[FlowControlType::USER], bucket[FlowControlType::GC]);
+        "userToken:{}, gcToken:{}, userBucket:{}, gcBucket:{}, array_id:{}",
+        userToken, gcToken, bucket[FlowControlType::USER], bucket[FlowControlType::GC], arrayId);
     bucket[FlowControlType::USER].fetch_add(userToken);
     bucket[FlowControlType::GC].fetch_add(gcToken);
 
@@ -303,10 +304,11 @@ FlowControl::_TryForceResetToken(FlowControlType type)
     bucket[FlowControlType::GC] = 0;
 
     isForceReset = false;
+    uint32_t arrayId = arrayInfo->GetIndex();
     POS_TRACE_INFO(EID(FLOW_CONTROL_FORCERESET_DONE),
-        "userPrevBucket:{}, gcPrevBucket:{}, gcThreshold:{}, freeSegments:{}",
+        "userPrevBucket:{}, gcPrevBucket:{}, gc_normal_threshold:{}, free_segment_count:{}, array_id:{}",
         previousBucket[FlowControlType::USER], previousBucket[FlowControlType::GC],
-        gcThreshold, freeSegments);
+        gcThreshold, freeSegments, arrayId);
 
     return true;
 }

--- a/src/gc/gc_flush_completion.cpp
+++ b/src/gc/gc_flush_completion.cpp
@@ -127,6 +127,7 @@ GcFlushCompletion::_DoSpecificJob(void)
     {
         event = inputEvent;
     }
+    gcStripeManager->MapUpdateRequested();
     stripe->Flush(event);
     return true;
 }

--- a/src/gc/gc_flush_completion.cpp
+++ b/src/gc/gc_flush_completion.cpp
@@ -160,6 +160,10 @@ GcFlushCompletion::Init(void)
             }
         }
     }
+    {
+        BlkAddr rba;
+        std::tie(rba, volId) = stripe->GetReverseMapEntry(0);
+    }
     sectorRbaList.sort();
     currPos = sectorRbaList.begin();
     lsid = stripe->GetUserLsid();

--- a/src/gc/gc_flush_completion.cpp
+++ b/src/gc/gc_flush_completion.cpp
@@ -98,6 +98,7 @@ GcFlushCompletion::_DoSpecificJob(void)
 
     if (isInit == false)
     {
+        gcStripeManager->FlushCompleted();
         Init();
     }
 
@@ -127,7 +128,7 @@ GcFlushCompletion::_DoSpecificJob(void)
     {
         event = inputEvent;
     }
-    gcStripeManager->MapUpdateRequested();
+    gcStripeManager->UpdateMapRequested();
     stripe->Flush(event);
     return true;
 }

--- a/src/gc/gc_flush_submission.cpp
+++ b/src/gc/gc_flush_submission.cpp
@@ -193,14 +193,20 @@ GcFlushSubmission::Execute(void)
         iArrayInfo->GetIndex(),
         false);
 
+    bool result = (IOSubmitHandlerStatus::SUCCESS == errorReturned || IOSubmitHandlerStatus::FAIL_IN_SYSTEM_STOP == errorReturned);
+    if (result == true)
+    {
+        gcStripeManager->FlushSubmitted();
+    }
+
     POS_TRACE_DEBUG(EID(GC_STRIPE_FLUSH_SUBMISSION),
         "arrayName:{}, validCnt:{}, stripeUserLsid:{}, result:{}",
         arrayName,
         validCnt,
         logicalStripeId,
-        (IOSubmitHandlerStatus::SUCCESS == errorReturned || IOSubmitHandlerStatus::FAIL_IN_SYSTEM_STOP == errorReturned));
+        result);
 
-    return (IOSubmitHandlerStatus::SUCCESS == errorReturned || IOSubmitHandlerStatus::FAIL_IN_SYSTEM_STOP == errorReturned);
+    return result;
 }
 
 Stripe*

--- a/src/gc/gc_map_update_completion.cpp
+++ b/src/gc/gc_map_update_completion.cpp
@@ -102,8 +102,8 @@ GcMapUpdateCompletion::_DoSpecificJob(void)
     volumeManager->DecreasePendingIOCount(volId, VolumeIoType::InternalIo);
     airlog("InternalIoPendingCnt", "user", volId, -1);
 
-    gcStripeManager->SetFinished();
     gcStripeManager->UpdateMapCompleted();
+    gcStripeManager->SetFinished();
 
     POS_TRACE_DEBUG(EID(GC_MAP_UPDATE_COMPLETION),
         "gc map update completion, arrayName:{}, stripeUserLsid:{}",

--- a/src/gc/gc_map_update_completion.cpp
+++ b/src/gc/gc_map_update_completion.cpp
@@ -103,6 +103,7 @@ GcMapUpdateCompletion::_DoSpecificJob(void)
     airlog("InternalIoPendingCnt", "user", volId, -1);
 
     gcStripeManager->SetFinished();
+    gcStripeManager->MapUpdateCompleted();
 
     POS_TRACE_DEBUG(EID(GC_MAP_UPDATE_COMPLETION),
         "gc map update completion, arrayName:{}, stripeUserLsid:{}",

--- a/src/gc/gc_map_update_completion.cpp
+++ b/src/gc/gc_map_update_completion.cpp
@@ -103,7 +103,7 @@ GcMapUpdateCompletion::_DoSpecificJob(void)
     airlog("InternalIoPendingCnt", "user", volId, -1);
 
     gcStripeManager->SetFinished();
-    gcStripeManager->MapUpdateCompleted();
+    gcStripeManager->UpdateMapCompleted();
 
     POS_TRACE_DEBUG(EID(GC_MAP_UPDATE_COMPLETION),
         "gc map update completion, arrayName:{}, stripeUserLsid:{}",

--- a/src/gc/gc_stripe_manager.cpp
+++ b/src/gc/gc_stripe_manager.cpp
@@ -97,7 +97,7 @@ GcStripeManager::GcStripeManager(IArrayInfo* iArrayInfo,
     _SetBufferPool();
     if (publisher == nullptr)
     {
-        publisher = new TelemetryPublisher("SpaceInfo");
+        publisher = new TelemetryPublisher("GCStripeManager");
         publisher->AddDefaultLabel("array_id", to_string(arrayId));
         TelemetryClientSingleton::Instance()->RegisterPublisher(publisher);
     }

--- a/src/gc/gc_stripe_manager.cpp
+++ b/src/gc/gc_stripe_manager.cpp
@@ -95,6 +95,7 @@ GcStripeManager::GcStripeManager(IArrayInfo* iArrayInfo,
     gcStripeCntFlushCompleted = 0;
     gcStripeCntMapUpdateRequested = 0;
     gcStripeCntMapUpdateCompleted = 0;
+    gcStripeCntForceFlushRequested = 0;
 
     volumeEventPublisher->RegisterSubscriber(this, arrayName, arrayId);
     _SetBufferPool();
@@ -293,6 +294,12 @@ GcStripeManager::SetFinished(void)
         metric.AddLabel("array_id", to_string(arrayId));
         v->push_back(metric);
     }
+    {
+        POSMetric metric(TEL90006_GC_STRIPE_COUNT_FORCE_FLUSH_REQUESTED, POSMetricTypes::MT_GAUGE);
+        metric.SetGaugeValue(gcStripeCntForceFlushRequested);
+        metric.AddLabel("array_id", to_string(arrayId));
+        v->push_back(metric);
+    }
     publisher->PublishMetricList(v);
 }
 
@@ -348,6 +355,10 @@ GcStripeManager::SetFlushed(uint32_t volumeId, bool force)
     gcActiveWriteBuffers[volumeId] = nullptr;
     flushed[volumeId] = true;
     ++gcStripeCntRequested;
+    if (force == true)
+    {
+        ++gcStripeCntForceFlushRequested;
+    }
 }
 
 void

--- a/src/gc/gc_stripe_manager.h
+++ b/src/gc/gc_stripe_manager.h
@@ -96,6 +96,8 @@ public:
     void CheckTimeout(void);
     virtual bool TryFlushLock(uint32_t volId);
     virtual void ReleaseFlushLock(uint32_t volId);
+    void MapUpdateRequested(void);
+    void MapUpdateCompleted(void);
 
     static const uint32_t GC_VOLUME_COUNT = MAX_VOLUME_COUNT;
 
@@ -127,6 +129,7 @@ private:
     std::vector<BlkInfo>* blkInfoList[GC_VOLUME_COUNT];
     const PartitionLogicalSize* udSize;
     std::atomic<uint32_t> flushedStripeCnt;
+    std::atomic<uint32_t> mapUpdatingCnt;
 
     VolumeEventPublisher* volumeEventPublisher;
     MemoryManager* memoryManager;

--- a/src/gc/gc_stripe_manager.h
+++ b/src/gc/gc_stripe_manager.h
@@ -138,6 +138,7 @@ private:
     std::atomic<uint64_t> gcStripeCntFlushCompleted;
     std::atomic<uint64_t> gcStripeCntMapUpdateRequested;
     std::atomic<uint64_t> gcStripeCntMapUpdateCompleted;
+    std::atomic<uint64_t> gcStripeCntForceFlushRequested;
 
     VolumeEventPublisher* volumeEventPublisher;
     MemoryManager* memoryManager;

--- a/src/gc/gc_stripe_manager.h
+++ b/src/gc/gc_stripe_manager.h
@@ -118,9 +118,6 @@ private:
     void _SetForceFlushInterval(void);
     void _StartTimer(uint32_t volumeId);
     void _ResetFlushLock(uint32_t volId);
-    void _PublishTotalProcessingCount(uint32_t count);
-    void _PublishFlushingCount(uint32_t count);
-    void _PublishUpdatingCount(uint32_t count);
 
     std::vector<Stripe*> gcStripeArray;
     IArrayInfo* iArrayInfo;
@@ -134,9 +131,13 @@ private:
     std::mutex gcWriteBufferLock[GC_VOLUME_COUNT];
     std::vector<BlkInfo>* blkInfoList[GC_VOLUME_COUNT];
     const PartitionLogicalSize* udSize;
-    std::atomic<uint32_t> totalProcessingCnt;
-    std::atomic<uint32_t> flushingCnt;
-    std::atomic<uint32_t> mapUpdatingCnt;
+
+    std::atomic<uint64_t> gcStripeCntRequested;
+    std::atomic<uint64_t> gcStripeCntCompleted;
+    std::atomic<uint64_t> gcStripeCntFlushRequested;
+    std::atomic<uint64_t> gcStripeCntFlushCompleted;
+    std::atomic<uint64_t> gcStripeCntMapUpdateRequested;
+    std::atomic<uint64_t> gcStripeCntMapUpdateCompleted;
 
     VolumeEventPublisher* volumeEventPublisher;
     MemoryManager* memoryManager;

--- a/src/gc/stripe_copier.cpp
+++ b/src/gc/stripe_copier.cpp
@@ -89,34 +89,19 @@ StripeCopier::Execute(void)
     uint32_t listSize = meta->GetVictimStripe(copyIndex, stripeOffset)->GetBlkInfoListSize();
     if (0 != listSize)
     {
+        uint32_t count = listSize - listIndex;
+        vector<void*> buffers;
+        meta->GetBuffers(count, &buffers);
+        uint32_t bufCount = buffers.size();
         uint32_t requestCount = 0;
-
-        for (; listIndex < listSize;)
+        for (uint32_t i = 0; i < bufCount; i++)
         {
-            void* buffer = nullptr;
-            buffer = meta->GetBuffer(victimStripeId);
-            if (nullptr == buffer)
-            {
-                meta->SetStartCopyBlks(requestCount);
-                bufAllocRetryCnt++;
-                if (bufAllocRetryCnt % 100 == 0)
-                {
-                    POS_TRACE_DEBUG(EID(GC_GET_READ_BUFFER_FAILED), "stipe_id:{}, failure_count:{}",
-                        victimStripeId, bufAllocRetryCnt);
-                }
-                return false;
-            }
-            else
-            {
-                bufAllocRetryCnt = 0;
-            }
-
+            void* buffer = buffers.back();
+            buffers.pop_back();
             std::list<BlkInfo> blkInfoList = meta->GetVictimStripe(copyIndex, stripeOffset)->GetBlkInfoList(listIndex);
             LogicalBlkAddr lsa;
             auto startBlkInfo = blkInfoList.begin();
-
             uint32_t startOffset = startBlkInfo->vsa.offset;
-
             uint32_t offset = (startOffset / BLOCKS_IN_CHUNK) * BLOCKS_IN_CHUNK;
             lsa = {victimStripeId, offset};
 
@@ -134,7 +119,18 @@ StripeCopier::Execute(void)
             listIndex++;
         }
         meta->SetStartCopyBlks(requestCount);
+        if (count > bufCount)
+        {
+            bufAllocRetryCnt++;
+            if (bufAllocRetryCnt % 100 == 0)
+            {
+                POS_TRACE_DEBUG(EID(GC_GET_READ_BUFFER_FAILED), "stipe_id:{}, required_buf_count:{}, acquired_buf_count:{}, retry_count:{}",
+                    victimStripeId, count, bufCount, bufAllocRetryCnt);
+            }
+            return false;
+        }
     }
+    bufAllocRetryCnt = 0;
     meta->SetStartCopyStripes();
 
     victimStripeId += CopierMeta::GC_CONCURRENT_COUNT;
@@ -151,7 +147,6 @@ StripeCopier::Execute(void)
         }
         eventScheduler->EnqueueEvent(stripeCopier);
     }
-
     return true;
 }
 

--- a/src/io/general_io/rba_state_manager.cpp
+++ b/src/io/general_io/rba_state_manager.cpp
@@ -171,6 +171,8 @@ RBAStateManager::_AcquireOwnership(uint32_t volumeID, BlkAddr startRba,
 {
     if (unlikely(volumeID >= MAX_VOLUME_COUNT))
     {
+        POS_TRACE_ERROR(EID(RBAMGR_WRONG_VOLUME_ID), "vol_id:{}", volumeID);
+        assert(false);
         std::pair<POS_EVENT_ID, EventLevel> eventIdWithLevel(
             EID(RBAMGR_WRONG_VOLUME_ID), EventLevel::ERROR);
         throw eventIdWithLevel;

--- a/src/io/general_io/rba_state_manager.cpp
+++ b/src/io/general_io/rba_state_manager.cpp
@@ -172,7 +172,6 @@ RBAStateManager::_AcquireOwnership(uint32_t volumeID, BlkAddr startRba,
     if (unlikely(volumeID >= MAX_VOLUME_COUNT))
     {
         POS_TRACE_ERROR(EID(RBAMGR_WRONG_VOLUME_ID), "vol_id:{}", volumeID);
-        assert(false);
         std::pair<POS_EVENT_ID, EventLevel> eventIdWithLevel(
             EID(RBAMGR_WRONG_VOLUME_ID), EventLevel::ERROR);
         throw eventIdWithLevel;

--- a/src/resource_manager/buffer_pool.h
+++ b/src/resource_manager/buffer_pool.h
@@ -55,7 +55,7 @@ public:
             HugepageAllocatorSingleton::Instance());
     virtual ~BufferPool(void);
     virtual void* TryGetBuffer(void);
-    virtual bool TryGetBuffers(uint32_t count, std::vector<void*>* retBuffers);
+    virtual bool TryGetBuffers(uint32_t reqCnt, std::vector<void*>* retBuffers, uint32_t minAcqCnt);
     virtual void ReturnBuffer(void*);
     virtual void ReturnBuffers(std::vector<void*>* buffers);
     virtual bool IsAllocated(void) { return isAllocated; }
@@ -64,6 +64,8 @@ public:
 private:
     bool _Init(void);
     void _Clear(void);
+    void _TrySwapWhenConsumerPoolEmpty(void);
+    void _TrySwapWhenProducerPoolIsNotEmpty(void);
     void _Swap(void);
 
     const BufferInfo BUFFER_INFO;
@@ -79,7 +81,7 @@ private:
     std::mutex consumerLock;
     std::mutex producerLock;
     bool isAllocated = false;
-    size_t swapSize = 0;
+    size_t swapThreshold = 0;
     const static size_t SWAP_THRESHOLD_PERCENT = 25;
 };
 

--- a/src/telemetry/telemetry_id.h
+++ b/src/telemetry/telemetry_id.h
@@ -138,6 +138,10 @@ static const std::string TEL70011_WRITE_BPS_NETWORK = "write_bps_network";
 
 static const std::string TEL80000_DEVICE_PENDING_IO_COUNT = "device_pending_io_count";
 
+static const std::string TEL90000_GC_TOTAL_PROCESSING_COUNT = "gc_total_processing_count";
+static const std::string TEL90001_GC_FLUSHING_COUNT = "gc_flushing_count";
+static const std::string TEL90002_GC_UPDATING_COUNT = "gc_updating_count";
+
 static const std::string TEL100000_RESOURCE_CHECKER_AVAILABLE_MEMORY = "available_memory_size";
 
 static const std::string TEL110000_MEDIA_ERROR_COUNT_LOWER = "soft_media_error_lower";

--- a/src/telemetry/telemetry_id.h
+++ b/src/telemetry/telemetry_id.h
@@ -144,6 +144,7 @@ static const std::string TEL90002_GC_STRIPE_COUNT_FLUSH_REQUESTED  = "gc_stripe_
 static const std::string TEL90003_GC_STRIPE_COUNT_FLUSH_COMPLETED  = "gc_stripe_count_flush_completed";
 static const std::string TEL90004_GC_STRIPE_COUNT_MAP_UPDATE_REQUESTED  = "gc_stripe_count_map_update_requested";
 static const std::string TEL90005_GC_STRIPE_COUNT_MAP_UPDATE_COMPLETED  = "gc_stripe_count_map_update_completed";
+static const std::string TEL90006_GC_STRIPE_COUNT_FORCE_FLUSH_REQUESTED  = "gc_stripe_count_force_flush_requested";
 
 static const std::string TEL100000_RESOURCE_CHECKER_AVAILABLE_MEMORY = "available_memory_size";
 

--- a/src/telemetry/telemetry_id.h
+++ b/src/telemetry/telemetry_id.h
@@ -138,9 +138,12 @@ static const std::string TEL70011_WRITE_BPS_NETWORK = "write_bps_network";
 
 static const std::string TEL80000_DEVICE_PENDING_IO_COUNT = "device_pending_io_count";
 
-static const std::string TEL90000_GC_TOTAL_PROCESSING_COUNT = "gc_total_processing_count";
-static const std::string TEL90001_GC_FLUSHING_COUNT = "gc_flushing_count";
-static const std::string TEL90002_GC_UPDATING_COUNT = "gc_updating_count";
+static const std::string TEL90000_GC_STRIPE_COUNT_REQUESTED = "gc_stripe_count_requested";
+static const std::string TEL90001_GC_STRIPE_COUNT_COMPLETED = "gc_stripe_count_completed";
+static const std::string TEL90002_GC_STRIPE_COUNT_FLUSH_REQUESTED  = "gc_stripe_count_flush_requested";
+static const std::string TEL90003_GC_STRIPE_COUNT_FLUSH_COMPLETED  = "gc_stripe_count_flush_completed";
+static const std::string TEL90004_GC_STRIPE_COUNT_MAP_UPDATE_REQUESTED  = "gc_stripe_count_map_update_requested";
+static const std::string TEL90005_GC_STRIPE_COUNT_MAP_UPDATE_COMPLETED  = "gc_stripe_count_map_update_completed";
 
 static const std::string TEL100000_RESOURCE_CHECKER_AVAILABLE_MEMORY = "available_memory_size";
 

--- a/test/unit-tests/gc/copier_meta_mock.h
+++ b/test/unit-tests/gc/copier_meta_mock.h
@@ -10,7 +10,7 @@ class MockCopierMeta : public CopierMeta
 {
 public:
     using CopierMeta::CopierMeta;
-    MOCK_METHOD(void*, GetBuffer, (StripeId stripeId), (override));
+    MOCK_METHOD(void, GetBuffers, (uint32_t count, std::vector<void*>* retBuffers), (override));
     MOCK_METHOD(void, ReturnBuffer, (StripeId stripeId, void* buffer), (override));
     MOCK_METHOD(void, SetStartCopyStripes, (), (override));
     MOCK_METHOD(void, SetStartCopyBlks, (uint32_t blocks), (override));

--- a/test/unit-tests/gc/gc_flush_completion_test.cpp
+++ b/test/unit-tests/gc/gc_flush_completion_test.cpp
@@ -128,12 +128,17 @@ TEST_F(GcFlushCompletionTestFixture, Execute_testIfgcFlushCompletionWhenAcquireR
     EXPECT_CALL(*gcStripeManager, ReturnBuffer(dataBuffer)).Times(1);
     for (uint32_t index = 0 ; index < partitionLogicalSize.blksPerStripe; index++)
     {
-        std::pair<uint32_t, uint32_t> revMapEntry = {index, testVolumeId};
-        EXPECT_CALL(*stripe, GetReverseMapEntry(index)).WillOnce(Return(revMapEntry));
+        if (index > 0)
+        {
+            std::pair<uint32_t, uint32_t> revMapEntry = {index, testVolumeId};
+            EXPECT_CALL(*stripe, GetReverseMapEntry(index)).WillOnce(Return(revMapEntry));
+        }
         // VirtualBlkAddr vsa = {.stripeId = 100, .offset = index};
         // EXPECT_CALL(*vsaMap, GetVSAInternal(testVolumeId, index, _)).WillOnce(Return(vsa));
         // EXPECT_CALL(*stripe, GetVictimVsa(index)).WillOnce(Return(vsa));
     }
+    std::pair<uint32_t, uint32_t> revMapEntry = {0, testVolumeId};
+    EXPECT_CALL(*stripe, GetReverseMapEntry(0)).WillRepeatedly(Return(revMapEntry));
     gcFlushCompletion->Init();
     list<RbaAndSize>* rbaList = gcFlushCompletion->GetRbaList();
     EXPECT_CALL(*rbaStateManager, AcquireOwnershipRbaList(testVolumeId, _, _, _)).WillOnce(Return(rbaList->begin()));
@@ -158,12 +163,17 @@ TEST_F(GcFlushCompletionTestFixture, Execute_testgcFlushExecuteWhenAcquireOwners
 
     for (uint32_t index = 0 ; index < partitionLogicalSize.blksPerStripe; index++)
     {
-        std::pair<uint32_t, uint32_t> revMapEntry = {index, testVolumeId};
-        EXPECT_CALL(*stripe, GetReverseMapEntry(index)).WillOnce(Return(revMapEntry));
+        if (index > 0)
+        {
+            std::pair<uint32_t, uint32_t> revMapEntry = {index, testVolumeId};
+            EXPECT_CALL(*stripe, GetReverseMapEntry(index)).WillOnce(Return(revMapEntry));
+        }
         // VirtualBlkAddr vsa = {.stripeId = 100, .offset = index};
         // EXPECT_CALL(*vsaMap, GetVSAInternal(testVolumeId, index, _)).WillOnce(Return(vsa));
         // EXPECT_CALL(*stripe, GetVictimVsa(index)).WillOnce(Return(vsa));
     }
+    std::pair<uint32_t, uint32_t> revMapEntry = {0, testVolumeId};
+    EXPECT_CALL(*stripe, GetReverseMapEntry(0)).WillRepeatedly(Return(revMapEntry));
     gcFlushCompletion->Init();
     list<RbaAndSize>* rbaList = gcFlushCompletion->GetRbaList();
     EXPECT_CALL(*rbaStateManager, AcquireOwnershipRbaList(testVolumeId, _, _, _)).WillOnce(Return(rbaList->end()));
@@ -187,13 +197,19 @@ TEST_F(GcFlushCompletionTestFixture, Execute_testRbaListShouldBeUniqueAndBeSorte
     uint32_t cnt = 0;
     for (uint32_t index = 0 ; index < partitionLogicalSize.blksPerStripe; index++)
     {
-        uint32_t rba = (4 - (index % 4)) * 100; // 400, 300, 200, or 100, Because it is a total of 16 cycles, it overlaps four times.
-        std::pair<uint32_t, uint32_t> revMapEntry = {rba, testVolumeId};
-        EXPECT_CALL(*stripe, GetReverseMapEntry(index)).WillOnce(Return(revMapEntry));
+        if (index > 0)
+        {
+            uint32_t rba = (4 - (index % 4)) * 100; // 400, 300, 200, or 100, Because it is a total of 16 cycles, it overlaps four times.
+            std::pair<uint32_t, uint32_t> revMapEntry = {rba, testVolumeId};
+            EXPECT_CALL(*stripe, GetReverseMapEntry(index)).WillOnce(Return(revMapEntry));
+        }
         // VirtualBlkAddr vsa = {.stripeId = 100, .offset = index};
         // EXPECT_CALL(*vsaMap, GetVSAInternal(testVolumeId, rba, _)).WillRepeatedly(Return(vsa));
         // EXPECT_CALL(*stripe, GetVictimVsa(index)).WillOnce(Return(vsa));
     }
+    uint32_t rba = (4 - (0 % 4)) * 100; // for index 0
+    std::pair<uint32_t, uint32_t> revMapEntry = {rba, testVolumeId};
+    EXPECT_CALL(*stripe, GetReverseMapEntry(0)).WillRepeatedly(Return(revMapEntry));
     gcFlushCompletion->Init();
     list<RbaAndSize>* rbaList = gcFlushCompletion->GetRbaList();
 

--- a/test/unit-tests/gc/gc_stripe_manager_mock.h
+++ b/test/unit-tests/gc/gc_stripe_manager_mock.h
@@ -26,10 +26,10 @@ public:
     MOCK_METHOD(std::vector<BlkInfo>*, GetBlkInfoList, (uint32_t volumeId), (override));
     MOCK_METHOD(void, SetFlushed, (uint32_t volumeId, bool force), (override));
     MOCK_METHOD(bool, IsAllFinished, (), (override));
-    MOCK_METHOD(bool, FlushSubmitted, (), (override));
-    MOCK_METHOD(bool, FlushCompleted, (), (override));
-    MOCK_METHOD(bool, UpdateMapRequested, (), (override));
-    MOCK_METHOD(bool, UpdateMapCompleted, (), (override));
+    MOCK_METHOD(void, FlushSubmitted, (), (override));
+    MOCK_METHOD(void, FlushCompleted, (), (override));
+    MOCK_METHOD(void, UpdateMapRequested, (), (override));
+    MOCK_METHOD(void, UpdateMapCompleted, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/gc/gc_stripe_manager_mock.h
+++ b/test/unit-tests/gc/gc_stripe_manager_mock.h
@@ -26,6 +26,10 @@ public:
     MOCK_METHOD(std::vector<BlkInfo>*, GetBlkInfoList, (uint32_t volumeId), (override));
     MOCK_METHOD(void, SetFlushed, (uint32_t volumeId, bool force), (override));
     MOCK_METHOD(bool, IsAllFinished, (), (override));
+    MOCK_METHOD(bool, FlushSubmitted, (), (override));
+    MOCK_METHOD(bool, FlushCompleted, (), (override));
+    MOCK_METHOD(bool, UpdateMapRequested, (), (override));
+    MOCK_METHOD(bool, UpdateMapCompleted, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/gc/stripe_copier_test.cpp
+++ b/test/unit-tests/gc/stripe_copier_test.cpp
@@ -165,8 +165,8 @@ TEST_F(StripeCopierTestFixture, Execute_testIfExecuteFailsWhenBufferAllocationFa
     EXPECT_CALL(*meta, GetVictimStripe(copyIndex, baseStripeId % STRIPES_PER_SEGMENT)).WillRepeatedly(Return(&victimStripe));
     EXPECT_CALL(victimStripe, LoadValidBlock).WillOnce(Return(true));
     EXPECT_CALL(victimStripe, GetBlkInfoListSize).WillOnce(Return(1));
-    EXPECT_CALL(*meta, GetBuffer(baseStripeId)).WillOnce(Return(nullptr));
-
+    std::vector<void*> emptyVector;
+    EXPECT_CALL(*meta, GetBuffers(_,_)).WillOnce(testing::SetArgPointee<1>(emptyVector));
     EXPECT_TRUE(stripeCopier->Execute() == false);
 
     delete eventScheduler;
@@ -191,7 +191,8 @@ TEST_F(StripeCopierTestFixture, Execute_testIfExecuteSucceedsWhenThereIsOneValid
     EXPECT_CALL(*meta, GetVictimStripe(copyIndex, baseStripeId % STRIPES_PER_SEGMENT)).WillRepeatedly(Return(&victimStripe));
     EXPECT_CALL(victimStripe, LoadValidBlock).WillOnce(Return(true));
     EXPECT_CALL(victimStripe, GetBlkInfoListSize).WillOnce(Return(1));
-    EXPECT_CALL(*meta, GetBuffer(baseStripeId)).WillOnce(Return((void*)0x20000000));
+    std::vector<void*> oneBuffer{(void*)0x20000000};
+    EXPECT_CALL(*meta, GetBuffers(_,_)).WillOnce(testing::SetArgPointee<1>(oneBuffer));
     std::list<BlkInfo> blkInfoList;
     BlkInfo blkInfo = {.rba = testRba, .volID = testVolId,
                 .vsa = {.stripeId = testStripeId, .offset = testStripeOffset}};
@@ -227,7 +228,8 @@ TEST_F(StripeCopierTestFixture, Execute_CopyOneValidBlockCreateCopyEvent)
     EXPECT_CALL(*meta, GetVictimStripe(copyIndex, baseStripeId % STRIPES_PER_SEGMENT)).WillRepeatedly(Return(&victimStripe));
     EXPECT_CALL(victimStripe, LoadValidBlock).WillOnce(Return(true));
     EXPECT_CALL(victimStripe, GetBlkInfoListSize).WillOnce(Return(1));
-    EXPECT_CALL(*meta, GetBuffer(baseStripeId)).WillOnce(Return((void*)0x20000000));
+    std::vector<void*> oneBuffer{(void*)0x20000000};
+    EXPECT_CALL(*meta, GetBuffers(_,_)).WillOnce(testing::SetArgPointee<1>(oneBuffer));
     std::list<BlkInfo> blkInfoList;
     BlkInfo blkInfo = {.rba = testRba, .volID = testVolId,
                 .vsa = {.stripeId = testStripeId, .offset = testStripeOffset}};

--- a/test/unit-tests/resource_manager/buffer_pool_mock.h
+++ b/test/unit-tests/resource_manager/buffer_pool_mock.h
@@ -44,7 +44,7 @@ class MockBufferPool : public BufferPool
 public:
     using BufferPool::BufferPool;
     MOCK_METHOD(void*, TryGetBuffer, (), (override));
-    MOCK_METHOD(bool, TryGetBuffers, (uint32_t count, std::vector<void*>* retBuffers), (override));
+    MOCK_METHOD(bool, TryGetBuffers, (uint32_t count, std::vector<void*>* retBuffers, uint32_t minCount), (override));
     MOCK_METHOD(void, ReturnBuffer, (void*), (override));
 };
 


### PR DESCRIPTION
GC stripe force flush시 잘못된 vol_id 전달로 인한 exception case 수정
GC THRESHOLD 설정 오류 수정
Flow control 모듈등의 로그에 array id 누락되어 추가
Read buffer 여러개 획득시 한번의 lock획득으로 일괄 획득하도록 버퍼풀 로직 수정
GC flushing count / map updating count를 telemetry metrics로 추가