### PR TITLE
[AWIBOF-7453] store only SegmentInfoData instead of storing SegmentInfo Object

### DIFF
--- a/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
@@ -305,7 +305,7 @@ SegmentCtx::AfterLoad(char* buf)
     ctxDirtyVersion = ctxHeader.ctxVersion + 1;
     for(uint32_t i = 0; i < addrInfo->GetnumUserAreaSegments(); i++)
     {
-       memcpy(segmentInfos[i].data, buf + i * sizeof(SegmentInfoData) + sizeof(SegmentCtxHeader), sizeof(SegmentInfoData));
+       memcpy(&segmentInfos[i].data, buf + i * sizeof(SegmentInfoData) + sizeof(SegmentCtxHeader), sizeof(SegmentInfoData));
     }
     _RebuildSegmentList();
 }
@@ -337,7 +337,7 @@ SegmentCtx::BeforeFlush(char* buf)
     ctxHeader.ctxVersion = ctxDirtyVersion++;
     for(uint32_t i=0;i<addrInfo->GetnumUserAreaSegments();i++)
     {
-       memcpy(buf + i * sizeof(SegmentInfoData) + sizeof(SegmentCtxHeader), segmentInfos[i].data, sizeof(SegmentInfoData));
+       memcpy(buf + i * sizeof(SegmentInfoData) + sizeof(SegmentCtxHeader), &segmentInfos[i].data, sizeof(SegmentInfoData));
     }
 }
 

--- a/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
@@ -303,11 +303,11 @@ SegmentCtx::AfterLoad(char* buf)
     POS_TRACE_DEBUG(EID(ALLOCATOR_FILE_LOAD_ERROR), "SegmentCtx file loaded:{}", ctxHeader.ctxVersion);
     ctxStoredVersion = ctxHeader.ctxVersion;
     ctxDirtyVersion = ctxHeader.ctxVersion + 1;
-    _RebuildSegmentList();
     for(uint32_t i = 0; i < addrInfo->GetnumUserAreaSegments(); i++)
     {
        memcpy(segmentInfos[i].data, buf + i * sizeof(SegmentInfoData) + sizeof(SegmentCtxHeader), sizeof(SegmentInfoData));
     }
+    _RebuildSegmentList();
 }
 
 void

--- a/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
@@ -354,7 +354,7 @@ SegmentCtx::GetSectionAddr(int section)
         }
         case SC_SEGMENT_INFO:
         {
-            ret = (char*)segmentInfos;
+            ret = (char*)segmentInfos->data;
             break;
         }
     }
@@ -374,7 +374,7 @@ SegmentCtx::GetSectionSize(int section)
         }
         case SC_SEGMENT_INFO:
         {
-            ret = addrInfo->GetnumUserAreaSegments() * sizeof(SegmentInfo);
+            ret = addrInfo->GetnumUserAreaSegments() * sizeof(SegmentInfoData);
             break;
         }
     }

--- a/src/allocator/context_manager/segment_ctx/segment_ctx.h
+++ b/src/allocator/context_manager/segment_ctx/segment_ctx.h
@@ -82,7 +82,7 @@ public:
 
     virtual void MoveToFreeState(SegmentId segId);
     virtual uint32_t GetValidBlockCount(SegmentId segId);
-    virtual int GetOccupiedStripeCount(SegmentId segId);
+    virtual uint32_t GetOccupiedStripeCount(SegmentId segId);
     virtual SegmentState GetSegmentState(SegmentId segId);
     virtual void ResetSegmentsStates(void);
 
@@ -147,6 +147,7 @@ private:
     std::atomic<uint64_t> ctxStoredVersion;
 
     SegmentInfo* segmentInfos;
+    SegmentInfoData* segmentInfoData;
 
     SegmentList* segmentList[SegmentState::NUM_STATES];
     SegmentList* rebuildList;

--- a/src/allocator/context_manager/segment_ctx/segment_info.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_info.cpp
@@ -229,4 +229,13 @@ SegmentInfo::AllocateSegmentInfoData(SegmentInfoData *segmentInfoData)
     data = segmentInfoData;
 }
 
+void
+SegmentInfo::UpdateFrom(SegmentInfo &segmentInfo)
+{
+    this->data->validBlockCount = (uint32_t)segmentInfo.data->validBlockCount;
+    this->data->occupiedStripeCount = (uint32_t)segmentInfo.data->occupiedStripeCount;
+    this->data->state = segmentInfo.data->state;
+}
+
+
 } // namespace pos

--- a/src/allocator/context_manager/segment_ctx/segment_info.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_info.cpp
@@ -48,7 +48,9 @@ SegmentInfo::SegmentInfo(void)
 // Constructor for UT to inject precondition values
 SegmentInfo::SegmentInfo(uint32_t blkCount, uint32_t stripeCount, SegmentState segmentState)
 {
-    InitSegmentInfoData(blkCount, stripeCount, segmentState);
+    SetValidBlockCount(blkCount);
+    SetOccupiedStripeCount(stripeCount);
+    SetState(segmentState);
 }
 
 SegmentInfo::~SegmentInfo(void)
@@ -62,7 +64,7 @@ SegmentInfo::GetValidBlockCount(void)
 }
 
 void
-SegmentInfo::SetValidBlockCount(int cnt)
+SegmentInfo::SetValidBlockCount(uint32_t cnt)
 {
     // for wbt
     data.validBlockCount = cnt;
@@ -218,14 +220,6 @@ SegmentInfo::GetValidBlockCountIfSsdState(void)
     {
         return data.validBlockCount;
     }
-}
-
-void
-SegmentInfo::InitSegmentInfoData(uint32_t blkCount, uint32_t stripeCount, SegmentState segmentState)
-{
-    data.validBlockCount = blkCount;
-    data.occupiedStripeCount = stripeCount;
-    data.state = segmentState;
 }
 
 } // namespace pos

--- a/src/allocator/context_manager/segment_ctx/segment_info.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_info.cpp
@@ -47,48 +47,46 @@ SegmentInfo::SegmentInfo(void)
 
 // Constructor for UT to inject precondition values
 SegmentInfo::SegmentInfo(uint32_t blkCount, uint32_t stripeCount, SegmentState segmentState)
-: data(nullptr)
 {
     InitSegmentInfoData(blkCount, stripeCount, segmentState);
 }
 
 SegmentInfo::~SegmentInfo(void)
 {
-    DisposeSegmentInfoData();
 }
 
 uint32_t
 SegmentInfo::GetValidBlockCount(void)
 {
-    return data->validBlockCount;
+    return data.validBlockCount;
 }
 
 void
 SegmentInfo::SetValidBlockCount(int cnt)
 {
     // for wbt
-    data->validBlockCount = cnt;
+    data.validBlockCount = cnt;
 }
 
 uint32_t
 SegmentInfo::IncreaseValidBlockCount(uint32_t inc)
 {
-    return data->validBlockCount.fetch_add(inc) + inc;
+    return data.validBlockCount.fetch_add(inc) + inc;
 }
 
 std::pair<bool, SegmentState>
 SegmentInfo::DecreaseValidBlockCount(uint32_t dec, bool allowVictimSegRelease)
 {
     std::lock_guard<std::mutex> lock(seglock);
-    int32_t decreased = data->validBlockCount.fetch_sub(dec) - dec;
+    int32_t decreased = data.validBlockCount.fetch_sub(dec) - dec;
 
     if (decreased == 0)
     {
         if (true == allowVictimSegRelease)
         {
-            if (data->state == SegmentState::VICTIM || data->state == SegmentState::SSD)
+            if (data.state == SegmentState::VICTIM || data.state == SegmentState::SSD)
             {
-                std::pair<bool, SegmentState> result = {true, data->state};
+                std::pair<bool, SegmentState> result = {true, data.state};
                 _MoveToFreeState();
 
                 return result;
@@ -96,9 +94,9 @@ SegmentInfo::DecreaseValidBlockCount(uint32_t dec, bool allowVictimSegRelease)
         }
         else
         {
-            if (data->state == SegmentState::SSD)
+            if (data.state == SegmentState::SSD)
             {
-                std::pair<bool, SegmentState> result = {true, data->state};
+                std::pair<bool, SegmentState> result = {true, data.state};
                 _MoveToFreeState();
 
                 return result;
@@ -112,64 +110,64 @@ SegmentInfo::DecreaseValidBlockCount(uint32_t dec, bool allowVictimSegRelease)
         return {false, SegmentState::ERROR};
     }
 
-    return {false, data->state};
+    return {false, data.state};
 }
 
 void
 SegmentInfo::SetOccupiedStripeCount(uint32_t cnt)
 {
-    data->occupiedStripeCount = cnt;
+    data.occupiedStripeCount = cnt;
 }
 
 uint32_t
 SegmentInfo::GetOccupiedStripeCount(void)
 {
-    return data->occupiedStripeCount;
+    return data.occupiedStripeCount;
 }
 
 uint32_t
 SegmentInfo::IncreaseOccupiedStripeCount(void)
 {
     // ++ is equivalent to fetch_add(1) + 1
-    return ++(data->occupiedStripeCount);
+    return ++(data.occupiedStripeCount);
 }
 
 void
 SegmentInfo::SetState(SegmentState newState)
 {
     std::lock_guard<std::mutex> lock(seglock);
-    data->state = newState;
+    data.state = newState;
 }
 
 SegmentState
 SegmentInfo::GetState(void)
 {
     std::lock_guard<std::mutex> lock(seglock);
-    return data->state;
+    return data.state;
 }
 
 void
 SegmentInfo::_MoveToFreeState(void)
 {
-    data->occupiedStripeCount = 0;
-    data->validBlockCount = 0;
+    data.occupiedStripeCount = 0;
+    data.validBlockCount = 0;
 
-    data->state = SegmentState::FREE;
+    data.state = SegmentState::FREE;
 }
 
 void
 SegmentInfo::MoveToNvramState(void)
 {
     std::lock_guard<std::mutex> lock(seglock);
-    if (data->state != SegmentState::FREE)
+    if (data.state != SegmentState::FREE)
     {
         POS_TRACE_ERROR(EID(UNKNOWN_ALLOCATOR_ERROR),
             "Failed to move to NVRAM state. Segment state {} valid count {} occupied stripe count {}",
-            data->state, data->validBlockCount, data->occupiedStripeCount);
+            data.state, data.validBlockCount, data.occupiedStripeCount);
         assert(false);
     }
 
-    data->state = SegmentState::NVRAM;
+    data.state = SegmentState::NVRAM;
 }
 
 bool
@@ -177,7 +175,7 @@ SegmentInfo::MoveToSsdStateOrFreeStateIfItBecomesEmpty(void)
 {
     std::lock_guard<std::mutex> lock(seglock);
 
-    if (data->validBlockCount == 0)
+    if (data.validBlockCount == 0)
     {
         _MoveToFreeState();
 
@@ -185,7 +183,7 @@ SegmentInfo::MoveToSsdStateOrFreeStateIfItBecomesEmpty(void)
     }
     else
     {
-        data->state = SegmentState::SSD;
+        data.state = SegmentState::SSD;
         return false;
     }
 }
@@ -194,15 +192,15 @@ bool
 SegmentInfo::MoveToVictimState(void)
 {
     std::lock_guard<std::mutex> lock(seglock);
-    if (data->state != SegmentState::SSD)
+    if (data.state != SegmentState::SSD)
     {
         POS_TRACE_ERROR(EID(UNKNOWN_ALLOCATOR_ERROR),
-            "Cannot move to victim state as it's not SSD state, state: {}", data->state);
+            "Cannot move to victim state as it's not SSD state, state: {}", data.state);
         return false;
     }
     else
     {
-        data->state = SegmentState::VICTIM;
+        data.state = SegmentState::VICTIM;
 
         return true;
     }
@@ -212,34 +210,22 @@ uint32_t
 SegmentInfo::GetValidBlockCountIfSsdState(void)
 {
     std::lock_guard<std::mutex> lock(seglock);
-    if (data->state != SegmentState::SSD)
+    if (data.state != SegmentState::SSD)
     {
         return UINT32_MAX;
     }
     else
     {
-        return data->validBlockCount;
+        return data.validBlockCount;
     }
 }
 
 void
 SegmentInfo::InitSegmentInfoData(uint32_t blkCount, uint32_t stripeCount, SegmentState segmentState)
 {
-    if(nullptr == data){
-        data = new SegmentInfoData();
-    }
-    data->validBlockCount = blkCount;
-    data->occupiedStripeCount = stripeCount;
-    data->state = segmentState;
-}
-
-void
-SegmentInfo::DisposeSegmentInfoData()
-{
-    if(nullptr != data){
-        delete data;
-        data = nullptr;
-    }
+    data.validBlockCount = blkCount;
+    data.occupiedStripeCount = stripeCount;
+    data.state = segmentState;
 }
 
 } // namespace pos

--- a/src/allocator/context_manager/segment_ctx/segment_info.h
+++ b/src/allocator/context_manager/segment_ctx/segment_info.h
@@ -56,7 +56,8 @@ struct SegmentInfoData
     std::atomic<uint32_t> validBlockCount;
     std::atomic<uint32_t> occupiedStripeCount;
     SegmentState state;
-    //DO NOT ADD ANY METHODS HERE TO SUPPORT BACKWARD COMPATIBILITY
+    // TODO(sang7.park) : add reserved field here.
+    // DO NOT ADD ANY VIRTUAL METHODS HERE TO SUPPORT BACKWARD COMPATIBILITY
 };
 
 class SegmentInfo
