### PR TITLE
[AWIBOF-7559] Prioritize --timeout over default timeout for MOUNTARRAY/UNMOUNTARRAY

### DIFF
--- a/doc/guides/cli/poseidonos-cli.md
+++ b/doc/guides/cli/poseidonos-cli.md
@@ -31,7 +31,7 @@ poseidonos-cli [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
       --version          Display the version information.
 ```

--- a/doc/guides/cli/poseidonos-cli_array.md
+++ b/doc/guides/cli/poseidonos-cli_array.md
@@ -33,7 +33,7 @@ poseidonos-cli array [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_array_addspare.md
+++ b/doc/guides/cli/poseidonos-cli_array_addspare.md
@@ -38,7 +38,7 @@ poseidonos-cli array addspare [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_array_autocreate.md
+++ b/doc/guides/cli/poseidonos-cli_array_autocreate.md
@@ -49,7 +49,7 @@ poseidonos-cli array autocreate [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_array_create.md
+++ b/doc/guides/cli/poseidonos-cli_array_create.md
@@ -52,7 +52,7 @@ poseidonos-cli array create [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_array_delete.md
+++ b/doc/guides/cli/poseidonos-cli_array_delete.md
@@ -37,7 +37,7 @@ poseidonos-cli array delete [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_array_list.md
+++ b/doc/guides/cli/poseidonos-cli_array_list.md
@@ -43,7 +43,7 @@ poseidonos-cli array list [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_array_mount.md
+++ b/doc/guides/cli/poseidonos-cli_array_mount.md
@@ -39,7 +39,7 @@ poseidonos-cli array mount [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_array_rebuild.md
+++ b/doc/guides/cli/poseidonos-cli_array_rebuild.md
@@ -37,7 +37,7 @@ poseidonos-cli array rebuild [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_array_replace.md
+++ b/doc/guides/cli/poseidonos-cli_array_replace.md
@@ -37,7 +37,7 @@ poseidonos-cli array replace [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_array_rmspare.md
+++ b/doc/guides/cli/poseidonos-cli_array_rmspare.md
@@ -36,7 +36,7 @@ poseidonos-cli array rmspare [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_array_unmount.md
+++ b/doc/guides/cli/poseidonos-cli_array_unmount.md
@@ -36,7 +36,7 @@ poseidonos-cli array unmount [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_cluster.md
+++ b/doc/guides/cli/poseidonos-cli_cluster.md
@@ -40,7 +40,7 @@ poseidonos-cli cluster [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_cluster_ln.md
+++ b/doc/guides/cli/poseidonos-cli_cluster_ln.md
@@ -31,7 +31,7 @@ poseidonos-cli cluster ln [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_cluster_lr.md
+++ b/doc/guides/cli/poseidonos-cli_cluster_lr.md
@@ -31,7 +31,7 @@ poseidonos-cli cluster lr [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_cluster_lv.md
+++ b/doc/guides/cli/poseidonos-cli_cluster_lv.md
@@ -31,7 +31,7 @@ poseidonos-cli cluster lv [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_cluster_start-rep.md
+++ b/doc/guides/cli/poseidonos-cli_cluster_start-rep.md
@@ -39,7 +39,7 @@ poseidonos-cli cluster start-rep [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_completion.md
+++ b/doc/guides/cli/poseidonos-cli_completion.md
@@ -74,7 +74,7 @@ poseidonos-cli completion [bash|zsh|fish|powershell]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_devel.md
+++ b/doc/guides/cli/poseidonos-cli_devel.md
@@ -34,7 +34,7 @@ poseidonos-cli devel [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_devel_reset-event-wrr.md
+++ b/doc/guides/cli/poseidonos-cli_devel_reset-event-wrr.md
@@ -31,7 +31,7 @@ poseidonos-cli devel reset-event-wrr [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_devel_resetmbr.md
+++ b/doc/guides/cli/poseidonos-cli_devel_resetmbr.md
@@ -33,7 +33,7 @@ poseidonos-cli devel resetmbr [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_devel_stop-rebuilding.md
+++ b/doc/guides/cli/poseidonos-cli_devel_stop-rebuilding.md
@@ -32,7 +32,7 @@ poseidonos-cli devel stop-rebuilding [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_devel_update-event-wrr.md
+++ b/doc/guides/cli/poseidonos-cli_devel_update-event-wrr.md
@@ -33,7 +33,7 @@ poseidonos-cli devel update-event-wrr [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_device.md
+++ b/doc/guides/cli/poseidonos-cli_device.md
@@ -35,7 +35,7 @@ poseidonos-cli device [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_device_create.md
+++ b/doc/guides/cli/poseidonos-cli_device_create.md
@@ -36,7 +36,7 @@ poseidonos-cli device create [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_device_list.md
+++ b/doc/guides/cli/poseidonos-cli_device_list.md
@@ -33,7 +33,7 @@ poseidonos-cli device list [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_device_scan.md
+++ b/doc/guides/cli/poseidonos-cli_device_scan.md
@@ -32,7 +32,7 @@ poseidonos-cli device scan [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_device_smart-log.md
+++ b/doc/guides/cli/poseidonos-cli_device_smart-log.md
@@ -32,7 +32,7 @@ poseidonos-cli device smart-log [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_logger.md
+++ b/doc/guides/cli/poseidonos-cli_logger.md
@@ -35,7 +35,7 @@ poseidonos-cli logger [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_logger_apply-filter.md
+++ b/doc/guides/cli/poseidonos-cli_logger_apply-filter.md
@@ -47,7 +47,7 @@ poseidonos-cli logger apply-filter [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_logger_get-level.md
+++ b/doc/guides/cli/poseidonos-cli_logger_get-level.md
@@ -32,7 +32,7 @@ poseidonos-cli logger get-level [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_logger_info.md
+++ b/doc/guides/cli/poseidonos-cli_logger_info.md
@@ -31,7 +31,7 @@ poseidonos-cli logger info [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_logger_set-level.md
+++ b/doc/guides/cli/poseidonos-cli_logger_set-level.md
@@ -39,7 +39,7 @@ poseidonos-cli logger set-level [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_logger_set-preference.md
+++ b/doc/guides/cli/poseidonos-cli_logger_set-preference.md
@@ -33,7 +33,7 @@ poseidonos-cli logger set-preference [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_qos.md
+++ b/doc/guides/cli/poseidonos-cli_qos.md
@@ -39,7 +39,7 @@ poseidonos-cli qos [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_qos_create.md
+++ b/doc/guides/cli/poseidonos-cli_qos_create.md
@@ -46,7 +46,7 @@ poseidonos-cli qos create [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_qos_list.md
+++ b/doc/guides/cli/poseidonos-cli_qos_list.md
@@ -36,7 +36,7 @@ poseidonos-cli qos list [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_qos_reset.md
+++ b/doc/guides/cli/poseidonos-cli_qos_reset.md
@@ -36,7 +36,7 @@ poseidonos-cli qos reset [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_subsystem.md
+++ b/doc/guides/cli/poseidonos-cli_subsystem.md
@@ -32,7 +32,7 @@ poseidonos-cli subsystem [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_subsystem_add-listener.md
+++ b/doc/guides/cli/poseidonos-cli_subsystem_add-listener.md
@@ -39,7 +39,7 @@ poseidonos-cli subsystem add-listener [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_subsystem_create-transport.md
+++ b/doc/guides/cli/poseidonos-cli_subsystem_create-transport.md
@@ -37,7 +37,7 @@ poseidonos-cli subsystem create-transport [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_subsystem_create.md
+++ b/doc/guides/cli/poseidonos-cli_subsystem_create.md
@@ -42,7 +42,7 @@ poseidonos-cli subsystem create [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_subsystem_delete.md
+++ b/doc/guides/cli/poseidonos-cli_subsystem_delete.md
@@ -36,7 +36,7 @@ poseidonos-cli subsystem delete [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_subsystem_list.md
+++ b/doc/guides/cli/poseidonos-cli_subsystem_list.md
@@ -38,7 +38,7 @@ poseidonos-cli subsystem list [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_system.md
+++ b/doc/guides/cli/poseidonos-cli_system.md
@@ -35,7 +35,7 @@ poseidonos-cli system [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_system_get-property.md
+++ b/doc/guides/cli/poseidonos-cli_system_get-property.md
@@ -34,7 +34,7 @@ poseidonos-cli system get-property [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_system_info.md
+++ b/doc/guides/cli/poseidonos-cli_system_info.md
@@ -31,7 +31,7 @@ poseidonos-cli system info [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_system_set-property.md
+++ b/doc/guides/cli/poseidonos-cli_system_set-property.md
@@ -39,7 +39,7 @@ poseidonos-cli system set-property [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_system_start.md
+++ b/doc/guides/cli/poseidonos-cli_system_start.md
@@ -31,7 +31,7 @@ poseidonos-cli system start [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_system_stop.md
+++ b/doc/guides/cli/poseidonos-cli_system_stop.md
@@ -32,7 +32,7 @@ poseidonos-cli system stop [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_telemetry.md
+++ b/doc/guides/cli/poseidonos-cli_telemetry.md
@@ -37,7 +37,7 @@ poseidonos-cli telemetry [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_telemetry_get-property.md
+++ b/doc/guides/cli/poseidonos-cli_telemetry_get-property.md
@@ -31,7 +31,7 @@ poseidonos-cli telemetry get-property [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_telemetry_set-property.md
+++ b/doc/guides/cli/poseidonos-cli_telemetry_set-property.md
@@ -32,7 +32,7 @@ poseidonos-cli telemetry set-property [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_telemetry_start.md
+++ b/doc/guides/cli/poseidonos-cli_telemetry_start.md
@@ -31,7 +31,7 @@ poseidonos-cli telemetry start [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_telemetry_stop.md
+++ b/doc/guides/cli/poseidonos-cli_telemetry_stop.md
@@ -31,7 +31,7 @@ poseidonos-cli telemetry stop [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_volume.md
+++ b/doc/guides/cli/poseidonos-cli_volume.md
@@ -36,7 +36,7 @@ poseidonos-cli volume [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_volume_create.md
+++ b/doc/guides/cli/poseidonos-cli_volume_create.md
@@ -44,7 +44,7 @@ poseidonos-cli volume create [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_volume_delete.md
+++ b/doc/guides/cli/poseidonos-cli_volume_delete.md
@@ -38,7 +38,7 @@ poseidonos-cli volume delete [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_volume_list.md
+++ b/doc/guides/cli/poseidonos-cli_volume_list.md
@@ -43,7 +43,7 @@ poseidonos-cli volume list [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_volume_mount-with-subsystem.md
+++ b/doc/guides/cli/poseidonos-cli_volume_mount-with-subsystem.md
@@ -43,7 +43,7 @@ poseidonos-cli volume mount-with-subsystem [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_volume_mount.md
+++ b/doc/guides/cli/poseidonos-cli_volume_mount.md
@@ -47,7 +47,7 @@ poseidonos-cli volume mount [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_volume_rename.md
+++ b/doc/guides/cli/poseidonos-cli_volume_rename.md
@@ -38,7 +38,7 @@ poseidonos-cli volume rename [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_volume_set-property.md
+++ b/doc/guides/cli/poseidonos-cli_volume_set-property.md
@@ -42,7 +42,7 @@ poseidonos-cli volume set-property [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_volume_unmount.md
+++ b/doc/guides/cli/poseidonos-cli_volume_unmount.md
@@ -38,7 +38,7 @@ poseidonos-cli volume unmount [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/doc/guides/cli/poseidonos-cli_wbt.md
+++ b/doc/guides/cli/poseidonos-cli_wbt.md
@@ -73,7 +73,7 @@ poseidonos-cli wbt [testname] [flags]
       --json-res         Print response in JSON form.
       --node string      Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.
       --port string      Set the port number to PoseidonOS for this command. (default "18716")
-      --timeout uint32   Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.) (default 180)
+      --timeout uint32   Timeout for this command in seconds. (default 180)
       --unit             Display unit (B, KB, MB, ...) when displaying capacity.
 ```
 

--- a/tool/cli/cmd/arraycmds/mount_array.go
+++ b/tool/cli/cmd/arraycmds/mount_array.go
@@ -44,7 +44,7 @@ Example:
 		}
 		displaymgr.PrintRequest(string(reqJson))
 
