### PR TITLE
[SHPOS-1032] Change the location where stripeLoadStatus is created

### DIFF
--- a/src/allocator/wbstripe_manager/wbstripe_manager.cpp
+++ b/src/allocator/wbstripe_manager/wbstripe_manager.cpp
@@ -76,7 +76,7 @@ WBStripeManager::WBStripeManager(TelemetryPublisher* tp_, int numVolumes_, IReve
 }
 
 WBStripeManager::WBStripeManager(TelemetryPublisher* tp_, AllocatorAddressInfo* info, ContextManager* ctxMgr, BlockManager* blkMgr, std::string arrayName, int arrayId)
-: WBStripeManager(tp_, MAX_VOLUME_COUNT, nullptr, nullptr, nullptr, nullptr, info, ctxMgr, blkMgr, new StripeLoadStatus(), arrayName, arrayId)
+: WBStripeManager(tp_, MAX_VOLUME_COUNT, nullptr, nullptr, nullptr, nullptr, info, ctxMgr, blkMgr, nullptr, arrayName, arrayId)
 {
     allocCtx = ctxMgr->GetAllocatorCtx();
 }
@@ -104,6 +104,10 @@ WBStripeManager::Init(void)
     if (eventScheduler == nullptr)
     {
         eventScheduler = EventSchedulerSingleton::Instance();
+    }
+    if (stripeLoadStatus == nullptr)
+    {
+        stripeLoadStatus = new StripeLoadStatus();
     }
     uint32_t totalNvmStripes = addrInfo->GetnumWbStripes();
     uint32_t chunksPerStripe = addrInfo->GetchunksPerStripe();

--- a/src/journal_manager/replay/replay_log_list.cpp
+++ b/src/journal_manager/replay/replay_log_list.cpp
@@ -113,7 +113,14 @@ ReplayLogList::_GetTime(void)
 bool
 ReplayLogList::IsEmpty(void)
 {
-    return (logGroups.size() == 0);
+    for (auto logGroup: logGroups)
+    {
+        if (logGroup.size() != 0)
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 void

--- a/test/unit-tests/journal_manager/replay/replay_log_list_test.cpp
+++ b/test/unit-tests/journal_manager/replay/replay_log_list_test.cpp
@@ -149,6 +149,7 @@ TEST(ReplayLogList, AddLog_testIfVolumeDeletingLogsAreAdded)
 TEST(ReplayLogList, IsEmpty_testIfReturnTrueWhenNoLogsAreAdded)
 {
     ReplayLogList logList;
+    logList.Init(2);
     EXPECT_TRUE(logList.IsEmpty() == true);
 }
 


### PR DESCRIPTION
- fixed the seg fault that occurs when array mount and unmount are repeated

Signed-off-by: munseop.lim <munseop.lim@samsung.com>