@@ -67,7 +68,7 @@ public:
     ~SegmentInfo(void);
 
     virtual uint32_t GetValidBlockCount(void);
-    virtual void SetValidBlockCount(int cnt);
+    virtual void SetValidBlockCount(uint32_t cnt);
     virtual uint32_t IncreaseValidBlockCount(uint32_t inc);
     virtual std::pair<bool, SegmentState> DecreaseValidBlockCount(uint32_t dec, bool allowVictimSegRelease);
 
@@ -84,12 +85,9 @@ public:
 
     virtual uint32_t GetValidBlockCountIfSsdState(void);
 
-    virtual void InitSegmentInfoData(uint32_t blkCount, uint32_t stripeCount, SegmentState segmentState);
-
     SegmentInfoData data;
 private:
     void _MoveToFreeState(void);
-
     std::mutex seglock;
 
 };

--- a/src/allocator/context_manager/segment_ctx/segment_info.h
+++ b/src/allocator/context_manager/segment_ctx/segment_info.h
@@ -63,10 +63,10 @@ public:
 
     }
 
-    SegmentInfoData(uint32_t blkCount, uint32_t stripeCount, SegmentState segmentState)
+    SegmentInfoData(uint32_t validBlockCount, uint32_t occupiedStripeCount, SegmentState segmentState)
     {
-        this->validBlockCount = blkCount;
-        this->occupiedStripeCount = stripeCount;
+        this->validBlockCount = validBlockCount;
+        this->occupiedStripeCount = occupiedStripeCount;
         this->state = segmentState;
     }
 
@@ -97,6 +97,7 @@ public:
 
     virtual uint32_t GetValidBlockCountIfSsdState(void);
     virtual void AllocateSegmentInfoData(SegmentInfoData* segmentInfoData);
+    virtual void UpdateFrom(SegmentInfo &segmentInfo);
 
 private:
     void _MoveToFreeState(void);

--- a/src/allocator/context_manager/segment_ctx/segment_info.h
+++ b/src/allocator/context_manager/segment_ctx/segment_info.h
@@ -85,9 +85,8 @@ public:
     virtual uint32_t GetValidBlockCountIfSsdState(void);
 
     virtual void InitSegmentInfoData(uint32_t blkCount, uint32_t stripeCount, SegmentState segmentState);
-    virtual void DisposeSegmentInfoData(void);
 
-    SegmentInfoData* data;
+    SegmentInfoData data;
 private:
     void _MoveToFreeState(void);
 

--- a/src/allocator/context_manager/segment_ctx/segment_info.h
+++ b/src/allocator/context_manager/segment_ctx/segment_info.h
@@ -51,22 +51,34 @@ enum SegmentState : int
     NUM_STATES,
 };
 
-struct SegmentInfoData
+class SegmentInfoData
 {
+public:
     std::atomic<uint32_t> validBlockCount;
     std::atomic<uint32_t> occupiedStripeCount;
     SegmentState state;
     // TODO(sang7.park) : add reserved field here.
     // DO NOT ADD ANY VIRTUAL METHODS HERE TO SUPPORT BACKWARD COMPATIBILITY
+    SegmentInfoData(){
+
+    }
+
+    SegmentInfoData(uint32_t blkCount, uint32_t stripeCount, SegmentState segmentState)
+    {
+        this->validBlockCount = blkCount;
+        this->occupiedStripeCount = stripeCount;
+        this->state = segmentState;
+    }
+
 };
 
 class SegmentInfo
 {
 public:
     SegmentInfo(void);
-    SegmentInfo(uint32_t blkCount, uint32_t stripeCount, SegmentState segmentState);
     ~SegmentInfo(void);
 
+    virtual void InitSegmentInfoData(void);
     virtual uint32_t GetValidBlockCount(void);
     virtual void SetValidBlockCount(uint32_t cnt);
     virtual uint32_t IncreaseValidBlockCount(uint32_t inc);
@@ -84,10 +96,12 @@ public:
     virtual bool MoveToVictimState(void);
 
     virtual uint32_t GetValidBlockCountIfSsdState(void);
+    virtual void AllocateSegmentInfoData(SegmentInfoData* segmentInfoData);
 
-    SegmentInfoData data;
 private:
     void _MoveToFreeState(void);
+
+    SegmentInfoData* data;
     std::mutex seglock;
 
 };

--- a/src/allocator/context_manager/segment_ctx/segment_info.h
+++ b/src/allocator/context_manager/segment_ctx/segment_info.h
@@ -51,6 +51,14 @@ enum SegmentState : int
     NUM_STATES,
 };
 
+struct SegmentInfoData
+{
+    std::atomic<uint32_t> validBlockCount;
+    std::atomic<uint32_t> occupiedStripeCount;
+    SegmentState state;
+    //DO NOT ADD ANY METHODS HERE TO SUPPORT BACKWARD COMPATIBILITY
+};
+
 class SegmentInfo
 {
 public:
@@ -76,14 +84,15 @@ public:
 
     virtual uint32_t GetValidBlockCountIfSsdState(void);
 
+    virtual void InitSegmentInfoData(uint32_t blkCount, uint32_t stripeCount, SegmentState segmentState);
+    virtual void DisposeSegmentInfoData(void);
+
+    SegmentInfoData* data;
 private:
     void _MoveToFreeState(void);
 
-    std::atomic<uint32_t> validBlockCount;
-    std::atomic<uint32_t> occupiedStripeCount;
-
     std::mutex seglock;
-    SegmentState state;
+
 };
 
 } // namespace pos

--- a/src/journal_manager/log_buffer/i_versioned_segment_context.h
+++ b/src/journal_manager/log_buffer/i_versioned_segment_context.h
@@ -39,6 +39,7 @@ namespace pos
 {
 class JournalConfiguration;
 class SegmentInfo;
+class SegmentInfoData;
 class VersionedSegmentInfo;
 
 class IVersionedSegmentContext

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -94,9 +94,7 @@ VersionedSegmentCtx::_Init(JournalConfiguration* journalConfiguration, SegmentIn
                            segId, loadedSegmentInfo[segId].GetValidBlockCount(),
                            loadedSegmentInfo[segId].GetOccupiedStripeCount(),
                            loadedSegmentInfo[segId].GetState());
-            segmentInfos[segId].SetValidBlockCount(loadedSegmentInfo[segId].GetValidBlockCount());
-            segmentInfos[segId].SetOccupiedStripeCount(loadedSegmentInfo[segId].GetOccupiedStripeCount());
-            segmentInfos[segId].SetState(loadedSegmentInfo[segId].GetState());
+            segmentInfos[segId].UpdateFrom(loadedSegmentInfo[segId]);
         }
     }
 }

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -83,8 +83,11 @@ VersionedSegmentCtx::_Init(JournalConfiguration* journalConfiguration, SegmentIn
 
     numSegments = numSegments_;
     segmentInfos = new SegmentInfo[numSegments];
+    segmentInfoData = new SegmentInfoData[numSegments];
     for (uint32_t segId = 0; segId < numSegments; segId++)
     {
+        segmentInfos[segId].AllocateSegmentInfoData(&segmentInfoData[segId]);
+        segmentInfos[segId].InitSegmentInfoData();
         if (nullptr != loadedSegmentInfo)
         {
             POS_TRACE_INFO(EID(JOURNAL_MANAGER_INITIALIZED), "Loaded segment: segId {}, validcnt {}, stripeCnt {}, state {}",

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -91,7 +91,7 @@ VersionedSegmentCtx::_Init(JournalConfiguration* journalConfiguration, SegmentIn
                            segId, loadedSegmentInfo[segId].GetValidBlockCount(),
                            loadedSegmentInfo[segId].GetOccupiedStripeCount(),
                            loadedSegmentInfo[segId].GetState());
-            memcpy(segmentInfos[segId].data, loadedSegmentInfo[segId].data, sizeof(SegmentInfoData));
+            memcpy(&segmentInfos[segId].data, &loadedSegmentInfo[segId].data, sizeof(SegmentInfoData));
         }
     }
 }

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -82,7 +82,7 @@ VersionedSegmentCtx::_Init(JournalConfiguration* journalConfiguration, SegmentIn
     config = journalConfiguration;
 
     numSegments = numSegments_;
-    segmentInfos = new SegmentInfo[numSegments]();
+    segmentInfos = new SegmentInfo[numSegments];
     for (uint32_t segId = 0; segId < numSegments; segId++)
     {
         if (nullptr != loadedSegmentInfo)
@@ -91,8 +91,7 @@ VersionedSegmentCtx::_Init(JournalConfiguration* journalConfiguration, SegmentIn
                            segId, loadedSegmentInfo[segId].GetValidBlockCount(),
                            loadedSegmentInfo[segId].GetOccupiedStripeCount(),
                            loadedSegmentInfo[segId].GetState());
-
-            memcpy(segmentInfos, loadedSegmentInfo, sizeof(SegmentInfo) * numSegments);
+            memcpy(segmentInfos[segId].data, loadedSegmentInfo[segId].data, sizeof(SegmentInfoData));
         }
     }
 }

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -91,7 +91,9 @@ VersionedSegmentCtx::_Init(JournalConfiguration* journalConfiguration, SegmentIn
                            segId, loadedSegmentInfo[segId].GetValidBlockCount(),
                            loadedSegmentInfo[segId].GetOccupiedStripeCount(),
                            loadedSegmentInfo[segId].GetState());
