### PR TITLE
[AWIBOF-7691] Fix concurrency issue in allocating and freeing wb stripe

### DIFF
--- a/src/allocator/stripe_manager/wbstripe_manager.cpp
+++ b/src/allocator/stripe_manager/wbstripe_manager.cpp
@@ -154,11 +154,14 @@ void
 WBStripeManager::FreeWBStripeId(StripeId wblsid)
 {
     assert(!IsUnMapStripe(wblsid));
-    allocCtx->ReleaseWbStripe(wblsid);
-    QosManagerSingleton::Instance()->DecreaseUsedStripeCnt(arrayName);
 
     assert(wbStripeArray[wblsid] != nullptr);
     wbStripeArray[wblsid] = nullptr;
+
+    // THIS SHOULD BE EXECUTED AFTER UPDATING wbStripeArray
+    allocCtx->ReleaseWbStripe(wblsid);
+
+    QosManagerSingleton::Instance()->DecreaseUsedStripeCnt(arrayName);
 }
 
 int

--- a/test/unit-tests/allocator/stripe_manager/wbstripe_manager_test.cpp
+++ b/test/unit-tests/allocator/stripe_manager/wbstripe_manager_test.cpp
@@ -110,7 +110,10 @@ WBStripeManagerTestFixture::_SetAllocatorAddressInfo(void)
 
 TEST_F(WBStripeManagerTestFixture, FreeWBStripeId_TestSimpleCaller)
 {
-    EXPECT_CALL(allocatorCtx, ReleaseWbStripe).Times(1);
+    EXPECT_CALL(allocatorCtx, ReleaseWbStripe).WillOnce([&](StripeId stripeId) {
+        // wbStripeArray should be cleared at this point
+        EXPECT_EQ(wbStripeManager->GetStripe(stripeId), nullptr);
+    });
 
     StripeId wbLsid = 0;
 


### PR DESCRIPTION
Update allocator context at last when freeing stripe so that anybody allocating wbstripe never sees non-empty wbStripeArray after get it from allocator context

Signed-off-by: Huijeong Kim <huijeong.kim@samsung.com>