-		res, gRpcErr := grpcmgr.SendMountArray(req)
+		res, gRpcErr := grpcmgr.SendMountArray(req, cmd.Flags().Changed("timeout"))
 		if gRpcErr != nil {
 			globals.PrintErrMsg(gRpcErr)
 			return gRpcErr

--- a/tool/cli/cmd/arraycmds/unmount_array.go
+++ b/tool/cli/cmd/arraycmds/unmount_array.go
@@ -57,7 +57,7 @@ Example:
 		}
 		displaymgr.PrintRequest(string(reqJson))
 
-		res, gRpcErr := grpcmgr.SendUnmountArray(req)
+		res, gRpcErr := grpcmgr.SendUnmountArray(req, cmd.Flags().Changed("timeout"))
 		if gRpcErr != nil {
 			globals.PrintErrMsg(gRpcErr)
 			return gRpcErr

--- a/tool/cli/cmd/grpcmgr/grpcmgr.go
+++ b/tool/cli/cmd/grpcmgr/grpcmgr.go
@@ -18,8 +18,10 @@ const dialErrorMsg = "Could not connect to the CLI server. Is PoseidonOS running
 const dialTimeout = 10
 
 // TODO (mj): We temporarily set long timeout values for mount/unmount array commands.
-const unmountArrayCmdTimeout = 1800
-const mountArrayCmdTimeout = 600
+const (
+	unmountArrayCmdTimeout uint32 = 1800
+	mountArrayCmdTimeout   uint32 = 600
+)
 
 func dialToCliServer() (*grpc.ClientConn, error) {
 	nodeName := globals.NodeName
@@ -445,7 +447,7 @@ func SendDeleteArray(req *pb.DeleteArrayRequest) (*pb.DeleteArrayResponse, error
 	return res, err
 }
 
-func SendMountArray(req *pb.MountArrayRequest) (*pb.MountArrayResponse, error) {
+func SendMountArray(req *pb.MountArrayRequest, isTimeoutSpecified bool) (*pb.MountArrayResponse, error) {
 	conn, err := dialToCliServer()
 	if err != nil {
 		err := errors.New(fmt.Sprintf("%s (internal error message: %s)",
@@ -455,7 +457,12 @@ func SendMountArray(req *pb.MountArrayRequest) (*pb.MountArrayResponse, error) {
 	defer conn.Close()
 
 	c := pb.NewPosCliClient(conn)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(mountArrayCmdTimeout))
+
+	duration := mountArrayCmdTimeout
+	if isTimeoutSpecified == true {
+		duration = globals.ReqTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(duration))
 	defer cancel()
 
 	res, err := c.MountArray(ctx, req)
@@ -467,7 +474,7 @@ func SendMountArray(req *pb.MountArrayRequest) (*pb.MountArrayResponse, error) {
 	return res, err
 }
 
-func SendUnmountArray(req *pb.UnmountArrayRequest) (*pb.UnmountArrayResponse, error) {
+func SendUnmountArray(req *pb.UnmountArrayRequest, isTimeoutSpecified bool) (*pb.UnmountArrayResponse, error) {
 	conn, err := dialToCliServer()
 	if err != nil {
 		err := errors.New(fmt.Sprintf("%s (internal error message: %s)",
@@ -477,7 +484,12 @@ func SendUnmountArray(req *pb.UnmountArrayRequest) (*pb.UnmountArrayResponse, er
 	defer conn.Close()
 
 	c := pb.NewPosCliClient(conn)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(unmountArrayCmdTimeout))
+
+	duration := unmountArrayCmdTimeout
+	if isTimeoutSpecified == true {
+		duration = globals.ReqTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(duration))
 	defer cancel()
 
 	res, err := c.UnmountArray(ctx, req)

--- a/tool/cli/cmd/root.go
+++ b/tool/cli/cmd/root.go
@@ -131,7 +131,7 @@ func regGlobalFlags() {
 	RootCmd.PersistentFlags().StringVar(&globals.FieldSeparator, "fs", "|", "Field separator for the output.")
 	RootCmd.PersistentFlags().StringVar(&globals.NodeName, "node", "",
 		`Name of the node to send this command. When both --ip and this flag are specified, this flag is applied only.`)
-	RootCmd.PersistentFlags().Uint32Var(&globals.ReqTimeout, "timeout", 180, "Timeout for this command in seconds. (Note: array unmount command has 30 minutes timeout.)")
+	RootCmd.PersistentFlags().Uint32Var(&globals.ReqTimeout, "timeout", 180, "Timeout for this command in seconds.")
 }
 
 func addCmd() {


### PR DESCRIPTION
 Prioritize --timeout over default timeout for MOUNTARRAY/UNMOUNTARRAY commands.
    
 Previously, the timeout values for those commands were not applied even though --timeout was specified. This is because those commands have default timeout values, which are prioritized over --timeout values. Consequently, this confuses the users.
    
This commit prioritizes the timeout values specified by --timeout over the default timeout values for those commands.