-            memcpy(&segmentInfos[segId].data, &loadedSegmentInfo[segId].data, sizeof(SegmentInfoData));
+            segmentInfos[segId].SetValidBlockCount(loadedSegmentInfo[segId].GetValidBlockCount());
+            segmentInfos[segId].SetOccupiedStripeCount(loadedSegmentInfo[segId].GetOccupiedStripeCount());
+            segmentInfos[segId].SetState(loadedSegmentInfo[segId].GetState());
         }
     }
 }

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.h
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.h
@@ -99,6 +99,7 @@ private:
     uint32_t numSegments;
     std::vector<std::shared_ptr<VersionedSegmentInfo>> segmentInfoDiffs;
     SegmentInfo* segmentInfos;
+    SegmentInfoData* segmentInfoData;
     const int ALL_LOG_GROUP = -1;
 };
 

--- a/test/integration-tests/segmentCtx/segment_ctx_integration_test.cpp
+++ b/test/integration-tests/segmentCtx/segment_ctx_integration_test.cpp
@@ -152,10 +152,11 @@ TEST_F(SegmentCtxIntegrationTest, UpdateSegmentList_IfTargetSegmentInvalidatedBy
     uint32_t expectedVictimSegId = 0;
 
     SegmentInfo* segInfos = new SegmentInfo[numOfSegment];
-    SegmentInfoData* segmentInfoData = new SegmentInfoData[numOfSegment];//(maxValidBlockCount, maxOccupiedStripeCount, SegmentState::SSD);
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numOfSegment];
     for (int i = 0; i < numOfSegment; ++i)
     {
         segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+        segInfos[i].InitSegmentInfoData();
         segInfos[i].SetValidBlockCount(maxValidBlockCount);
         segInfos[i].SetOccupiedStripeCount(maxOccupiedStripeCount);
         segInfos[i].SetState(SegmentState::SSD);
@@ -260,6 +261,7 @@ TEST_F(SegmentCtxIntegrationTest, UpdateSegmentList_IfTargetSegmentInvalidatedBy
     EXPECT_EQ(true, ret);
 
     delete [] segInfos;
+    delete [] segmentInfoData;
     delete segmentCtx;
     delete ioManager;
     delete allocatorCtx;
@@ -267,6 +269,5 @@ TEST_F(SegmentCtxIntegrationTest, UpdateSegmentList_IfTargetSegmentInvalidatedBy
     delete gcCtx;
     delete blockAllocStatus;
     delete contextReplayer;
-    delete[] segmentInfoData;
 }
 }

--- a/test/integration-tests/segmentCtx/segment_ctx_integration_test.cpp
+++ b/test/integration-tests/segmentCtx/segment_ctx_integration_test.cpp
@@ -151,7 +151,16 @@ TEST_F(SegmentCtxIntegrationTest, UpdateSegmentList_IfTargetSegmentInvalidatedBy
     const uint32_t arrayId = 0;
     uint32_t expectedVictimSegId = 0;
 
-    SegmentInfo* segInfos = new SegmentInfo[numOfSegment](maxValidBlockCount, maxOccupiedStripeCount, SegmentState::SSD);
+    SegmentInfo* segInfos = new SegmentInfo[numOfSegment];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numOfSegment];//(maxValidBlockCount, maxOccupiedStripeCount, SegmentState::SSD);
+    for (int i = 0; i < numOfSegment; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+        segInfos[i].SetValidBlockCount(maxValidBlockCount);
+        segInfos[i].SetOccupiedStripeCount(maxOccupiedStripeCount);
+        segInfos[i].SetState(SegmentState::SSD);
+
+    }
     SegmentCtx* segmentCtx = new SegmentCtx(&tp, rebuildCtx, &addrInfo, gcCtx, arrayId, segInfos);
 
     ON_CALL(addrInfo, IsUT).WillByDefault(Return(true));
@@ -258,5 +267,6 @@ TEST_F(SegmentCtxIntegrationTest, UpdateSegmentList_IfTargetSegmentInvalidatedBy
     delete gcCtx;
     delete blockAllocStatus;
     delete contextReplayer;
+    delete[] segmentInfoData;
 }
 }

--- a/test/integration-tests/segmentCtx/segment_ctx_tester.h
+++ b/test/integration-tests/segmentCtx/segment_ctx_tester.h
@@ -45,7 +45,7 @@ public:
     MOCK_METHOD(bool, InvalidateBlks, (VirtualBlks blks, bool allowVictimSegRelease), (override));
     MOCK_METHOD(void, ValidateBlocksWithGroupId, (VirtualBlks blks, int logGroupId), (override));
     MOCK_METHOD(uint32_t, GetValidBlockCount, (SegmentId segId), (override));
-    MOCK_METHOD(int, GetOccupiedStripeCount, (SegmentId segId), (override));
+    MOCK_METHOD(uint32_t, GetOccupiedStripeCount, (SegmentId segId), (override));
     MOCK_METHOD(bool, UpdateOccupiedStripeCount, (StripeId lsid), (override));
     MOCK_METHOD(SegmentInfo*, GetSegmentInfos, (), (override));
 

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_mock.h
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_mock.h
@@ -31,7 +31,7 @@ public:
     MOCK_METHOD(int, GetNumSections, (), (override));
     MOCK_METHOD(void, MoveToFreeState, (SegmentId segId), (override));
     MOCK_METHOD(uint32_t, GetValidBlockCount, (SegmentId segId), (override));
-    MOCK_METHOD(int, GetOccupiedStripeCount, (SegmentId segId), (override));
+    MOCK_METHOD(uint32_t, GetOccupiedStripeCount, (SegmentId segId), (override));
     MOCK_METHOD(SegmentState, GetSegmentState, (SegmentId segId), (override));
     MOCK_METHOD(void, ResetSegmentsStates, (), (override));
     MOCK_METHOD(void, AllocateSegment, (SegmentId segId), (override));

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_test.cpp
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_test.cpp
@@ -460,7 +460,7 @@ TEST_F(SegmentCtxTestFixture, GetSectionAddr_TestSimpleGetter)
     char* buf = segCtx->GetSectionAddr(SC_HEADER);
 
     buf = segCtx->GetSectionAddr(SC_SEGMENT_INFO);
-    EXPECT_EQ(reinterpret_cast<char*>(&segInfos), buf);
+    EXPECT_EQ(reinterpret_cast<char*>(segCtx->GetSegmentInfos()->data), buf);
 }
 
 TEST_F(SegmentCtxTestFixture, GetSectionSize_TestSimpleGetter)
@@ -475,7 +475,7 @@ TEST_F(SegmentCtxTestFixture, GetSectionSize_TestSimpleGetter)
 
     // when 2.
     ret = segCtx->GetSectionSize(SC_SEGMENT_INFO);
-    EXPECT_EQ(10 * sizeof(SegmentInfo), ret);
+    EXPECT_EQ(10 * sizeof(SegmentInfoData), ret);
 }
 
 TEST_F(SegmentCtxTestFixture, GetStoredVersion_TestSimpleGetter)

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_test.cpp
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_test.cpp
@@ -101,8 +101,14 @@ TEST(SegmentCtx, AfterLoad_testIfSegmentListIsRebuilt)
     EXPECT_CALL(addrInfo, GetnumUserAreaSegments).WillRepeatedly(Return(numSegInfos));
     EXPECT_CALL(segmentList[SegmentState::FREE], AddToList).Times(numSegInfos);
 
+    // initialize dummy buffer and fill out with segmentInfoData
     int dummySize = sizeof(SegmentCtxHeader) + numSegInfos * sizeof(SegmentInfoData);
-    char* dummybuf = new char[dummySize];
+    char* dummybuf = new char[dummySize]();
+    for(int i = 0; i < numSegInfos; ++i)
+    {
+        memcpy(dummybuf + sizeof(SegmentCtxHeader) + i * sizeof(SegmentInfoData), &segInfos[i].data, sizeof(SegmentInfoData));
+    }
+    
     // when
     segCtx.AfterLoad(dummybuf);
 

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_test.cpp
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_test.cpp
@@ -88,7 +88,12 @@ TEST(SegmentCtx, AfterLoad_testIfSegmentListIsRebuilt)
     header.sig = SegmentCtx::SIG_SEGMENT_CTX;
 
     int numSegInfos = 4;
-    SegmentInfo* segInfos = new SegmentInfo[numSegInfos](0, 0, SegmentState::FREE);
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::FREE);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
 
     SegmentCtx segCtx(nullptr, &header, segInfos, nullptr, nullptr, &addrInfo, nullptr, 0);
 
@@ -101,79 +106,11 @@ TEST(SegmentCtx, AfterLoad_testIfSegmentListIsRebuilt)
     EXPECT_CALL(addrInfo, GetnumUserAreaSegments).WillRepeatedly(Return(numSegInfos));
     EXPECT_CALL(segmentList[SegmentState::FREE], AddToList).Times(numSegInfos);
 
-    // Initialize dummy buffer with zero.
-    int dummySize = sizeof(SegmentCtxHeader) + numSegInfos * sizeof(SegmentInfoData);
-    char* dummybuf = new char[dummySize](); // () equals to memset(dummy, 0 ,dummySize).
-    for(int i = 0; i < numSegInfos; ++i)
-    {
-        memcpy(dummybuf + sizeof(SegmentCtxHeader) + i * sizeof(SegmentInfoData), &segInfos[i].data, sizeof(SegmentInfoData));
-    }
     // when
-    segCtx.AfterLoad(dummybuf);
+    segCtx.AfterLoad(nullptr);
 
     delete[] segInfos;
-    delete[] dummybuf;
-}
-
-TEST(SegmentCtx, AfterLoad_testIfSegmentInfoDataIsSuccessfullyUpdatedFromSegmentCtxFile)
-{
-    // Given
-    NiceMock<MockAllocatorAddressInfo> addrInfo;
-    SegmentCtxHeader header;
-    header.sig = SegmentCtx::SIG_SEGMENT_CTX;
-
-    // Initialize SegmentInfoData in SegmentCtx with initial values (0, 0, SegmentState::FREE).
-    int numSegInfos = 4;
-    SegmentInfo* segInfos = new SegmentInfo[numSegInfos](0, 0, SegmentState::FREE);
-    SegmentCtx segCtx(nullptr, &header, segInfos, nullptr, nullptr, &addrInfo, nullptr, 0);
-
-    NiceMock<MockSegmentList> segmentList[SegmentState::NUM_STATES];
-    for (int state = SegmentState::START; state < SegmentState::NUM_STATES; state++)
-    {
-        segCtx.SetSegmentList((SegmentState)state, &segmentList[state]);
-    }
-
-    EXPECT_CALL(addrInfo, GetnumUserAreaSegments).WillRepeatedly(Return(numSegInfos));
-
-    // Assume writtenSegmentInfoDataInFile pointer has segmentInfoData written in SegmentCtx File.
-    // Fill out SegmentInfoData with temporary values for test.
-    SegmentInfo* writtenSegmentInfoDataInFile = new SegmentInfo[numSegInfos];
-    for(int i = 0 ; i < numSegInfos ; ++i)
-    {
-        writtenSegmentInfoDataInFile[i].SetValidBlockCount(i);
-        writtenSegmentInfoDataInFile[i].SetOccupiedStripeCount(i*100);
-        writtenSegmentInfoDataInFile[i].SetState(SegmentState::SSD);
-    }
-
-    // Assume SegmentInfoData is loaded to loadedFromFileBuffer.
-    int loadedDataSize = sizeof(SegmentCtxHeader) + numSegInfos * sizeof(SegmentInfoData);
-    char* loadedSegmentInfoDataFromFile = new char[loadedDataSize](); // () equals to memset(dummy, 0 ,dummySize).
-    /*
-     * SegmentCtx::AfterLoad(char *buf)
-     * (Parameter given buffer)                      | char* buf[File Size of Segment Context File]                                            |
-     * (Expected layout of parameter given buffer)   | SegmentCtxHeader | SegmentInfoData[0] | SegmentInfoData[1] | ... | SegmentInfoData[N-1] |
-     */
-    for(int i = 0; i < numSegInfos; ++i)
-    {
-        memcpy(loadedSegmentInfoDataFromFile + sizeof(SegmentCtxHeader) + i * sizeof(SegmentInfoData), &writtenSegmentInfoDataInFile[i].data, sizeof(SegmentInfoData));
-    }
-
-    // When : execute SegmentCtx::AfterLoad() method.
-    segCtx.AfterLoad(loadedSegmentInfoDataFromFile);
-
-
-    // Then, SegmentInfoData is updated correctly.
-    for(int i = 0 ; i< numSegInfos ; ++i)
-    {
-        EXPECT_EQ(segCtx.GetValidBlockCount(i), i);
-        EXPECT_EQ(segCtx.GetOccupiedStripeCount(i), i*100);
-        EXPECT_EQ(segCtx.GetSegmentState(i), SegmentState::SSD);
-    }
-
-
-    delete[] segInfos;
-    delete[] writtenSegmentInfoDataInFile;
-    delete[] loadedSegmentInfoDataFromFile;
+    delete[] segmentInfoData;
 }
 
 
@@ -323,7 +260,13 @@ TEST(SegmentCtx, _SegmentFreed_testWhenSegmentIsInRebuilding)
     NiceMock<MockAllocatorAddressInfo> addrInfo;
     NiceMock<MockRebuildCtx> rebuildCtx;
     NiceMock<MockSegmentList> freeSegmentList, ssdSegmentList, rebuildSegmentList;
-    SegmentInfo* segInfos = new SegmentInfo[4](1, 0, SegmentState::SSD);
+    int numSegInfos = 4;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](1, 0, SegmentState::SSD);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
 
     NiceMock<MockGcCtx> gcCtx;
     SegmentCtx segmentCtx(nullptr, nullptr, segInfos, &rebuildSegmentList, &rebuildCtx, &addrInfo,
@@ -351,6 +294,7 @@ TEST(SegmentCtx, _SegmentFreed_testWhenSegmentIsInRebuilding)
     EXPECT_EQ(ret, true);
 
     delete[] segInfos;
+    delete[] segmentInfoData;
 }
 
 TEST(SegmentCtx, _SegmentFreed_testWhenSegmentIsRemovedFromTheRebuildList)
@@ -358,8 +302,13 @@ TEST(SegmentCtx, _SegmentFreed_testWhenSegmentIsRemovedFromTheRebuildList)
     NiceMock<MockAllocatorAddressInfo> addrInfo;
     NiceMock<MockRebuildCtx> rebuildCtx;
     NiceMock<MockSegmentList> freeSegmentList, ssdSegmentList, rebuildSegmentList;
-    SegmentInfo* segInfos = new SegmentInfo[4](1, 0, SegmentState::SSD);
-
+    int numSegInfos = 4;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](1, 0, SegmentState::SSD);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     NiceMock<MockGcCtx> gcCtx;
     NiceMock<MockTelemetryPublisher> tp;
     SegmentCtx segmentCtx(&tp, nullptr, segInfos, &rebuildSegmentList, &rebuildCtx, &addrInfo,
@@ -392,6 +341,7 @@ TEST(SegmentCtx, _SegmentFreed_testWhenSegmentIsRemovedFromTheRebuildList)
     EXPECT_EQ(ret, true);
 
     delete[] segInfos;
+    delete[] segmentInfoData;
 }
 
 TEST_F(SegmentCtxTestFixture, LoadRebuildList_testWhenEmptyRebuildListIsLoaded)
@@ -409,8 +359,13 @@ TEST_F(SegmentCtxTestFixture, LoadRebuildList_testWhenRebuildListIsLoaded)
     NiceMock<MockAllocatorAddressInfo> addrInfo;
     NiceMock<MockRebuildCtx> rebuildCtx;
     NiceMock<MockSegmentList> freeSegmentList, ssdSegmentList, rebuildSegmentList;
-    SegmentInfo* segInfos = new SegmentInfo[4](1, 0, SegmentState::SSD);
-
+    int numSegInfos = 4;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](1, 0, SegmentState::SSD);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     NiceMock<MockGcCtx> gcCtx;
     SegmentCtx segmentCtx(nullptr, nullptr, segInfos, &rebuildSegmentList, &rebuildCtx, &addrInfo,
         &gcCtx, 0);
@@ -435,6 +390,7 @@ TEST_F(SegmentCtxTestFixture, LoadRebuildList_testWhenRebuildListIsLoaded)
     EXPECT_EQ(ret, true);
 
     delete[] segInfos;
+    delete[] segmentInfoData;
 }
 
 TEST_F(SegmentCtxTestFixture, GetRebuildTargetSegmentCount_TestSimpleGetter)
@@ -535,7 +491,7 @@ TEST_F(SegmentCtxTestFixture, GetSectionAddr_TestSimpleGetter)
     char* buf = segCtx->GetSectionAddr(SC_HEADER);
 
     buf = segCtx->GetSectionAddr(SC_SEGMENT_INFO);
-    EXPECT_EQ(nullptr, buf);
+    EXPECT_NE(buf, nullptr);
 }
 
 TEST_F(SegmentCtxTestFixture, GetSectionSize_TestSimpleGetter)
@@ -590,7 +546,13 @@ TEST(SegmentCtx, AllocateFreeSegment_testWhenFreeListIsEmpty)
 {
     // given
     NiceMock<MockAllocatorAddressInfo>* addrInfo = new NiceMock<MockAllocatorAddressInfo>;
-    SegmentInfo* segInfos = new SegmentInfo[100]();
+    int numSegInfos = 100;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::FREE);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     NiceMock<MockSegmentList> freeSegmentList;
     NiceMock<MockRebuildCtx>* rebuildCtx = new NiceMock<MockRebuildCtx>();
     NiceMock<MockTelemetryPublisher>* tp = new NiceMock<MockTelemetryPublisher>();
@@ -607,13 +569,20 @@ TEST(SegmentCtx, AllocateFreeSegment_testWhenFreeListIsEmpty)
     delete[] segInfos;
     delete rebuildCtx;
     delete tp;
+    delete[] segmentInfoData;
 }
 
 TEST(SegmentCtx, AllocateFreeSegment_testWhenSegmentIsAllocated)
 {
     // given
     NiceMock<MockAllocatorAddressInfo>* addrInfo = new NiceMock<MockAllocatorAddressInfo>;
-    SegmentInfo* segInfos = new SegmentInfo[100]();
+    int numSegInfos = 100;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::FREE);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     NiceMock<MockSegmentList> freeSegmentList, nvramSegmentList;
     NiceMock<MockRebuildCtx>* rebuildCtx = new NiceMock<MockRebuildCtx>();
     NiceMock<MockTelemetryPublisher>* tp = new NiceMock<MockTelemetryPublisher>();
@@ -636,6 +605,7 @@ TEST(SegmentCtx, AllocateFreeSegment_testWhenSegmentIsAllocated)
     delete[] segInfos;
     delete rebuildCtx;
     delete tp;
+    delete[] segmentInfoData;
 }
 
 TEST(SegmentCtx, AllocateGCVictimSegment_testWhenVictimSegmentIsFound)
@@ -644,8 +614,13 @@ TEST(SegmentCtx, AllocateGCVictimSegment_testWhenVictimSegmentIsFound)
     NiceMock<MockAllocatorAddressInfo>* addrInfo = new NiceMock<MockAllocatorAddressInfo>;
     NiceMock<MockSegmentList> freeSegmentList, ssdSegmentList, victimSegmentList, rebuildSegmentList;
     NiceMock<MockTelemetryPublisher>* tp = new NiceMock<MockTelemetryPublisher>();
-    SegmentInfo* segInfos = new SegmentInfo[4](0, 0, SegmentState::SSD);
-
+    int numSegInfos = 4;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::SSD);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     NiceMock<MockGcCtx> gcCtx;
     SegmentCtx segCtx(tp, nullptr, segInfos, &rebuildSegmentList, nullptr, addrInfo, &gcCtx, 0);
     segCtx.SetSegmentList(SegmentState::FREE, &freeSegmentList);
@@ -669,6 +644,7 @@ TEST(SegmentCtx, AllocateGCVictimSegment_testWhenVictimSegmentIsFound)
     delete addrInfo;
     delete[] segInfos;
     delete tp;
+    delete[] segmentInfoData;
 }
 
 TEST(SegmentCtx, AllocateGCVictimSegment_testWhenVictimSegmentIsFoundFromTheRebuildList)
@@ -677,8 +653,14 @@ TEST(SegmentCtx, AllocateGCVictimSegment_testWhenVictimSegmentIsFoundFromTheRebu
     NiceMock<MockAllocatorAddressInfo>* addrInfo = new NiceMock<MockAllocatorAddressInfo>;
     NiceMock<MockSegmentList> freeSegmentList, ssdSegmentList, victimSegmentList, rebuildSegmentList;
     NiceMock<MockTelemetryPublisher>* tp = new NiceMock<MockTelemetryPublisher>();
-    SegmentInfo* segInfos = new SegmentInfo[4](0, 0, SegmentState::SSD);
+    int numSegInfos = 4;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::SSD);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
 
+    }
     NiceMock<MockGcCtx> gcCtx;
     SegmentCtx segCtx(tp, nullptr, segInfos, &rebuildSegmentList, nullptr, addrInfo, &gcCtx, 0);
     segCtx.SetSegmentList(SegmentState::FREE, &freeSegmentList);
@@ -702,6 +684,7 @@ TEST(SegmentCtx, AllocateGCVictimSegment_testWhenVictimSegmentIsFoundFromTheRebu
     delete addrInfo;
     delete[] segInfos;
     delete tp;
+    delete[] segmentInfoData;
 }
 
 TEST(SegmentCtx, AllocateGCVictimSegment_testWhenVictimSegmentIsNotFound)
@@ -710,8 +693,13 @@ TEST(SegmentCtx, AllocateGCVictimSegment_testWhenVictimSegmentIsNotFound)
     NiceMock<MockAllocatorAddressInfo>* addrInfo = new NiceMock<MockAllocatorAddressInfo>;
     NiceMock<MockSegmentList> freeSegmentList, ssdSegmentList;
     NiceMock<MockTelemetryPublisher>* tp = new NiceMock<MockTelemetryPublisher>();
-    SegmentInfo* segInfos = new SegmentInfo[4](10, 0, SegmentState::NVRAM);
-
+    int numSegInfos = 4;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](10, 0, SegmentState::SSD);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     NiceMock<MockGcCtx> gcCtx;
     SegmentCtx segCtx(tp, nullptr, segInfos, nullptr, nullptr, addrInfo, &gcCtx, 0);
     segCtx.SetSegmentList(SegmentState::FREE, &freeSegmentList);
@@ -726,6 +714,7 @@ TEST(SegmentCtx, AllocateGCVictimSegment_testWhenVictimSegmentIsNotFound)
     delete addrInfo;
     delete[] segInfos;
     delete tp;
+    delete[] segmentInfoData;
 }
 
 TEST(SegmentCtx, DISABLED_ResetSegmentState_testIfSegmentStateChangedAsIntended)
@@ -739,7 +728,10 @@ TEST(SegmentCtx, DISABLED_ResetSegmentState_testIfSegmentStateChangedAsIntended)
     NiceMock<MockTelemetryPublisher> tp;
 
     {
-        SegmentInfo segInfos(100, 10, SegmentState::VICTIM);
+        SegmentInfo segInfos;
+        SegmentInfoData segmentInfoData(100, 10, SegmentState::VICTIM);
+        segInfos.AllocateSegmentInfoData(&segmentInfoData);
+
         SegmentCtx segCtx(&tp, nullptr, &segInfos, nullptr, nullptr, &addrInfo, &gcCtx, 0);
         for (int state = SegmentState::START; state < SegmentState::NUM_STATES; state++)
         {
@@ -750,7 +742,9 @@ TEST(SegmentCtx, DISABLED_ResetSegmentState_testIfSegmentStateChangedAsIntended)
         EXPECT_EQ(segInfos.GetState(), SegmentState::SSD);
     }
     {
-        SegmentInfo segInfos(100, 10, SegmentState::SSD);
+        SegmentInfo segInfos;
+        SegmentInfoData segmentInfoData(100, 10, SegmentState::SSD);
+        segInfos.AllocateSegmentInfoData(&segmentInfoData);
         SegmentCtx segCtx(&tp, nullptr, &segInfos, nullptr, nullptr, &addrInfo, &gcCtx, 0);
         for (int state = SegmentState::START; state < SegmentState::NUM_STATES; state++)
         {
@@ -761,7 +755,9 @@ TEST(SegmentCtx, DISABLED_ResetSegmentState_testIfSegmentStateChangedAsIntended)
         EXPECT_EQ(segInfos.GetState(), SegmentState::SSD);
     }
     {
-        SegmentInfo segInfos(0, 10, SegmentState::SSD);
+        SegmentInfo segInfos;
+        SegmentInfoData segmentInfoData(0, 10, SegmentState::SSD);
+        segInfos.AllocateSegmentInfoData(&segmentInfoData);
         SegmentCtx segCtx(&tp, nullptr, &segInfos, nullptr, nullptr, &addrInfo, &gcCtx, 0);
         for (int state = SegmentState::START; state < SegmentState::NUM_STATES; state++)
         {
@@ -772,7 +768,9 @@ TEST(SegmentCtx, DISABLED_ResetSegmentState_testIfSegmentStateChangedAsIntended)
         EXPECT_EQ(segInfos.GetState(), SegmentState::FREE);
     }
     {
-        SegmentInfo segInfos(0, 0, SegmentState::FREE);
+        SegmentInfo segInfos;
+        SegmentInfoData segmentInfoData(0, 0, SegmentState::FREE);
+        segInfos.AllocateSegmentInfoData(&segmentInfoData);
         SegmentCtx segCtx(&tp, nullptr, &segInfos, nullptr, nullptr, &addrInfo, &gcCtx, 0);
         for (int state = SegmentState::START; state < SegmentState::NUM_STATES; state++)
         {
@@ -839,8 +837,13 @@ TEST(SegmentCtx, MakeRebuildTarget_testWhenRebuildTargetListIsEmpty)
     NiceMock<MockRebuildCtx> rebuildCtx;
     NiceMock<MockSegmentList> ssdSegmentList, victimSegmentList, nvramSegmentList, rebuildSegmentList;
     NiceMock<MockTelemetryPublisher>* tp = new NiceMock<MockTelemetryPublisher>();
-    SegmentInfo* segInfos = new SegmentInfo[4](0, 0, SegmentState::SSD);
-
+    int numSegInfos = 4;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::SSD);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     NiceMock<MockGcCtx> gcCtx;
     SegmentCtx segmentCtx(tp, nullptr, segInfos, &rebuildSegmentList, &rebuildCtx, &addrInfo, &gcCtx, 0);
     segmentCtx.SetSegmentList(SegmentState::SSD, &ssdSegmentList);
@@ -862,6 +865,7 @@ TEST(SegmentCtx, MakeRebuildTarget_testWhenRebuildTargetListIsEmpty)
 
     delete[] segInfos;
     delete tp;
+    delete[] segmentInfoData;
 }
 
 TEST(SegmentCtx, MakeRebuildTarget_testWhenRebuildTargetListIsNotEmpty)
@@ -870,8 +874,13 @@ TEST(SegmentCtx, MakeRebuildTarget_testWhenRebuildTargetListIsNotEmpty)
     NiceMock<MockRebuildCtx> rebuildCtx;
     NiceMock<MockSegmentList> ssdSegmentList, victimSegmentList, nvramSegmentList, rebuildSegmentList;
     NiceMock<MockTelemetryPublisher>* tp = new NiceMock<MockTelemetryPublisher>();
-    SegmentInfo* segInfos = new SegmentInfo[4](0, 0, SegmentState::SSD);
-
+    int numSegInfos = 4;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::SSD);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     NiceMock<MockGcCtx> gcCtx;
     SegmentCtx segmentCtx(tp, nullptr, segInfos, &rebuildSegmentList, &rebuildCtx, &addrInfo, &gcCtx, 0);
     segmentCtx.SetSegmentList(SegmentState::SSD, &ssdSegmentList);
@@ -900,6 +909,7 @@ TEST(SegmentCtx, MakeRebuildTarget_testWhenRebuildTargetListIsNotEmpty)
 
     delete[] segInfos;
     delete tp;
+    delete[] segmentInfoData;
 }
 
 TEST(SegmentCtx, SetRebuildCompleted_testIfSegmentIsRemovedFromTheList)
@@ -907,8 +917,13 @@ TEST(SegmentCtx, SetRebuildCompleted_testIfSegmentIsRemovedFromTheList)
     NiceMock<MockAllocatorAddressInfo> addrInfo;
     NiceMock<MockRebuildCtx> rebuildCtx;
     NiceMock<MockSegmentList> ssdSegmentList, rebuildSegmentList;
-    SegmentInfo* segInfos = new SegmentInfo[4](0, 0, SegmentState::SSD);
-
+    int numSegInfos = 4;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::SSD);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     NiceMock<MockGcCtx> gcCtx;
     SegmentCtx segmentCtx(nullptr, nullptr, segInfos, &rebuildSegmentList, &rebuildCtx, &addrInfo,
         &gcCtx, 0);
@@ -924,6 +939,7 @@ TEST(SegmentCtx, SetRebuildCompleted_testIfSegmentIsRemovedFromTheList)
     EXPECT_EQ(ret, 0);
 
     delete[] segInfos;
+    delete[] segmentInfoData;
 }
 
 TEST(SegmentCtx, ResetSegmentsState_testIfSegmentStateBecomesNVRAMWhenOccupiedStripeCountIsZeroDuringLogReplay)
@@ -935,8 +951,13 @@ TEST(SegmentCtx, ResetSegmentsState_testIfSegmentStateBecomesNVRAMWhenOccupiedSt
     NiceMock<MockRebuildCtx> rebuildCtx;
     NiceMock<MockSegmentList> rebuildSegmentList;
     NiceMock<MockTelemetryPublisher>* tp = new NiceMock<MockTelemetryPublisher>();
-    SegmentInfo* segInfos = new SegmentInfo[4](0, 0, SegmentState::SSD);
-
+    int numSegInfos = 4;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::SSD);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     NiceMock<MockGcCtx> gcCtx;
     SegmentCtx segmentCtx(tp, nullptr, segInfos, &rebuildSegmentList, &rebuildCtx, &addrInfo, &gcCtx, 0);
 
@@ -966,5 +987,6 @@ TEST(SegmentCtx, ResetSegmentsState_testIfSegmentStateBecomesNVRAMWhenOccupiedSt
     EXPECT_EQ(SegmentState::FREE, segInfos[3].GetState());
 
     delete[] segInfos;
+    delete[] segmentInfoData;
 }
 } // namespace pos

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_mock.h
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_mock.h
@@ -12,7 +12,7 @@ class MockSegmentInfo : public SegmentInfo
 public:
     using SegmentInfo::SegmentInfo;
     MOCK_METHOD(uint32_t, GetValidBlockCount, (), (override));
-    MOCK_METHOD(void, SetValidBlockCount, (int cnt), (override));
+    MOCK_METHOD(void, SetValidBlockCount, (uint32_t cnt), (override));
     MOCK_METHOD(uint32_t, IncreaseValidBlockCount, (uint32_t inc), (override));
     MOCK_METHOD((std::pair<bool, SegmentState>), DecreaseValidBlockCount, (uint32_t dec, bool allowVictimSegRelease), (override));
     MOCK_METHOD(void, SetOccupiedStripeCount, (uint32_t cnt), (override));
@@ -23,7 +23,6 @@ public:
     MOCK_METHOD(bool, MoveToSsdStateOrFreeStateIfItBecomesEmpty, (), (override));
     MOCK_METHOD(bool, MoveToVictimState, (), (override));
     MOCK_METHOD(uint32_t, GetValidBlockCountIfSsdState, (), (override));
-    MOCK_METHOD(void, InitSegmentInfoData, (uint32_t blkCount, uint32_t stripeCount, SegmentState segmentState), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_mock.h
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_mock.h
@@ -11,6 +11,7 @@ class MockSegmentInfo : public SegmentInfo
 {
 public:
     using SegmentInfo::SegmentInfo;
+    MOCK_METHOD(void, InitSegmentInfoData, (), (override));
     MOCK_METHOD(uint32_t, GetValidBlockCount, (), (override));
     MOCK_METHOD(void, SetValidBlockCount, (uint32_t cnt), (override));
     MOCK_METHOD(uint32_t, IncreaseValidBlockCount, (uint32_t inc), (override));
@@ -23,6 +24,7 @@ public:
     MOCK_METHOD(bool, MoveToSsdStateOrFreeStateIfItBecomesEmpty, (), (override));
     MOCK_METHOD(bool, MoveToVictimState, (), (override));
     MOCK_METHOD(uint32_t, GetValidBlockCountIfSsdState, (), (override));
+    MOCK_METHOD(void,  AllocateSegmentInfoData,(SegmentInfoData* segmentInfoData), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_mock.h
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_mock.h
@@ -23,6 +23,8 @@ public:
     MOCK_METHOD(bool, MoveToSsdStateOrFreeStateIfItBecomesEmpty, (), (override));
     MOCK_METHOD(bool, MoveToVictimState, (), (override));
     MOCK_METHOD(uint32_t, GetValidBlockCountIfSsdState, (), (override));
+    MOCK_METHOD(void, InitSegmentInfoData, (uint32_t blkCount, uint32_t stripeCount, SegmentState segmentState), (override));
+    MOCK_METHOD(void, DisposeSegmentInfoData, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_mock.h
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_mock.h
@@ -24,7 +24,6 @@ public:
     MOCK_METHOD(bool, MoveToVictimState, (), (override));
     MOCK_METHOD(uint32_t, GetValidBlockCountIfSsdState, (), (override));
     MOCK_METHOD(void, InitSegmentInfoData, (uint32_t blkCount, uint32_t stripeCount, SegmentState segmentState), (override));
-    MOCK_METHOD(void, DisposeSegmentInfoData, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_test.cpp
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_test.cpp
@@ -248,4 +248,26 @@ TEST(SegmentInfo, GetValidBlockCountIfSsdState_testIfValidCountIsReturnedWhenIts
     EXPECT_EQ(freeSegInfo.GetValidBlockCountIfSsdState(), UINT32_MAX);
 }
 
+TEST(SegmentInfo, UpdateFrom_testIfSegmentInfoDataIsSuccessfullyUpdatedByUpdateFromMethod)
+{
+    // Given initialized SegmentInfo and specific data allocated SegmentInfo.
+    SegmentInfo SegInfo;
+    SegmentInfoData SegInfoData(0, 0, SegmentState::FREE);
+    SegInfo.AllocateSegmentInfoData(&SegInfoData);
+    SegInfo.InitSegmentInfoData();
+
+    // initialized specific values in filledSegInfo.
+    SegmentInfo filledSegInfo;
+    SegmentInfoData filledSegInfoData(5, 3, SegmentState::VICTIM);
+    filledSegInfo.AllocateSegmentInfoData(&filledSegInfoData);
+
+    // When execute SegmentInfo::UpdateFrom()
+    SegInfo.UpdateFrom(filledSegInfo);
+
+    // Then SegInfo data must be updated.
+    EXPECT_EQ(SegInfo.GetValidBlockCount(), 5);
+    EXPECT_EQ(SegInfo.GetOccupiedStripeCount(), 3);
+    EXPECT_EQ(SegInfo.GetState(), SegmentState::VICTIM);
+}
+
 } // namespace pos

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_test.cpp
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_test.cpp
@@ -16,9 +16,54 @@ TEST(SegmentInfo, SegmentInfo_Constructor)
     }
 }
 
+TEST(SegmentInfo, SegmentInfoData_ConstructorInitializationValue)
+{
+    int numSegInfos = 4;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::FREE);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
+
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        EXPECT_EQ(segInfos[i].GetValidBlockCount(), 0);
+        EXPECT_EQ(segInfos[i].GetOccupiedStripeCount(), 0);
+        EXPECT_EQ(segInfos[i].GetState(), SegmentState::FREE);
+    }
+
+    delete[] segInfos;
+    delete[] segmentInfoData;
+}
+
+TEST(SegmentInfo, InitSegmentInfoData_testIfSegmentInfoDataInitializationSuccess)
+{
+    int numSegInfos = 4;
+    SegmentInfo* segInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos];
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+        segInfos[i].InitSegmentInfoData();
+    }
+
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        EXPECT_EQ(segInfos[i].GetValidBlockCount(), 0);
+        EXPECT_EQ(segInfos[i].GetOccupiedStripeCount(), 0);
+        EXPECT_EQ(segInfos[i].GetState(), SegmentState::FREE);
+    }
+
+    delete[] segInfos;
+    delete[] segmentInfoData;
+}
+
 TEST(SegmentInfo, SetValidBlockCount_TestSimpleSetter)
 {
-    SegmentInfo segInfos(0,0,SegmentState::FREE);
+    SegmentInfo segInfos;
+    SegmentInfoData segmentInfoData(0, 0, SegmentState::FREE);
+    segInfos.AllocateSegmentInfoData(&segmentInfoData);
 
     segInfos.SetValidBlockCount(5);
     EXPECT_EQ(segInfos.GetValidBlockCount(), 5);
@@ -32,7 +77,9 @@ TEST(SegmentInfo, SetValidBlockCount_TestSimpleSetter)
 
 TEST(SegmentInfo, IncreaseValidBlockCount_TestIncreaseValue)
 {
-    SegmentInfo segInfos(0,0,SegmentState::FREE);
+    SegmentInfo segInfos;
+    SegmentInfoData segmentInfoData(0, 0, SegmentState::FREE);
+    segInfos.AllocateSegmentInfoData(&segmentInfoData);
 
     EXPECT_EQ(segInfos.IncreaseValidBlockCount(5), 5);
     EXPECT_EQ(segInfos.IncreaseValidBlockCount(3), 8);
@@ -43,7 +90,10 @@ TEST(SegmentInfo, IncreaseValidBlockCount_TestIncreaseValue)
 TEST(SegmentInfo, DecreaseValidBlockCount_testDecreaseToNonZero)
 {
     // given
-    SegmentInfo segInfos(10, 0, SegmentState::FREE);
+    SegmentInfo segInfos;
+    SegmentInfoData segmentInfoData(10, 0, SegmentState::FREE);
+    segInfos.AllocateSegmentInfoData(&segmentInfoData);
+
     // when
     auto result = segInfos.DecreaseValidBlockCount(3, false);
     bool segmentFreed = result.first;
@@ -54,7 +104,10 @@ TEST(SegmentInfo, DecreaseValidBlockCount_testDecreaseToNonZero)
 TEST(SegmentInfo, DecreaseValidBlockCount_testDecreaseToZeroWhenSsdState)
 {
     // given
-    SegmentInfo segInfos(3, 10, SegmentState::SSD);
+    SegmentInfo segInfos;
+    SegmentInfoData segmentInfoData(3, 10, SegmentState::SSD);
+    segInfos.AllocateSegmentInfoData(&segmentInfoData);
+
     // when
     auto result = segInfos.DecreaseValidBlockCount(3, false);
     bool segmentFreed = result.second;
@@ -71,7 +124,10 @@ TEST(SegmentInfo, DecreaseValidBlockCount_testDecreaseToZeroWhenSsdState)
 TEST(SegmentInfo, DecreaseValidBlockCount_testDecreaseToZeroWhenNvramState)
 {
     // given
-    SegmentInfo segInfos(3, 10, SegmentState::NVRAM);
+    SegmentInfo segInfos;
+    SegmentInfoData segmentInfoData(3, 10, SegmentState::NVRAM);
+    segInfos.AllocateSegmentInfoData(&segmentInfoData);
+
     // when
     auto result = segInfos.DecreaseValidBlockCount(3, false);
     bool segmentFreed = result.first;
@@ -83,7 +139,10 @@ TEST(SegmentInfo, DecreaseValidBlockCount_testDecreaseToZeroWhenNvramState)
 TEST(SegmentInfo, SetOccupiedStripeCount_TestSimpleSetter)
 {
     // given
-    SegmentInfo segInfos(0,0,SegmentState::FREE);
+    SegmentInfo segInfos;
+    SegmentInfoData segmentInfoData(0, 0, SegmentState::FREE);
+    segInfos.AllocateSegmentInfoData(&segmentInfoData);
+
     // when
     segInfos.SetOccupiedStripeCount(3);
     // then
@@ -94,7 +153,10 @@ TEST(SegmentInfo, SetOccupiedStripeCount_TestSimpleSetter)
 TEST(SegmentInfo, IncreaseOccupiedStripeCount_TestIncreaseValue)
 {
     // given
-    SegmentInfo segInfos(0,0,SegmentState::FREE);
+    SegmentInfo segInfos;
+    SegmentInfoData segmentInfoData(0, 0, SegmentState::FREE);
+    segInfos.AllocateSegmentInfoData(&segmentInfoData);
+
     // when, then
     EXPECT_EQ(segInfos.IncreaseOccupiedStripeCount(), 1);
     EXPECT_EQ(segInfos.IncreaseOccupiedStripeCount(), 2);
@@ -106,7 +168,9 @@ TEST(SegmentInfo, IncreaseOccupiedStripeCount_TestIncreaseValue)
 TEST(SegmentInfo, MoveToNvramState_testIfStateChanged)
 {
     // given
-    SegmentInfo segInfos(0,0,SegmentState::FREE);
+    SegmentInfo segInfos;
+    SegmentInfoData segmentInfoData(0, 0, SegmentState::FREE);
+    segInfos.AllocateSegmentInfoData(&segmentInfoData);
     // when
     segInfos.MoveToNvramState();
     // then
@@ -116,7 +180,10 @@ TEST(SegmentInfo, MoveToNvramState_testIfStateChanged)
 TEST(SegmentInfo, MoveToSsdState_testIfStateChangedToSSD)
 {
     // given
-    SegmentInfo segInfos(10, 10, SegmentState::NVRAM);
+    SegmentInfo segInfos;
+    SegmentInfoData segmentInfoData(10, 10, SegmentState::NVRAM);
+    segInfos.AllocateSegmentInfoData(&segmentInfoData);
+
     // when
     segInfos.MoveToSsdStateOrFreeStateIfItBecomesEmpty();
     // then
@@ -126,7 +193,10 @@ TEST(SegmentInfo, MoveToSsdState_testIfStateChangedToSSD)
 TEST(SegmentInfo, MoveToSsdState_testIfStateChangedToFree)
 {
     // given
-    SegmentInfo segInfos(0, 10, SegmentState::NVRAM);
+    SegmentInfo segInfos;
+    SegmentInfoData segmentInfoData(0, 10, SegmentState::NVRAM);
+    segInfos.AllocateSegmentInfoData(&segmentInfoData);
+
     // when
     segInfos.MoveToSsdStateOrFreeStateIfItBecomesEmpty();
     // then
@@ -136,7 +206,10 @@ TEST(SegmentInfo, MoveToSsdState_testIfStateChangedToFree)
 TEST(SegmentInfo, MoveToVictimState_testIfStateChanged)
 {
     // given
-    SegmentInfo segInfos(10, 10, SegmentState::SSD);
+    SegmentInfo segInfos;
+    SegmentInfoData segmentInfoData(10, 10, SegmentState::SSD);
+    segInfos.AllocateSegmentInfoData(&segmentInfoData);
+
     // when
     segInfos.MoveToVictimState();
     // then
@@ -146,20 +219,32 @@ TEST(SegmentInfo, MoveToVictimState_testIfStateChanged)
 TEST(SegmentInfo, GetValidBlockCountIfSsdState_testIfValidCountIsReturnedWhenItsSsdState)
 {
     // given
-    SegmentInfo segInfos(34, 10, SegmentState::SSD);
+    SegmentInfo segInfos;
+    SegmentInfoData segmentInfoData(34, 10, SegmentState::SSD);
+    segInfos.AllocateSegmentInfoData(&segmentInfoData);
+
     // when
     EXPECT_EQ(segInfos.GetValidBlockCountIfSsdState(), 34);
 }
 
 TEST(SegmentInfo, GetValidBlockCountIfSsdState_testIfValidCountIsReturnedWhenItsNotSsdState)
 {
-    SegmentInfo freeSegInfo(0, 0, SegmentState::FREE);
+    SegmentInfo freeSegInfo;
+    SegmentInfoData freeSegInfoData(0, 10, SegmentState::FREE);
+    freeSegInfo.AllocateSegmentInfoData(&freeSegInfoData);
+
     EXPECT_EQ(freeSegInfo.GetValidBlockCountIfSsdState(), UINT32_MAX);
 
-    SegmentInfo nvramSegInfo(30, 0, SegmentState::NVRAM);
+    SegmentInfo nvramSegInfo;
+    SegmentInfoData nvramSegInfoData(30, 0, SegmentState::NVRAM);
+    nvramSegInfo.AllocateSegmentInfoData(&nvramSegInfoData);
+
     EXPECT_EQ(freeSegInfo.GetValidBlockCountIfSsdState(), UINT32_MAX);
 
-    SegmentInfo victimSegInfo(30, 0, SegmentState::VICTIM);
+    SegmentInfo victimSegInfo;
+    SegmentInfoData victimSegInfoData(30, 0, SegmentState::VICTIM);
+    victimSegInfo.AllocateSegmentInfoData(&victimSegInfoData);
+
     EXPECT_EQ(freeSegInfo.GetValidBlockCountIfSsdState(), UINT32_MAX);
 }
 

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_test.cpp
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_test.cpp
@@ -18,7 +18,7 @@ TEST(SegmentInfo, SegmentInfo_Constructor)
 
 TEST(SegmentInfo, SetValidBlockCount_TestSimpleSetter)
 {
-    SegmentInfo segInfos;
+    SegmentInfo segInfos(0,0,SegmentState::FREE);
 
     segInfos.SetValidBlockCount(5);
     EXPECT_EQ(segInfos.GetValidBlockCount(), 5);
@@ -32,11 +32,12 @@ TEST(SegmentInfo, SetValidBlockCount_TestSimpleSetter)
 
 TEST(SegmentInfo, IncreaseValidBlockCount_TestIncreaseValue)
 {
-    SegmentInfo segInfos;
+    SegmentInfo segInfos(0,0,SegmentState::FREE);
 
     EXPECT_EQ(segInfos.IncreaseValidBlockCount(5), 5);
     EXPECT_EQ(segInfos.IncreaseValidBlockCount(3), 8);
     EXPECT_EQ(segInfos.IncreaseValidBlockCount(10), 18);
+
 }
 
 TEST(SegmentInfo, DecreaseValidBlockCount_testDecreaseToNonZero)
@@ -82,7 +83,7 @@ TEST(SegmentInfo, DecreaseValidBlockCount_testDecreaseToZeroWhenNvramState)
 TEST(SegmentInfo, SetOccupiedStripeCount_TestSimpleSetter)
 {
     // given
-    SegmentInfo segInfos;
+    SegmentInfo segInfos(0,0,SegmentState::FREE);
     // when
     segInfos.SetOccupiedStripeCount(3);
     // then
@@ -93,7 +94,7 @@ TEST(SegmentInfo, SetOccupiedStripeCount_TestSimpleSetter)
 TEST(SegmentInfo, IncreaseOccupiedStripeCount_TestIncreaseValue)
 {
     // given
-    SegmentInfo segInfos;
+    SegmentInfo segInfos(0,0,SegmentState::FREE);
     // when, then
     EXPECT_EQ(segInfos.IncreaseOccupiedStripeCount(), 1);
     EXPECT_EQ(segInfos.IncreaseOccupiedStripeCount(), 2);
@@ -105,7 +106,7 @@ TEST(SegmentInfo, IncreaseOccupiedStripeCount_TestIncreaseValue)
 TEST(SegmentInfo, MoveToNvramState_testIfStateChanged)
 {
     // given
-    SegmentInfo segInfos;
+    SegmentInfo segInfos(0,0,SegmentState::FREE);
     // when
     segInfos.MoveToNvramState();
     // then

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_test.cpp
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_test.cpp
@@ -55,10 +55,17 @@ TEST(VersionedSegmentCtx, Init_testIfInitWhenNumberOfLogGroupsIsTwo)
     NiceMock<MockJournalConfiguration> config;
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
-    SegmentInfo* segmentInfos = new SegmentInfo[3];
+    int numSegInfos = 3;
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::FREE);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segmentInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     versionedSegCtx.Init(&config, segmentInfos, 3);
 
     delete[] segmentInfos;
+    delete[] segmentInfoData;
 }
 
 TEST(VersionedSegmentCtx, Dispose_testIfContextIsDeleted)
@@ -75,11 +82,18 @@ TEST(VersionedSegmentCtx, Dispose_testIfContextIsDeleted)
     versionedSegCtx.Dispose();
 
     // When : Init and Dispose
-    SegmentInfo* segmentInfos = new SegmentInfo[3];
+    int numSegInfos = 3;
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::FREE);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segmentInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     versionedSegCtx.Init(&config, segmentInfos, 3);
     versionedSegCtx.Dispose();
 
     delete[] segmentInfos;
+    delete[] segmentInfoData;
 }
 
 TEST(VersionedSegmentCtx, IncreaseValidBlockCount_testIfValidBlockCountIsIncreasedAndDecreased)
@@ -90,7 +104,13 @@ TEST(VersionedSegmentCtx, IncreaseValidBlockCount_testIfValidBlockCountIsIncreas
     NiceMock<MockJournalConfiguration> config;
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
-    SegmentInfo* segmentInfos = new SegmentInfo[3];
+    int numSegInfos = 3;
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::FREE);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segmentInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
 
     std::vector<std::shared_ptr<VersionedSegmentInfo>> versionedSegmentInfo;
     for (int index = 0; index < numLogGroups; index++)
@@ -111,6 +131,7 @@ TEST(VersionedSegmentCtx, IncreaseValidBlockCount_testIfValidBlockCountIsIncreas
     versionedSegCtx.IncreaseValidBlockCount(targetLogGroup, 1, 4);
 
     delete[] segmentInfos;
+    delete[] segmentInfoData;
 }
 
 TEST(VersionedSegmentCtx, IncreaseOccupiedStripeCount_testIfOccupiedStripeCountIsIncreased)
@@ -121,8 +142,13 @@ TEST(VersionedSegmentCtx, IncreaseOccupiedStripeCount_testIfOccupiedStripeCountI
     NiceMock<MockJournalConfiguration> config;
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
-    SegmentInfo* segmentInfos = new SegmentInfo[3];
-
+    int numSegInfos = 3;
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::FREE);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segmentInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     std::vector<std::shared_ptr<VersionedSegmentInfo>> versionedSegmentInfo;
     for (int index = 0; index < numLogGroups; index++)
     {
@@ -140,6 +166,7 @@ TEST(VersionedSegmentCtx, IncreaseOccupiedStripeCount_testIfOccupiedStripeCountI
     versionedSegCtx.IncreaseOccupiedStripeCount(targetLogGroup, 1);
 
     delete[] segmentInfos;
+    delete[] segmentInfoData;
 }
 
 TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfChangedValueIsReturned)
@@ -150,9 +177,13 @@ TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfChangedValueIsReturned)
     NiceMock<MockJournalConfiguration> config;
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
-    int numSegments = 3;
-    SegmentInfo* segmentInfos = new SegmentInfo[numSegments];
-
+    int numSegInfos = 3;
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::FREE);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segmentInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     std::vector<std::shared_ptr<VersionedSegmentInfo>> versionedSegmentInfo;
     for (int index = 0; index < numLogGroups; index++)
     {
@@ -190,6 +221,7 @@ TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfChangedValueIsReturned)
     EXPECT_EQ(result[2].GetOccupiedStripeCount(), 0);
 
     delete[] segmentInfos;
+    delete[] segmentInfoData;
 }
 
 TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfChangedValueIsApplied)
@@ -200,8 +232,14 @@ TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfChangedValueIsApplied)
     NiceMock<MockJournalConfiguration> config;
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
-    int numSegments = 3;
-    SegmentInfo* segmentInfos = new SegmentInfo[numSegments];
+    int numSegInfos = 3;
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::FREE);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segmentInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
+
     segmentInfos[0].SetValidBlockCount(10);
     segmentInfos[1].SetValidBlockCount(9);
     segmentInfos[2].SetValidBlockCount(1);
@@ -244,6 +282,7 @@ TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfChangedValueIsApplied)
     EXPECT_EQ(result[2].GetOccupiedStripeCount(), 0 + 0);
 
     delete[] segmentInfos;
+    delete[] segmentInfoData;
 }
 
 TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfFailsWhenInvalidLogGroupIdIsProvided)
@@ -254,8 +293,13 @@ TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfFailsWhenInvalidLogGroupId
     NiceMock<MockJournalConfiguration> config;
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
-    int numSegments = 3;
-    SegmentInfo* segmentInfos = new SegmentInfo[numSegments];
+    int numSegInfos = 3;
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::FREE);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segmentInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
 
     std::vector<std::shared_ptr<VersionedSegmentInfo>> versionedSegmentInfo;
     for (int index = 0; index < numLogGroups; index++)
@@ -269,6 +313,7 @@ TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfFailsWhenInvalidLogGroupId
     ASSERT_DEATH(versionedSegCtx.GetUpdatedInfoToFlush(5), "");
 
     delete[] segmentInfos;
+    delete[] segmentInfoData;
 }
 
 TEST(VersionedSegmentCtx, ResetFlushedInfo_testIfInfoIsResetted)
@@ -279,8 +324,13 @@ TEST(VersionedSegmentCtx, ResetFlushedInfo_testIfInfoIsResetted)
     NiceMock<MockJournalConfiguration> config;
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
-    int numSegments = 3;
-    SegmentInfo* segmentInfos = new SegmentInfo[numSegments];
+    int numSegInfos = 3;
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::FREE);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segmentInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
 
     std::vector<std::shared_ptr<VersionedSegmentInfo>> versionedSegmentInfo;
     for (int index = 0; index < numLogGroups; index++)
@@ -306,6 +356,7 @@ TEST(VersionedSegmentCtx, ResetFlushedInfo_testIfInfoIsResetted)
     versionedSegCtx.ResetFlushedInfo(targetLogGroup);
 
     delete[] segmentInfos;
+    delete[] segmentInfoData;
 }
 
 TEST(VersionedSegmentCtx, ResetSegInfos_testIfSegmentFreed)
@@ -316,8 +367,13 @@ TEST(VersionedSegmentCtx, ResetSegInfos_testIfSegmentFreed)
     NiceMock<MockJournalConfiguration> config;
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
-    int numSegments = 3;
-    SegmentInfo* segmentInfos = new SegmentInfo[numSegments];
+    int numSegInfos = 3;
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegInfos];
+    SegmentInfoData* segmentInfoData = new SegmentInfoData[numSegInfos](0, 0, SegmentState::FREE);
+    for (int i = 0; i < numSegInfos; ++i)
+    {
+        segmentInfos[i].AllocateSegmentInfoData(&segmentInfoData[i]);
+    }
     segmentInfos[0].SetOccupiedStripeCount(100);
     segmentInfos[1].SetOccupiedStripeCount(12);
     segmentInfos[2].SetOccupiedStripeCount(0);
@@ -349,6 +405,7 @@ TEST(VersionedSegmentCtx, ResetSegInfos_testIfSegmentFreed)
     EXPECT_EQ(result[1].GetOccupiedStripeCount(), 0);
 
     delete[] segmentInfos;
+    delete[] segmentInfoData;
 }
 
 } // namespace pos

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_test.cpp
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_test.cpp
@@ -55,7 +55,7 @@ TEST(VersionedSegmentCtx, Init_testIfInitWhenNumberOfLogGroupsIsTwo)
     NiceMock<MockJournalConfiguration> config;
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
-    SegmentInfo* segmentInfos = new SegmentInfo[3]();
+    SegmentInfo* segmentInfos = new SegmentInfo[3];
     versionedSegCtx.Init(&config, segmentInfos, 3);
 
     delete[] segmentInfos;
@@ -75,7 +75,7 @@ TEST(VersionedSegmentCtx, Dispose_testIfContextIsDeleted)
     versionedSegCtx.Dispose();
 
     // When : Init and Dispose
-    SegmentInfo* segmentInfos = new SegmentInfo[3]();
+    SegmentInfo* segmentInfos = new SegmentInfo[3];
     versionedSegCtx.Init(&config, segmentInfos, 3);
     versionedSegCtx.Dispose();
 
@@ -90,7 +90,7 @@ TEST(VersionedSegmentCtx, IncreaseValidBlockCount_testIfValidBlockCountIsIncreas
     NiceMock<MockJournalConfiguration> config;
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
-    SegmentInfo* segmentInfos = new SegmentInfo[3]();
+    SegmentInfo* segmentInfos = new SegmentInfo[3];
 
     std::vector<std::shared_ptr<VersionedSegmentInfo>> versionedSegmentInfo;
     for (int index = 0; index < numLogGroups; index++)
@@ -121,7 +121,7 @@ TEST(VersionedSegmentCtx, IncreaseOccupiedStripeCount_testIfOccupiedStripeCountI
     NiceMock<MockJournalConfiguration> config;
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
-    SegmentInfo* segmentInfos = new SegmentInfo[3]();
+    SegmentInfo* segmentInfos = new SegmentInfo[3];
 
     std::vector<std::shared_ptr<VersionedSegmentInfo>> versionedSegmentInfo;
     for (int index = 0; index < numLogGroups; index++)
@@ -151,7 +151,7 @@ TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfChangedValueIsReturned)
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
     int numSegments = 3;
-    SegmentInfo* segmentInfos = new SegmentInfo[numSegments]();
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegments];
 
     std::vector<std::shared_ptr<VersionedSegmentInfo>> versionedSegmentInfo;
     for (int index = 0; index < numLogGroups; index++)
@@ -201,7 +201,7 @@ TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfChangedValueIsApplied)
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
     int numSegments = 3;
-    SegmentInfo* segmentInfos = new SegmentInfo[numSegments]();
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegments];
     segmentInfos[0].SetValidBlockCount(10);
     segmentInfos[1].SetValidBlockCount(9);
     segmentInfos[2].SetValidBlockCount(1);
@@ -255,7 +255,7 @@ TEST(VersionedSegmentCtx, GetUpdatedInfoToFlush_testIfFailsWhenInvalidLogGroupId
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
     int numSegments = 3;
-    SegmentInfo* segmentInfos = new SegmentInfo[numSegments]();
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegments];
 
     std::vector<std::shared_ptr<VersionedSegmentInfo>> versionedSegmentInfo;
     for (int index = 0; index < numLogGroups; index++)
@@ -280,7 +280,7 @@ TEST(VersionedSegmentCtx, ResetFlushedInfo_testIfInfoIsResetted)
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
     int numSegments = 3;
-    SegmentInfo* segmentInfos = new SegmentInfo[numSegments]();
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegments];
 
     std::vector<std::shared_ptr<VersionedSegmentInfo>> versionedSegmentInfo;
     for (int index = 0; index < numLogGroups; index++)
@@ -317,7 +317,7 @@ TEST(VersionedSegmentCtx, ResetSegInfos_testIfSegmentFreed)
     ON_CALL(config, GetNumLogGroups).WillByDefault(Return(numLogGroups));
 
     int numSegments = 3;
-    SegmentInfo* segmentInfos = new SegmentInfo[numSegments]();
+    SegmentInfo* segmentInfos = new SegmentInfo[numSegments];
     segmentInfos[0].SetOccupiedStripeCount(100);
     segmentInfos[1].SetOccupiedStripeCount(12);
     segmentInfos[2].SetOccupiedStripeCount(0);


### PR DESCRIPTION
- Bug scenario : To support backward compatibility, loading metadata among different POS binary must be possible. But loading Object including virtual methods causes corruption.
- Solution : Save only data not object including virtual methods.
- Added UT/IT fix
- fixed VersionedSegmentCtx memory issue

----------------------------------------------------------------------
Backward Compatibility 지원에 있어서 문제가 되었던 부분을 수정했습니다.

기존 문제 상황 
- 커밋 1 (이해하기 쉽게 커밋 해시를 1,2 로 표현하겠습니다.) 에서 빌드하고 Array 생성 및 mount 하여 IO를 실행
- Array에 저장되는 데이터와 관계 없는 소스코드 변경을 포함한 커밋 2 추가 및 동일 머신에서 빌드
- 커밋 2의 포세이돈을 실행하여 커밋 1에서 저장된 Array를 dirty bringup 시도
- **예측은 정상 실행 되어야하나 데이터 관련 변경점이 없는 상황임에도 불구하고 dirty bringup 실패** 

문제 해결에 대한 변경사항
- 기존에 Object 전체를 memcpy하는 방식(virtual table 까지 복사)에서 Object 내부의 Data만 복사하여 저장하는 방식으로 변경
- 문제 상황은 [IMS](https://solims.swservice.samsungds.net:8080/issue/browse/AWIBOF-7453) 커맨트의 그림에서 확인 가능합니다.

추후 계획
- 본 커밋이 들어간 이후에 SegmentInfoData에 Reserved 영역 추가를 지원할 수 있습니다.

버그 수정
- VersionedSegmentCtx의 UT 코드를 수정하다가 메모리 관련 이슈가 있어서 해당 부분을 수정하였습니다.
- 관련 내용은 커맨트로 남겨두도록 하겠습니다.
