### PR TITLE
[AWIBOF-7825] Array builiding logic improvement

### DIFF
--- a/src/array/array.h
+++ b/src/array/array.h
@@ -30,8 +30,7 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef ARRAY_H_
-#define ARRAY_H_
+#pragma once
 
 #include <list>
 #include <string>
@@ -58,6 +57,7 @@
 #include "src/include/array_config.h"
 #include "src/array/service/array_service_layer.h"
 #include "src/array/array_metrics_publisher.h"
+#include "src/array/build/array_builder_adapter.h"
 
 using namespace std;
 
@@ -87,13 +87,13 @@ public:
     Array(string name, IArrayRebuilder* rbdr, IAbrControl* abr, IStateControl* iState);
     Array(string name, IArrayRebuilder* rbdr, IAbrControl* abr, ArrayDeviceManager* devMgr, DeviceManager* sysDevMgr,
         PartitionManager* ptnMgr, ArrayState* arrayState, PartitionServices* svc, EventScheduler* eventScheduler,
-        ArrayServiceLayer* arrayservice);
+        ArrayServiceLayer* arrayservice, ArrayBuilderAdapter* arrayBuilder = nullptr);
     virtual ~Array(void);
     virtual int Init(void) override;
     virtual void Dispose(void) override;
     virtual void Shutdown(void) override;
     virtual int Load(void);
-    virtual int Create(DeviceSet<string> nameSet, string metaFt, string dataFt);
+    virtual int Create(const DeviceSet<string>& devs, string metaFt, string dataFt);
     virtual void Flush(void) override;
     virtual int Delete(void);
     virtual int AddSpare(string devName);
@@ -132,7 +132,6 @@ public:
 
 private:
     int _LoadImpl(void);
-    int _CreatePartitions(RaidTypeEnum metaRaid, RaidTypeEnum dataRaid);
     void _DeletePartitions(void);
     int _Flush(void);
     int _Flush(ArrayMeta& meta);
@@ -158,6 +157,7 @@ private:
     EventScheduler* eventScheduler = nullptr;
     ArrayServiceLayer* arrayService = nullptr;
     ArrayMetricsPublisher* publisher = nullptr;
+    ArrayBuilderAdapter* arrayBuilder = nullptr;
     id_t uniqueId = 0;
     bool isWTEnabled = false;
     string targetAddress = "";
@@ -166,4 +166,3 @@ private:
     DebugInfoQueue<ArrayDebugInfo> debugArrayQueue;
 };
 } // namespace pos
-#endif // ARRAY_H_

--- a/src/array/array_name_policy.h
+++ b/src/array/array_name_policy.h
@@ -43,13 +43,7 @@ namespace pos
 class ArrayNamePolicy
 {
 public:
-    int CheckArrayName(string name);
-    // StringChecker
-private:
-    const size_t MIN_LEN = 2;
-    const size_t MAX_LEN = 63;
-    const char SPACE = ' ';
-    const char* ALLOWED_CHAR = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_- ";
+    static int CheckArrayName(string name);
 };
 
 } // namespace pos

--- a/src/array/build/array_build_info.h
+++ b/src/array/build/array_build_info.h
@@ -30,52 +30,37 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "array_name_policy.h"
+#pragma once
 
-#include "src/include/pos_event_id.h"
-#include "src/logger/logger.h"
+#include <vector>
+
+#include "src/array/device/array_device.h"
+#include "src/array/partition/partition.h"
+
+using namespace std;
 
 namespace pos
 {
-int
-ArrayNamePolicy::CheckArrayName(string name)
+class ArrayBuildInfo
 {
-    const size_t MIN_LEN = 2;
-    const size_t MAX_LEN = 63;
-    const char SPACE = ' ';
-    const char* ALLOWED_CHAR = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_- ";
-
-    int ret = EID(SUCCESS);
-    StringChecker checker(name);
-    size_t len = checker.Length();
-    if (len < MIN_LEN)
+public:
+    void Dispose(void)
     {
-        ret = EID(CREATE_ARRAY_NAME_TOO_SHORT);
-        POS_TRACE_WARN(ret, "name len: {}", len);
-        return ret;
+        for (auto i : devices)
+        {
+            delete i;
+        }
+        devices.clear();
+        for (auto i : partitions)
+        {
+            delete i;
+        }
+        partitions.clear();
     }
-    else if (len > MAX_LEN)
-    {
-        ret = EID(CREATE_ARRAY_NAME_TOO_LONG);
-        POS_TRACE_WARN(ret, "name len: {}", len);
-        return ret;
-    }
-
-    if (checker.StartWith(SPACE) || checker.EndWith(SPACE))
-    {
-        ret = EID(CREATE_ARRAY_NAME_START_OR_END_WITH_SPACE);
-        POS_TRACE_WARN(ret, "name: {}", name);
-        return ret;
-    }
-
-    if (checker.OnlyContains(ALLOWED_CHAR) == false)
-    {
-        ret = EID(CREATE_ARRAY_NAME_INCLUDES_SPECIAL_CHAR);
-        POS_TRACE_WARN(ret, "name allowed only: {}", ALLOWED_CHAR);
-        return ret;
-    }
-
-    return ret;
-}
+    virtual ~ArrayBuildInfo() {};
+    int buildResult;
+    vector<ArrayDevice*> devices;
+    vector<Partition*> partitions;
+};
 
 } // namespace pos

--- a/src/array/build/array_builder.h
+++ b/src/array/build/array_builder.h
@@ -30,52 +30,23 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "array_name_policy.h"
+#pragma once
 
-#include "src/include/pos_event_id.h"
-#include "src/logger/logger.h"
+#include "array_build_info.h"
+#include "src/array/meta/device_meta.h"
+#include "src/array_models/dto/device_set.h"
+
+using namespace std;
 
 namespace pos
 {
-int
-ArrayNamePolicy::CheckArrayName(string name)
+class ArrayBuilder
 {
-    const size_t MIN_LEN = 2;
-    const size_t MAX_LEN = 63;
-    const char SPACE = ' ';
-    const char* ALLOWED_CHAR = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_- ";
-
-    int ret = EID(SUCCESS);
-    StringChecker checker(name);
-    size_t len = checker.Length();
-    if (len < MIN_LEN)
-    {
-        ret = EID(CREATE_ARRAY_NAME_TOO_SHORT);
-        POS_TRACE_WARN(ret, "name len: {}", len);
-        return ret;
-    }
-    else if (len > MAX_LEN)
-    {
-        ret = EID(CREATE_ARRAY_NAME_TOO_LONG);
-        POS_TRACE_WARN(ret, "name len: {}", len);
-        return ret;
-    }
-
-    if (checker.StartWith(SPACE) || checker.EndWith(SPACE))
-    {
-        ret = EID(CREATE_ARRAY_NAME_START_OR_END_WITH_SPACE);
-        POS_TRACE_WARN(ret, "name: {}", name);
-        return ret;
-    }
-
-    if (checker.OnlyContains(ALLOWED_CHAR) == false)
-    {
-        ret = EID(CREATE_ARRAY_NAME_INCLUDES_SPECIAL_CHAR);
-        POS_TRACE_WARN(ret, "name allowed only: {}", ALLOWED_CHAR);
-        return ret;
-    }
-
-    return ret;
-}
+public:
+    static ArrayBuildInfo* Load(const DeviceSet<DeviceMeta>& devs,
+        string metaRaid, string dataRaid);
+    static ArrayBuildInfo* Create(string name, const DeviceSet<string>& devs,
+        string metaRaid, string dataRaid);
+};
 
 } // namespace pos

--- a/src/array/build/array_builder_adapter.cpp
+++ b/src/array/build/array_builder_adapter.cpp
@@ -30,52 +30,21 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "array_name_policy.h"
-
-#include "src/include/pos_event_id.h"
-#include "src/logger/logger.h"
+#include "array_builder_adapter.h"
 
 namespace pos
 {
-int
-ArrayNamePolicy::CheckArrayName(string name)
+ArrayBuildInfo*
+ArrayBuilderAdapter::Load(const DeviceSet<DeviceMeta>& devs,
+    string metaRaid, string dataRaid)
 {
-    const size_t MIN_LEN = 2;
-    const size_t MAX_LEN = 63;
-    const char SPACE = ' ';
-    const char* ALLOWED_CHAR = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_- ";
-
-    int ret = EID(SUCCESS);
-    StringChecker checker(name);
-    size_t len = checker.Length();
-    if (len < MIN_LEN)
-    {
-        ret = EID(CREATE_ARRAY_NAME_TOO_SHORT);
-        POS_TRACE_WARN(ret, "name len: {}", len);
-        return ret;
-    }
-    else if (len > MAX_LEN)
-    {
-        ret = EID(CREATE_ARRAY_NAME_TOO_LONG);
-        POS_TRACE_WARN(ret, "name len: {}", len);
-        return ret;
-    }
-
-    if (checker.StartWith(SPACE) || checker.EndWith(SPACE))
-    {
-        ret = EID(CREATE_ARRAY_NAME_START_OR_END_WITH_SPACE);
-        POS_TRACE_WARN(ret, "name: {}", name);
-        return ret;
-    }
-
-    if (checker.OnlyContains(ALLOWED_CHAR) == false)
-    {
-        ret = EID(CREATE_ARRAY_NAME_INCLUDES_SPECIAL_CHAR);
-        POS_TRACE_WARN(ret, "name allowed only: {}", ALLOWED_CHAR);
-        return ret;
-    }
-
-    return ret;
+    return ArrayBuilder::Load(devs, metaRaid, dataRaid);
 }
 
+ArrayBuildInfo*
+ArrayBuilderAdapter::Create(string name, const DeviceSet<string>& devs,
+    string metaRaid, string dataRaid)
+{
+    return ArrayBuilder::Create(name, devs, metaRaid, dataRaid);
+}
 } // namespace pos

--- a/src/array/build/array_builder_adapter.h
+++ b/src/array/build/array_builder_adapter.h
@@ -30,52 +30,21 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "array_name_policy.h"
+#pragma once
 
-#include "src/include/pos_event_id.h"
-#include "src/logger/logger.h"
+#include "array_builder.h"
+
+using namespace std;
 
 namespace pos
 {
-int
-ArrayNamePolicy::CheckArrayName(string name)
+class ArrayBuilderAdapter
 {
-    const size_t MIN_LEN = 2;
-    const size_t MAX_LEN = 63;
-    const char SPACE = ' ';
-    const char* ALLOWED_CHAR = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_- ";
-
-    int ret = EID(SUCCESS);
-    StringChecker checker(name);
-    size_t len = checker.Length();
-    if (len < MIN_LEN)
-    {
-        ret = EID(CREATE_ARRAY_NAME_TOO_SHORT);
-        POS_TRACE_WARN(ret, "name len: {}", len);
-        return ret;
-    }
-    else if (len > MAX_LEN)
-    {
-        ret = EID(CREATE_ARRAY_NAME_TOO_LONG);
-        POS_TRACE_WARN(ret, "name len: {}", len);
-        return ret;
-    }
-
-    if (checker.StartWith(SPACE) || checker.EndWith(SPACE))
-    {
-        ret = EID(CREATE_ARRAY_NAME_START_OR_END_WITH_SPACE);
-        POS_TRACE_WARN(ret, "name: {}", name);
-        return ret;
-    }
-
-    if (checker.OnlyContains(ALLOWED_CHAR) == false)
-    {
-        ret = EID(CREATE_ARRAY_NAME_INCLUDES_SPECIAL_CHAR);
-        POS_TRACE_WARN(ret, "name allowed only: {}", ALLOWED_CHAR);
-        return ret;
-    }
-
-    return ret;
-}
-
+public:
+    virtual ~ArrayBuilderAdapter() {};
+    virtual ArrayBuildInfo* Load(const DeviceSet<DeviceMeta>& devs,
+        string metaRaid, string dataRaid);
+    virtual ArrayBuildInfo* Create(string name, const DeviceSet<string>& devs,
+        string metaRaid, string dataRaid);
+};
 } // namespace pos

--- a/src/array/build/device_builder.cpp
+++ b/src/array/build/device_builder.cpp
@@ -1,0 +1,150 @@
+/*
+ *   BSD LICENSE
+ *   Copyright (c) 2021 Samsung Electronics Corporation
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Samsung Electronics Corporation nor the names of
+ *       its contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "device_builder.h"
+#include "src/array/device/array_device.h"
+#include "src/logger/logger.h"
+
+namespace pos
+{
+
+int
+DeviceBuilder::Create(const DeviceSet<string>& nameSet,
+    vector<ArrayDevice*>& devs, IDevInfo* getDev)
+{
+    uint32_t index = 0;
+    for (string devName : nameSet.data)
+    {
+        DevName name(devName);
+        UblockSharedPtr ublock = getDev->GetDev(name);
+        if (ublock == nullptr)
+        {
+            int eid = EID(CREATE_ARRAY_SSD_NAME_NOT_FOUND);
+            POS_TRACE_WARN(eid, "ssd_name: {}", devName);
+            return eid;
+        }
+        ArrayDevice* dev = new ArrayDevice(ublock, ArrayDeviceState::NORMAL,
+            index, ArrayDeviceType::DATA);
+        devs.push_back(dev);
+        index++;
+    }
+
+    for (string devName : nameSet.nvm)
+    {
+        DevName name(devName);
+        UblockSharedPtr ublock = getDev->GetDev(name);
+        if (ublock == nullptr)
+        {
+            int eid = EID(CREATE_ARRAY_NVM_NAME_NOT_FOUND);
+            POS_TRACE_WARN(eid, "nvm_name: {}", devName);
+            return eid;
+        }
+        ArrayDevice* dev = new ArrayDevice(ublock, ArrayDeviceState::NORMAL,
+            0, ArrayDeviceType::NVM);
+        devs.push_back(dev);
+    }
+
+    for (string devName : nameSet.spares)
+    {
+        DevName name(devName);
+        UblockSharedPtr ublock = getDev->GetDev(name);
+        if (ublock == nullptr)
+        {
+            int eid = EID(CREATE_ARRAY_SSD_NAME_NOT_FOUND);
+            POS_TRACE_WARN(eid, "ssd_name: {}", devName);
+            return eid;
+        }
+        ArrayDevice* dev = new ArrayDevice(ublock, ArrayDeviceState::NORMAL,
+            0, ArrayDeviceType::SPARE);
+        devs.push_back(dev);
+    }
+    return 0;
+}
+
+int
+DeviceBuilder::Load(const DeviceSet<DeviceMeta>& metaSet,
+        vector<ArrayDevice*>& devs, IDevInfo* getDev)
+{
+    uint32_t index = 0;
+    for (DeviceMeta meta : metaSet.data)
+    {
+        ArrayDevice* dev = nullptr;
+        DevUid uid(meta.uid);
+
+        if (ArrayDeviceState::FAULT == meta.state)
+        {
+            dev = new ArrayDevice(nullptr, ArrayDeviceState::FAULT, index, ArrayDeviceType::DATA);
+        }
+        else
+        {
+            UblockSharedPtr uBlock = getDev->GetDev(uid);
+            if (uBlock == nullptr)
+            {
+                meta.state = ArrayDeviceState::FAULT;
+            }
+            else if (ArrayDeviceState::REBUILD == meta.state)
+            {
+                POS_TRACE_DEBUG(EID(ARRAY_DEV_DEBUG_MSG),
+                    "Rebuilding device found {}", meta.uid);
+            }
+
+            dev = new ArrayDevice(uBlock, meta.state, index, ArrayDeviceType::DATA);
+        }
+        devs.push_back(dev);
+        index++;
+    }
+
+    for (DeviceMeta meta : metaSet.nvm)
+    {
+        DevUid uid(meta.uid);
+        UblockSharedPtr uBlock = getDev->GetDev(uid);
+        if (nullptr == uBlock)
+        {
+            int eventId = EID(ARRAY_NVM_NOT_FOUND);
+            POS_TRACE_WARN(eventId, "devUid: {}", meta.uid);
+            return eventId;
+        }
+        devs.push_back(new ArrayDevice(uBlock, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::NVM));
+    }
+
+    for (DeviceMeta meta : metaSet.spares)
+    {
+        DevUid uid(meta.uid);
+        UblockSharedPtr uBlock = getDev->GetDev(uid);
+        if (nullptr != uBlock)
+        {
+            devs.push_back(new ArrayDevice(uBlock, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::SPARE));
+        }
+    }
+    return 0;
+}
+} // namespace pos

--- a/src/array/build/device_builder.h
+++ b/src/array/build/device_builder.h
@@ -30,52 +30,26 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "array_name_policy.h"
+#pragma once
 
-#include "src/include/pos_event_id.h"
-#include "src/logger/logger.h"
+#include "src/device/device_manager.h"
+#include "src/array/device/array_device.h"
+#include "src/array_models/dto/device_set.h"
+#include "src/array/meta/device_meta.h"
+
+using namespace std;
 
 namespace pos
 {
-int
-ArrayNamePolicy::CheckArrayName(string name)
+class DeviceBuilder
 {
-    const size_t MIN_LEN = 2;
-    const size_t MAX_LEN = 63;
-    const char SPACE = ' ';
-    const char* ALLOWED_CHAR = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_- ";
-
-    int ret = EID(SUCCESS);
-    StringChecker checker(name);
-    size_t len = checker.Length();
-    if (len < MIN_LEN)
-    {
-        ret = EID(CREATE_ARRAY_NAME_TOO_SHORT);
-        POS_TRACE_WARN(ret, "name len: {}", len);
-        return ret;
-    }
-    else if (len > MAX_LEN)
-    {
-        ret = EID(CREATE_ARRAY_NAME_TOO_LONG);
-        POS_TRACE_WARN(ret, "name len: {}", len);
-        return ret;
-    }
-
-    if (checker.StartWith(SPACE) || checker.EndWith(SPACE))
-    {
-        ret = EID(CREATE_ARRAY_NAME_START_OR_END_WITH_SPACE);
-        POS_TRACE_WARN(ret, "name: {}", name);
-        return ret;
-    }
-
-    if (checker.OnlyContains(ALLOWED_CHAR) == false)
-    {
-        ret = EID(CREATE_ARRAY_NAME_INCLUDES_SPECIAL_CHAR);
-        POS_TRACE_WARN(ret, "name allowed only: {}", ALLOWED_CHAR);
-        return ret;
-    }
-
-    return ret;
-}
+public:
+    static int Create(const DeviceSet<string>& nameSet,
+        vector<ArrayDevice*>& devs, /* OUT PARAM */
+        IDevInfo* getDev = DeviceManagerSingleton::Instance());
+    static int Load(const DeviceSet<DeviceMeta>& metaSet,
+        vector<ArrayDevice*>& devs, /* OUT PARAM */
+        IDevInfo* getDev = DeviceManagerSingleton::Instance());
+};
 
 } // namespace pos

--- a/src/array/device/array_device.h
+++ b/src/array/device/array_device.h
@@ -47,7 +47,7 @@ public:
     ArrayDevice(UblockSharedPtr uBlock,
         ArrayDeviceState state = ArrayDeviceState::NORMAL,
         uint32_t dataIndex = 0, ArrayDeviceType type = ArrayDeviceType::DATA);
-    ~ArrayDevice(void) override;
+    virtual ~ArrayDevice(void);
     string GetName(void) override;
     string GetSerial(void) override;
     uint32_t GetDataIndex(void) override;

--- a/src/array/device/array_device_api.cpp
+++ b/src/array/device/array_device_api.cpp
@@ -92,6 +92,14 @@ ArrayDeviceApi::ExtractDevicesByType(ArrayDeviceType type,
         [type](auto d) { return d->GetType() == type; });
 }
 
+vector<ArrayDevice*>
+ArrayDeviceApi::ExtractDevicesByTypeAndState(ArrayDeviceType type, ArrayDeviceState state,
+    const vector<ArrayDevice*>& devs)
+{
+    return Enumerable::Where(devs,
+        [type, state](auto d) { return d->GetType() == type && d->GetState() == state; });
+}
+
 uint64_t
 ArrayDeviceApi::GetMinimumCapacity(const vector<ArrayDevice*>& devs)
 {

--- a/src/array/device/array_device_api.h
+++ b/src/array/device/array_device_api.h
@@ -55,6 +55,7 @@ public:
     static vector<ArrayDevice*> ExtractDevicesByState(ArrayDeviceState state, const vector<ArrayDevice*>& devs);
     static vector<ArrayDevice*> ExtractDevicesByType(ArrayDeviceType type, const vector<ArrayDevice*>& devs);
     static vector<ArrayDevice*> ExtractDevices(const vector<ArrayDevice*>& devs);
+    static vector<ArrayDevice*> ExtractDevicesByTypeAndState(ArrayDeviceType type, ArrayDeviceState state, const vector<ArrayDevice*>& devs);
     static uint64_t GetMinimumCapacity(const vector<ArrayDevice*>& devs);
     static DeviceSet<DeviceMeta> ExportDeviceMeta(const vector<ArrayDevice*>& devs);
     static int ImportInspection(const vector<ArrayDevice*>& devs);

--- a/src/array/device/array_device_list.h
+++ b/src/array/device/array_device_list.h
@@ -33,33 +33,30 @@
 #pragma once
 
 #include <mutex>
-#include <string>
 #include <vector>
 
 #include "array_device.h"
-#include "src/array/meta/array_meta.h"
+#include "array_device_type.h"
 
 using namespace std;
 
 namespace pos
 {
-using ArrayDeviceSet = DeviceSet<ArrayDevice*>;
 
 class ArrayDeviceList
 {
 public:
     ArrayDeviceList();
     virtual ~ArrayDeviceList();
-    virtual int SetNvm(ArrayDevice* nvm);
+    virtual int Import(vector<ArrayDevice*> devs);
     virtual int AddSsd(ArrayDevice* dev);
-    virtual int RemoveSpare(ArrayDevice* target);
+    virtual int RemoveSsd(ArrayDevice* target);
     virtual int SpareToData(ArrayDevice* target, ArrayDevice*& swapOut);
     virtual void Clear(void);
-    virtual vector<ArrayDevice*> GetDevs(void);
+    virtual vector<ArrayDevice*>& GetDevs(void);
 
 private:
-    vector<ArrayDevice*>::iterator _FindDev(ArrayDevice* dev);
     mutex* mtx = nullptr;
-    vector<ArrayDevice*> devs;
+    vector<ArrayDevice*> devices;
 };
 } // namespace pos

--- a/src/array/device/array_device_manager.cpp
+++ b/src/array/device/array_device_manager.cpp
@@ -31,25 +31,23 @@
  */
 
 #include "array_device_manager.h"
+#include "array_device_api.h"
 
 #include <algorithm>
 #include <vector>
 
-#include "array_device_api.h"
 #include "src/device/base/ublock_device.h"
 #include "src/device/device_manager.h"
 #include "src/include/array_config.h"
 #include "src/include/pos_event_id.h"
 #include "src/logger/logger.h"
 #include "src/volume/volume_list.h"
-#include "src/helper/enumerable/query.h"
 
 namespace pos
 {
 ArrayDeviceManager::ArrayDeviceManager(DeviceManager* sysDevMgr, string arrayName)
-:
-    sysDevMgr_(sysDevMgr),
-    arrayName_(arrayName)
+: sysDevMgr_(sysDevMgr),
+  arrayName_(arrayName)
 {
     devs_ = new ArrayDeviceList();
 }
@@ -59,129 +57,16 @@ ArrayDeviceManager::~ArrayDeviceManager(void)
     delete devs_;
 }
 
-int
-ArrayDeviceManager::ImportByName(DeviceSet<string> nameSet)
+void
+ArrayDeviceManager::Clear(void)
 {
-    int ret = 0;
-
-    for (string devName : nameSet.nvm)
-    {
-        DevName name(devName);
-        UblockSharedPtr uBlock = sysDevMgr_->GetDev(name);
-        if (nullptr == uBlock || uBlock->GetType() != DeviceType::NVRAM)
-        {
-            int eventId = EID(CREATE_ARRAY_NVM_NAME_NOT_FOUND);
-            POS_TRACE_WARN(eventId, "devName: {}", devName);
-            return eventId;
-        }
-        ret = devs_->SetNvm(new ArrayDevice(uBlock, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::NVM));
-        if (ret != 0)
-        {
-            return ret;
-        }
-    }
-    uint32_t dataIndex = 0;
-    for (string devName : nameSet.data)
-    {
-        DevName name(devName);
-        UblockSharedPtr uBlock = sysDevMgr_->GetDev(name);
-        if (nullptr == uBlock || uBlock->GetType() != DeviceType::SSD)
-        {
-            int eventId = EID(CREATE_ARRAY_SSD_NAME_NOT_FOUND);
-            POS_TRACE_WARN(eventId, "devName: {}", devName);
-            return eventId;
-        }
-        ret = devs_->AddSsd((new ArrayDevice(uBlock, ArrayDeviceState::NORMAL, dataIndex, ArrayDeviceType::DATA)));
-        if (ret != 0)
-        {
-            return ret;
-        }
-        dataIndex++;
-    }
-    for (string devName : nameSet.spares)
-    {
-        DevName name(devName);
-        UblockSharedPtr uBlock = sysDevMgr_->GetDev(name);
-        if (nullptr == uBlock || uBlock->GetType() != DeviceType::SSD)
-        {
-            int eventId = EID(CREATE_ARRAY_SSD_NAME_NOT_FOUND);
-            POS_TRACE_WARN(eventId, "devName: {}", devName);
-            return eventId;
-        }
-        ret = devs_->AddSsd(new ArrayDevice(uBlock, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::SPARE));
-        if (ret != 0)
-        {
-            return ret;
-        }
-    }
-    ret = _CheckConstraints(devs_);
-    return ret;
+    devs_->Clear();
 }
 
 int
-ArrayDeviceManager::Import(DeviceSet<DeviceMeta> metaSet)
+ArrayDeviceManager::Import(vector<ArrayDevice*> devs)
 {
-    int ret = 0;
-    for (DeviceMeta meta : metaSet.nvm)
-    {
-        DevUid uid(meta.uid);
-        UblockSharedPtr uBlock = sysDevMgr_->GetDev(uid);
-        if (nullptr == uBlock)
-        {
-            int eventId = EID(ARRAY_NVM_NOT_FOUND);
-            POS_TRACE_WARN(eventId, "devUid: {}", meta.uid);
-            return eventId;
-        }
-        devs_->SetNvm(new ArrayDevice(uBlock, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::NVM));
-    }
-
-    uint32_t dataIndex = 0;
-    for (DeviceMeta meta : metaSet.data)
-    {
-        ArrayDevice* dev = nullptr;
-        DevUid uid(meta.uid);
-
-        if (ArrayDeviceState::FAULT == meta.state)
-        {
-            dev = new ArrayDevice(nullptr, ArrayDeviceState::FAULT, dataIndex, ArrayDeviceType::DATA);
-        }
-        else
-        {
-            UblockSharedPtr uBlock = sysDevMgr_->GetDev(uid);
-            if (uBlock == nullptr)
-            {
-                meta.state = ArrayDeviceState::FAULT;
-            }
-            else if (ArrayDeviceState::REBUILD == meta.state)
-            {
-                POS_TRACE_DEBUG(EID(ARRAY_DEV_DEBUG_MSG),
-                    "Rebuilding device found {}", meta.uid);
-            }
-
-            dev = new ArrayDevice(uBlock, meta.state, dataIndex, ArrayDeviceType::DATA);
-        }
-        devs_->AddSsd(dev);
-        dataIndex++;
-    }
-
-    ret = _CheckActiveSsdsCount(ArrayDeviceApi::ExtractDevicesByType(
-        ArrayDeviceType::DATA, devs_->GetDevs()));
-    if (0 != ret)
-    {
-        return ret;
-    }
-
-    for (DeviceMeta meta : metaSet.spares)
-    {
-        DevUid uid(meta.uid);
-        UblockSharedPtr uBlock = sysDevMgr_->GetDev(uid);
-        if (nullptr != uBlock)
-        {
-            devs_->AddSsd(new ArrayDevice(uBlock, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::SPARE));
-        }
-    }
-
-    return ret;
+    return devs_->Import(devs);
 }
 
 int
@@ -196,30 +81,22 @@ ArrayDeviceManager::AddSpare(string devName)
         POS_TRACE_WARN(eid, "devName: {}", devName);
         return eid;
     }
-
     if (spare->GetClass() != DeviceClass::SYSTEM)
     {
         int eid = EID(UNABLE_TO_ADD_SSD_ALREADY_OCCUPIED);
         POS_TRACE_WARN(eid, "devName: {}", devName);
         return eid;
     }
-
-    uint64_t baseCapa = _GetBaseCapacity(
-        ArrayDeviceApi::ExtractDevicesByType(ArrayDeviceType::DATA, devs_->GetDevs()));
+    uint64_t baseCapa = ArrayDeviceApi::GetMinimumCapacity(
+            ArrayDeviceApi::ExtractDevicesByType(ArrayDeviceType::DATA, devs_->GetDevs()));
     if (baseCapa > spare->GetSize())
     {
         int eid = EID(ADD_SPARE_CAPACITY_IS_TOO_SMALL);
-        POS_TRACE_WARN(eid, "devName: {}, minRequiredCapacity:{}, spareCapacity:{}", devName, baseCapa, spare->GetSize());
+        POS_TRACE_WARN(eid, "devName: {}, minRequiredCapacity:{}, spareCapacity:{}",
+            devName, baseCapa, spare->GetSize());
         return eid;
     }
-
     return devs_->AddSsd(new ArrayDevice(spare, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::SPARE));
-}
-
-void
-ArrayDeviceManager::Clear(void)
-{
-    devs_->Clear();
 }
 
 int
@@ -232,7 +109,7 @@ ArrayDeviceManager::RemoveSpare(string devName)
         POS_TRACE_WARN(eventId, "devName:{}", devName);
         return eventId;
     }
-    return devs_->RemoveSpare(dev);
+    return devs_->RemoveSsd(dev);
 }
 
 int
@@ -241,112 +118,10 @@ ArrayDeviceManager::ReplaceWithSpare(ArrayDevice* target, ArrayDevice*& swapOut)
     return devs_->SpareToData(target, swapOut);
 }
 
-vector<ArrayDevice*>
+vector<ArrayDevice*>&
 ArrayDeviceManager::GetDevs(void)
 {
     return devs_->GetDevs();
-}
-
-vector<ArrayDevice*>
-ArrayDeviceManager::GetFaulty(void)
-{
-    auto faultDevs = ArrayDeviceApi::ExtractDevicesByState(ArrayDeviceState::FAULT,
-        ArrayDeviceApi::ExtractDevicesByType(ArrayDeviceType::DATA, devs_->GetDevs()));
-    return faultDevs;
-}
-
-vector<ArrayDevice*>
-ArrayDeviceManager::GetRebuilding(void)
-{
-    return ArrayDeviceApi::ExtractDevicesByState(ArrayDeviceState::REBUILD,
-        ArrayDeviceApi::ExtractDevicesByType(ArrayDeviceType::DATA, devs_->GetDevs()));
-}
-
-vector<ArrayDevice*>
-ArrayDeviceManager::GetDataDevices(void)
-{
-    return ArrayDeviceApi::ExtractDevicesByType(ArrayDeviceType::DATA, devs_->GetDevs());
-}
-
-vector<ArrayDevice*>
-ArrayDeviceManager::GetSpareDevices(void)
-{
-    return ArrayDeviceApi::ExtractDevicesByType(ArrayDeviceType::SPARE, devs_->GetDevs());
-}
-
-vector<ArrayDevice*>
-ArrayDeviceManager::GetAvailableSpareDevices(void)
-{
-    return ArrayDeviceApi::ExtractDevicesByState(ArrayDeviceState::NORMAL,
-        ArrayDeviceApi::ExtractDevicesByType(ArrayDeviceType::SPARE, devs_->GetDevs()));
-}
-
-int
-ArrayDeviceManager::_CheckConstraints(ArrayDeviceList* devList)
-{
-    auto devs = devList->GetDevs();
-    auto dataDevs = ArrayDeviceApi::ExtractDevicesByType(ArrayDeviceType::DATA, devs);
-    auto spareDevs = ArrayDeviceApi::ExtractDevicesByType(ArrayDeviceType::SPARE, devs);
-    auto nvms = ArrayDeviceApi::ExtractDevicesByType(ArrayDeviceType::NVM, devs);
-    int ret = _CheckActiveSsdsCount(dataDevs);
-    if (0 != ret)
-    {
-        return ret;
-    }
-
-    uint64_t baseCapa = _GetBaseCapacity(dataDevs);
-    if (baseCapa < ArrayConfig::MINIMUM_SSD_SIZE_BYTE)
-    {
-        int eventId = EID(CREATE_ARRAY_SSD_CAPACITY_IS_LT_MIN);
-        POS_TRACE_ERROR(eventId, "size(byte): {}", baseCapa);
-        return eventId;
-    }
-
-    if (spareDevs.size() > 0)
-    {
-        uint64_t minSpareCapa = _GetBaseCapacity(spareDevs);
-        if (minSpareCapa < baseCapa)
-        {
-            int eventId = EID(CREATE_ARRAY_SPARE_CAPACITY_IS_LT_DATA);
-            POS_TRACE_ERROR(eventId, "minData:{}, minSpare:{}", baseCapa, minSpareCapa);
-            return eventId;
-        }
-    }
-    return ret;
-}
-
-int
-ArrayDeviceManager::_CheckActiveSsdsCount(const vector<ArrayDevice*>& devs)
-{
-    const int errorId = EID(CREATE_ARRAY_NO_AVAILABLE_DEVICE);
-    if (devs.size() > 0)
-    {
-        auto&& devList = Enumerable::Where(devs,
-            [](auto d) { return d->GetState() == ArrayDeviceState::NORMAL; });
-        if (devList.size() > 0)
-        {
-            return 0;
-        }
-    }
-    POS_TRACE_WARN(errorId, "num of active SSDs: {}", devs.size());
-    return errorId;
-}
-
-uint64_t
-ArrayDeviceManager::_GetBaseCapacity(const vector<ArrayDevice*>& devs)
-{
-    auto&& devList = Enumerable::Where(devs,
-        [](auto d) { return d->GetState() != ArrayDeviceState::FAULT; });
-
-    ArrayDevice* base = Enumerable::Minimum(devList,
-        [](auto d) { return d->GetUblock()->GetSize(); });
-
-    if (base == nullptr)
-    {
-        POS_TRACE_WARN(EID(CREATE_ARRAY_DEBUG_MSG), "Failed to acquire base capaicty, device cnt: {}", devList.size());
-        return 0;
-    }
-    return base->GetUblock()->GetSize();
 }
 
 void

--- a/src/array/device/array_device_manager.h
+++ b/src/array/device/array_device_manager.h
@@ -30,57 +30,39 @@
  *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef ARRAY_DEVICE_MANAGER_H_
-#define ARRAY_DEVICE_MANAGER_H_
+#pragma once
 
-#include <string>
-#include <tuple>
 #include <vector>
+#include <string>
 
 #include "array_device.h"
 #include "array_device_list.h"
-#include "src/array/meta/device_meta.h"
-#include "src/array_models/dto/device_set.h"
-#include "src/device/device_identifier.h"
+
 using namespace std;
 
 namespace pos
 {
 class DeviceManager;
-class DeviceMeta;
 
 class ArrayDeviceManager
 {
 public:
     ArrayDeviceManager(DeviceManager* sysDevMgr, string arrayName);
     virtual ~ArrayDeviceManager(void);
-    virtual int ImportByName(DeviceSet<string> nameSet);
-    virtual int Import(DeviceSet<DeviceMeta> metaSet);
     virtual void Clear(void);
+    virtual int Import(vector<ArrayDevice*> devs);
     virtual int AddSpare(string devName);
     virtual int RemoveSpare(string devName);
     virtual int ReplaceWithSpare(ArrayDevice* target, ArrayDevice*& swapOut);
-
-    virtual vector<ArrayDevice*> GetDevs(void);
-    virtual vector<ArrayDevice*> GetFaulty(void);
-    virtual vector<ArrayDevice*> GetRebuilding(void);
-    virtual vector<ArrayDevice*> GetDataDevices(void);
-    virtual vector<ArrayDevice*> GetSpareDevices(void);
-    virtual vector<ArrayDevice*> GetAvailableSpareDevices(void);
+    virtual vector<ArrayDevice*>& GetDevs(void);
 
     // This is UT helper method and doesn't need to be inherited. This isn't for production use.
     void SetArrayDeviceList(ArrayDeviceList* arrayDeviceList);
 
 private:
-    int _CheckConstraints(ArrayDeviceList* devList);
-    int _CheckActiveSsdsCount(const vector<ArrayDevice*>& devs);
-    uint64_t _GetBaseCapacity(const vector<ArrayDevice*>& devs);
-
     ArrayDeviceList* devs_ = nullptr;
     DeviceManager* sysDevMgr_;
-    string arrayName_;
+    string arrayName_ = "";
 };
 
 } // namespace pos
-
-#endif // ARRAY_DEVICE_MANAGER_H_

--- a/src/array/partition/nvm_partition.cpp
+++ b/src/array/partition/nvm_partition.cpp
@@ -152,14 +152,14 @@ int
 NvmPartition::_SetPhysicalAddress(uint64_t startLba, uint32_t blksPerChunk)
 {
     POS_TRACE_DEBUG(EID(CREATE_ARRAY_DEBUG_MSG), "NvmPartition::_SetPhysicalAddress, startLba:{}, blksPerChunk:{}, devsize:{}, devName:{}",
-        startLba, blksPerChunk, devs.size(), devs.front()->GetUblock()->GetName());
+        startLba, blksPerChunk, devs.size(), devs.front()->GetName());
     physicalSize.startLba = startLba;
     physicalSize.blksPerChunk = blksPerChunk;
     physicalSize.chunksPerStripe = ArrayConfig::NVM_DEVICE_COUNT;
     physicalSize.totalSegments = ArrayConfig::NVM_SEGMENT_SIZE;
     if (type == PartitionType::WRITE_BUFFER)
     {
-        physicalSize.stripesPerSegment = (devs.front()->GetUblock()->GetSize() / ArrayConfig::BLOCK_SIZE_BYTE -
+        physicalSize.stripesPerSegment = (devs.front()->GetSize() / ArrayConfig::BLOCK_SIZE_BYTE -
             DIV_ROUND_UP(physicalSize.startLba, (uint64_t)ArrayConfig::SECTORS_PER_BLOCK)) / blksPerChunk;
         POS_TRACE_DEBUG(EID(CREATE_ARRAY_DEBUG_MSG), "NvmPartition::_SetPhysicalAddress, WRITE_BUFFER, startLba:{}, blksPerChunk:{}, strPerSeg:{}",
             startLba, blksPerChunk, physicalSize.stripesPerSegment);

--- a/src/array/partition/partition_factory.cpp
+++ b/src/array/partition/partition_factory.cpp
@@ -116,6 +116,19 @@ PartitionFactory::CreateNvmPartitions(ArrayDevice* nvm, vector<Partition*>& part
     {
         POS_TRACE_INFO(EID(CREATE_ARRAY_DEBUG_MSG), "NVM partitions are created");
     }
+    else
+    {
+        POS_TRACE_WARN(ret, "Failed to invoke a chain of partition builders. Cleaning up the partition objects");
+        for (Partition* part : partitions)
+        {
+            if (part != nullptr)
+            {
+                delete part;
+            }
+        }
+        partitions.clear();
+    }
+
     for (auto builder : builders)
     {
         delete builder;

--- a/src/array/partition/ssd_partition_builder.cpp
+++ b/src/array/partition/ssd_partition_builder.cpp
@@ -119,7 +119,7 @@ SsdPartitionBuilder::_GetMinCapacity(const vector<ArrayDevice*>& devs)
         [](auto d) { return d->GetState() != ArrayDeviceState::FAULT; });
 
     ArrayDevice* min = Enumerable::Minimum(devList,
-        [](auto d) { return d->GetUblock()->GetSize(); });
+        [](auto d) { return d->GetSize(); });
     if (min != nullptr)
     {
         return min->GetSize();
@@ -135,7 +135,7 @@ SsdPartitionBuilder::_GetMaxCapacity(const vector<ArrayDevice*>& devs)
         [](auto d) { return d->GetState() != ArrayDeviceState::FAULT; });
 
     ArrayDevice* max = Enumerable::Maximum(devList,
-        [](auto d) { return d->GetUblock()->GetSize(); });
+        [](auto d) { return d->GetSize(); });
     if (max != nullptr)
     {
         return max->GetSize();

--- a/test/integration-tests/array/array_device_manager_test.cpp
+++ b/test/integration-tests/array/array_device_manager_test.cpp
@@ -1,5 +1,4 @@
 #include "src/array/device/array_device_manager.h"
-#include "src/array/device/array_device_api.h"
 
 #include <gtest/gtest.h>
 
@@ -13,6 +12,7 @@ using ::testing::_;
 using ::testing::AtLeast;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::Invoke;
 
 namespace pos
 {
@@ -54,470 +54,6 @@ SuppressUninterestingCalls(const std::list<shared_ptr<MockUBlockDevice>>& uBlock
         EXPECT_CALL(*uBlockDev, SetClass).WillRepeatedly([](DeviceClass cls){});
         EXPECT_CALL(*uBlockDev, GetSN).WillRepeatedly(Return("mock-SN"));
     }
-}
-
-TEST(ArrayDeviceManager, Import_testIfDeviceSetsAreSuccessfullyImported)
-{
-    // Given
-    MockDeviceManager mockSysDevMgr(nullptr);
-
-    ArrayDeviceManager arrDevMgr(&mockSysDevMgr, "mockArrayName");
-    DeviceSet<string> nameSet;
-    string nvm1 = "mock-nvm1";
-    string data1 = "mock-data1", data2 = "mock-data2", data3 = "mock-data3";
-    string spare1 = "mock-spare1";
-
-    nameSet.nvm.push_back(nvm1);
-    nameSet.data.push_back(data1);
-    nameSet.data.push_back(data2);
-    nameSet.data.push_back(data3);
-    nameSet.spares.push_back(spare1);
-    DevName nvm1Id(nvm1), data1Id(data1), data2Id(data2), data3Id(data3), spare1Id(spare1);
-
-    auto nvm1UblockDevPtr = MockUblockDevice(nvm1.c_str(), DeviceType::NVRAM, 805830656); // minNvmSize when logicalChunkCount is 2
-    auto data1UblockDevPtr = MockUblockDevice(data1.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data2UblockDevPtr = MockUblockDevice(data2.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data3UblockDevPtr = MockUblockDevice(data3.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto spare1UblockDevPtr = MockUblockDevice(spare1.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-
-    EXPECT_CALL(mockSysDevMgr, GetDev) // currently, we don't have a good gtest matcher for DevName, hence I'm just simply chaining the expected result
-        .WillOnce(Return(nvm1UblockDevPtr))
-        .WillOnce(Return(data1UblockDevPtr))
-        .WillOnce(Return(data2UblockDevPtr))
-        .WillOnce(Return(data3UblockDevPtr))
-        .WillOnce(Return(spare1UblockDevPtr));
-    SuppressUninterestingCalls({nvm1UblockDevPtr, data1UblockDevPtr, data2UblockDevPtr, data3UblockDevPtr, spare1UblockDevPtr});
-
-    // When
-    int actual = arrDevMgr.ImportByName(nameSet);
-
-    // Then
-    ASSERT_EQ(0, actual);
-    arrDevMgr.Clear(); // to avoid the leakage of mocks
-}
-
-TEST(ArrayDeviceManager, ImportByName_testIfNVMDeviceHasNoUblock)
-{
-    // Given
-    MockDeviceManager mockSysDevMgr(nullptr);
-    string mockArrayname = "mockArray";
-
-    ArrayDeviceManager arrDevMgr(&mockSysDevMgr, mockArrayname);
-    DeviceSet<string> nameSet;
-    string nvm1 = "mock-nvm1";
-    string data1 = "mock-data1", data2 = "mock-data2", data3 = "mock-data3";
-    string spare1 = "mock-spare1";
-
-    nameSet.nvm.push_back(nvm1);
-    nameSet.data.push_back(data1);
-    nameSet.data.push_back(data2);
-    nameSet.data.push_back(data3);
-    nameSet.spares.push_back(spare1);
-    DevName nvm1Id(nvm1), data1Id(data1), data2Id(data2), data3Id(data3), spare1Id(spare1);
-
-    auto nvm1UblockDevPtr = nullptr;
-
-    EXPECT_CALL(mockSysDevMgr, GetDev) // currently, we don't have a good gtest matcher for DevName, hence I'm just simply chaining the expected result
-        .WillOnce(Return(nvm1UblockDevPtr));
-
-    // When
-    int actual = arrDevMgr.ImportByName(nameSet);
-
-    // Then
-    int expected = EID(CREATE_ARRAY_NVM_NAME_NOT_FOUND);
-    ASSERT_EQ(expected, actual);
-    arrDevMgr.Clear(); // to avoid the leakage of mocks
-}
-
-TEST(ArrayDeviceManager, ImportByName_testIfNVMDeviceIsActuallySSDDevice)
-{
-    // Given
-    MockDeviceManager mockSysDevMgr(nullptr);
-    string mockArrayName = "mockArray";
-    ArrayDeviceManager arrDevMgr(&mockSysDevMgr, mockArrayName);
-    DeviceSet<string> nameSet;
-    string nvm1 = "mock-nvm1";
-    string data1 = "mock-data1", data2 = "mock-data2", data3 = "mock-data3";
-    string spare1 = "mock-spare1";
-
-    nameSet.nvm.push_back(nvm1);
-    nameSet.data.push_back(data1);
-    nameSet.data.push_back(data2);
-    nameSet.data.push_back(data3);
-    nameSet.spares.push_back(spare1);
-    DevName nvm1Id(nvm1), data1Id(data1), data2Id(data2), data3Id(data3), spare1Id(spare1);
-
-    auto nvm1UblockDevPtr = MockUblockDevice(nvm1.c_str(), DeviceType::SSD, 805830656); // minNvmSize when logicalChunkCount is 2
-
-    EXPECT_CALL(mockSysDevMgr, GetDev) // currently, we don't have a good gtest matcher for DevName, hence I'm just simply chaining the expected result
-        .WillOnce(Return(nvm1UblockDevPtr));
-
-    // When
-    int actual = arrDevMgr.ImportByName(nameSet);
-
-    // Then
-    int expected = EID(CREATE_ARRAY_NVM_NAME_NOT_FOUND);
-    ASSERT_EQ(expected, actual);
-    arrDevMgr.Clear(); // to avoid the leakage of mocks
-}
-
-TEST(ArrayDeviceManager, ImportByName_testIfDataDeviceHasNoUblock)
-{
-    // Given
-    MockDeviceManager mockSysDevMgr(nullptr);
-    string mockArrayName = "mockArray";
-    ArrayDeviceManager arrDevMgr(&mockSysDevMgr, mockArrayName);
-    DeviceSet<string> nameSet;
-    string nvm1 = "mock-nvm1";
-    string data1 = "mock-data1", data2 = "mock-data2", data3 = "mock-data3";
-    string spare1 = "mock-spare1";
-
-    nameSet.nvm.push_back(nvm1);
-    nameSet.data.push_back(data1);
-    nameSet.data.push_back(data2);
-    nameSet.data.push_back(data3);
-    nameSet.spares.push_back(spare1);
-    DevName nvm1Id(nvm1), data1Id(data1), data2Id(data2), data3Id(data3), spare1Id(spare1);
-
-    auto nvm1UblockDevPtr = MockUblockDevice(nvm1.c_str(), DeviceType::NVRAM, 805830656); // minNvmSize when logicalChunkCount is 2
-    auto data1UblockDevPtr = nullptr;
-
-    EXPECT_CALL(mockSysDevMgr, GetDev) // currently, we don't have a good gtest matcher for DevName, hence I'm just simply chaining the expected result
-        .WillOnce(Return(nvm1UblockDevPtr))
-        .WillOnce(Return(data1UblockDevPtr));
-    SuppressUninterestingCalls({nvm1UblockDevPtr, data1UblockDevPtr});
-
-    // When
-    int actual = arrDevMgr.ImportByName(nameSet);
-
-    // Then
-    int expected = EID(CREATE_ARRAY_SSD_NAME_NOT_FOUND);
-    ASSERT_EQ(expected, actual);
-    arrDevMgr.Clear(); // to avoid the leakage of mocks
-}
-
-TEST(ArrayDeviceManager, ImportByName_testIfDataDeviceIsActuallyNVMDevice)
-{
-    // Given
-    MockDeviceManager mockSysDevMgr(nullptr);
-    string mockArrayName = "mockArray";
-    ArrayDeviceManager arrDevMgr(&mockSysDevMgr, mockArrayName);
-    DeviceSet<string> nameSet;
-    string nvm1 = "mock-nvm1";
-    string data1 = "mock-data1", data2 = "mock-data2", data3 = "mock-data3";
-    string spare1 = "mock-spare1";
-
-    nameSet.nvm.push_back(nvm1);
-    nameSet.data.push_back(data1);
-    nameSet.data.push_back(data2);
-    nameSet.data.push_back(data3);
-    nameSet.spares.push_back(spare1);
-    DevName nvm1Id(nvm1), data1Id(data1), data2Id(data2), data3Id(data3), spare1Id(spare1);
-
-    auto nvm1UblockDevPtr = MockUblockDevice(nvm1.c_str(), DeviceType::NVRAM, 805830656); // minNvmSize when logicalChunkCount is 2
-    auto data1UblockDevPtr = MockUblockDevice(data1.c_str(), DeviceType::NVRAM, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-
-    EXPECT_CALL(mockSysDevMgr, GetDev) // currently, we don't have a good gtest matcher for DevName, hence I'm just simply chaining the expected result
-        .WillOnce(Return(nvm1UblockDevPtr))
-        .WillOnce(Return(data1UblockDevPtr));
-    SuppressUninterestingCalls({nvm1UblockDevPtr, data1UblockDevPtr});
-
-    // When
-    int actual = arrDevMgr.ImportByName(nameSet);
-
-    // Then
-    int expected = EID(CREATE_ARRAY_SSD_NAME_NOT_FOUND);
-    ASSERT_EQ(expected, actual);
-    arrDevMgr.Clear(); // to avoid the leakage of mocks
-}
-
-TEST(ArrayDeviceManager, ImportByName_testIfSpareDeviceHasNoUblock)
-{
-    // Given
-    MockDeviceManager mockSysDevMgr(nullptr);
-    string mockArrayName = "mockArray";
-    ArrayDeviceManager arrDevMgr(&mockSysDevMgr, mockArrayName);
-    DeviceSet<string> nameSet;
-    string nvm1 = "mock-nvm1";
-    string data1 = "mock-data1", data2 = "mock-data2", data3 = "mock-data3";
-    string spare1 = "mock-spare1";
-
-    nameSet.nvm.push_back(nvm1);
-    nameSet.data.push_back(data1);
-    nameSet.data.push_back(data2);
-    nameSet.data.push_back(data3);
-    nameSet.spares.push_back(spare1);
-    DevName nvm1Id(nvm1), data1Id(data1), data2Id(data2), data3Id(data3), spare1Id(spare1);
-
-    auto nvm1UblockDevPtr = MockUblockDevice(nvm1.c_str(), DeviceType::NVRAM, 805830656); // minNvmSize when logicalChunkCount is 2
-    auto data1UblockDevPtr = MockUblockDevice(data1.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data2UblockDevPtr = MockUblockDevice(data2.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data3UblockDevPtr = MockUblockDevice(data3.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto spare1UblockDevPtr = nullptr;
-
-    EXPECT_CALL(mockSysDevMgr, GetDev) // currently, we don't have a good gtest matcher for DevName, hence I'm just simply chaining the expected result
-        .WillOnce(Return(nvm1UblockDevPtr))
-        .WillOnce(Return(data1UblockDevPtr))
-        .WillOnce(Return(data2UblockDevPtr))
-        .WillOnce(Return(data3UblockDevPtr))
-        .WillOnce(Return(spare1UblockDevPtr));
-    SuppressUninterestingCalls({nvm1UblockDevPtr, data1UblockDevPtr, data2UblockDevPtr, data3UblockDevPtr, spare1UblockDevPtr});
-
-    // When
-    int actual = arrDevMgr.ImportByName(nameSet);
-
-    // Then
-    int expected = EID(CREATE_ARRAY_SSD_NAME_NOT_FOUND);
-    ASSERT_EQ(expected, actual);
-    arrDevMgr.Clear(); // to avoid the leakage of mocks
-}
-
-TEST(ArrayDeviceManager, ImportByName_testIfSpareDeviceIsActuallyNVMDevice)
-{
-    // Given
-    MockDeviceManager mockSysDevMgr(nullptr);
-    string mockArrayName = "mockArray";
-    ArrayDeviceManager arrDevMgr(&mockSysDevMgr, mockArrayName);
-    DeviceSet<string> nameSet;
-    string nvm1 = "mock-nvm1";
-    string data1 = "mock-data1", data2 = "mock-data2", data3 = "mock-data3";
-    string spare1 = "mock-spare1";
-
-    nameSet.nvm.push_back(nvm1);
-    nameSet.data.push_back(data1);
-    nameSet.data.push_back(data2);
-    nameSet.data.push_back(data3);
-    nameSet.spares.push_back(spare1);
-    DevName nvm1Id(nvm1), data1Id(data1), data2Id(data2), data3Id(data3), spare1Id(spare1);
-
-    auto nvm1UblockDevPtr = MockUblockDevice(nvm1.c_str(), DeviceType::NVRAM, 805830656); // minNvmSize when logicalChunkCount is 2
-    auto data1UblockDevPtr = MockUblockDevice(data1.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data2UblockDevPtr = MockUblockDevice(data2.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data3UblockDevPtr = MockUblockDevice(data3.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto spare1UblockDevPtr = MockUblockDevice(spare1.c_str(), DeviceType::NVRAM, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-
-    EXPECT_CALL(mockSysDevMgr, GetDev) // currently, we don't have a good gtest matcher for DevName, hence I'm just simply chaining the expected result
-        .WillOnce(Return(nvm1UblockDevPtr))
-        .WillOnce(Return(data1UblockDevPtr))
-        .WillOnce(Return(data2UblockDevPtr))
-        .WillOnce(Return(data3UblockDevPtr))
-        .WillOnce(Return(spare1UblockDevPtr));
-    SuppressUninterestingCalls({nvm1UblockDevPtr, data1UblockDevPtr, data2UblockDevPtr, data3UblockDevPtr, spare1UblockDevPtr});
-
-    // When
-    int actual = arrDevMgr.ImportByName(nameSet);
-
-    // Then
-    int expected = EID(CREATE_ARRAY_SSD_NAME_NOT_FOUND);
-    ASSERT_EQ(expected, actual);
-    arrDevMgr.Clear(); // to avoid the leakage of mocks
-}
-
-TEST(ArrayDeviceManager, Import_testIfDeviceSetsAreSuccessfullyImportedWithMetaSetInformation)
-{
-    // Used when loading array
-    // Given
-    MockDeviceManager mockSysDevMgr(nullptr);
-
-    ArrayDeviceManager arrDevMgr(&mockSysDevMgr, "mockArrayName");
-    DeviceSet<string> nameSet;
-    string nvm1 = "mock-nvm1";
-    string data1 = "mock-data1", data2 = "mock-data2", data3 = "mock-data3";
-    string spare1 = "mock-spare1";
-
-    nameSet.nvm.push_back(nvm1);
-    nameSet.data.push_back(data1);
-    nameSet.data.push_back(data2);
-    nameSet.data.push_back(data3);
-    nameSet.spares.push_back(spare1);
-    DevName nvm1Id(nvm1), data1Id(data1), data2Id(data2), data3Id(data3), spare1Id(spare1);
-
-    auto nvm1UblockDevPtr = MockUblockDevice(nvm1.c_str(), DeviceType::NVRAM, 805830656); // minNvmSize when logicalChunkCount is 2
-    auto data1UblockDevPtr = MockUblockDevice(data1.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data2UblockDevPtr = MockUblockDevice(data2.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data3UblockDevPtr = MockUblockDevice(data3.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto spare1UblockDevPtr = MockUblockDevice(spare1.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-
-    EXPECT_CALL(mockSysDevMgr, GetDev) // currently, we don't have a good gtest matcher for DevName, hence I'm just simply chaining the expected result
-        .WillOnce(Return(nvm1UblockDevPtr))
-        .WillOnce(Return(data1UblockDevPtr))
-        .WillOnce(Return(data2UblockDevPtr))
-        .WillOnce(Return(data3UblockDevPtr))
-        .WillOnce(Return(spare1UblockDevPtr))
-        .WillOnce(Return(nvm1UblockDevPtr))
-        .WillOnce(Return(data1UblockDevPtr))
-        .WillOnce(Return(data2UblockDevPtr))
-        .WillOnce(Return(data3UblockDevPtr))
-        .WillOnce(Return(spare1UblockDevPtr));
-    SuppressUninterestingCalls({nvm1UblockDevPtr, data1UblockDevPtr, data2UblockDevPtr, data3UblockDevPtr, spare1UblockDevPtr});
-
-    arrDevMgr.ImportByName(nameSet);
-    ArrayMeta arrayMeta;
-    arrayMeta.devs = ArrayDeviceApi::ExportDeviceMeta(arrDevMgr.GetDevs());
-    arrDevMgr.Clear();
-
-    // When
-    int actual = arrDevMgr.Import(arrayMeta.devs);
-
-    // Then
-    ASSERT_EQ(0, actual);
-    arrDevMgr.Clear(); // to avoid the leakage of mocks
-}
-
-TEST(ArrayDeviceManager, Import_testIfNVMDeviceHasNoUblockWithMetaSetInformation)
-{
-    // Used when loading array
-    // Given
-    MockDeviceManager mockSysDevMgr(nullptr);
-    string mockArrayName = "mockArray";
-    ArrayDeviceManager arrDevMgr(&mockSysDevMgr, mockArrayName);
-    DeviceSet<string> nameSet;
-    string nvm1 = "mock-nvm1";
-    string data1 = "mock-data1", data2 = "mock-data2", data3 = "mock-data3";
-    string spare1 = "mock-spare1";
-
-    nameSet.nvm.push_back(nvm1);
-    nameSet.data.push_back(data1);
-    nameSet.data.push_back(data2);
-    nameSet.data.push_back(data3);
-    nameSet.spares.push_back(spare1);
-    DevName nvm1Id(nvm1), data1Id(data1), data2Id(data2), data3Id(data3), spare1Id(spare1);
-
-    auto nvm1UblockDevPtr = MockUblockDevice(nvm1.c_str(), DeviceType::NVRAM, 805830656); // minNvmSize when logicalChunkCount is 2
-    auto data1UblockDevPtr = MockUblockDevice(data1.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data2UblockDevPtr = MockUblockDevice(data2.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data3UblockDevPtr = MockUblockDevice(data3.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto spare1UblockDevPtr = MockUblockDevice(spare1.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-
-    EXPECT_CALL(mockSysDevMgr, GetDev) // currently, we don't have a good gtest matcher for DevName, hence I'm just simply chaining the expected result
-        .WillOnce(Return(nvm1UblockDevPtr))
-        .WillOnce(Return(data1UblockDevPtr))
-        .WillOnce(Return(data2UblockDevPtr))
-        .WillOnce(Return(data3UblockDevPtr))
-        .WillOnce(Return(spare1UblockDevPtr))
-        .WillOnce(Return(nullptr));
-    SuppressUninterestingCalls({nvm1UblockDevPtr, data1UblockDevPtr, data2UblockDevPtr, data3UblockDevPtr, spare1UblockDevPtr});
-
-    arrDevMgr.ImportByName(nameSet);
-    ArrayMeta arrayMeta;
-    arrayMeta.devs = ArrayDeviceApi::ExportDeviceMeta(arrDevMgr.GetDevs());
-    arrDevMgr.Clear();
-
-    // When
-    uint32_t missingCnt = 0;
-    uint32_t brokenCnt = 0;
-    int actual = arrDevMgr.Import(arrayMeta.devs);
-
-    // Then
-    int expected = EID(ARRAY_NVM_NOT_FOUND);
-    ASSERT_EQ(expected, actual);
-    arrDevMgr.Clear(); // to avoid the leakage of mocks
-}
-
-TEST(ArrayDeviceManager, Import_testIfDataDeviceIsFaultState)
-{
-    // Used when loading array
-    // Given
-    MockDeviceManager mockSysDevMgr(nullptr);
-    string mockArrayName = "mockArray";
-    ArrayDeviceManager arrDevMgr(&mockSysDevMgr, mockArrayName);
-    DeviceSet<string> nameSet;
-    string nvm1 = "mock-nvm1";
-    string data1 = "mock-data1", data2 = "mock-data2", data3 = "mock-data3";
-    string spare1 = "mock-spare1";
-
-    nameSet.nvm.push_back(nvm1);
-    nameSet.data.push_back(data1);
-    nameSet.data.push_back(data2);
-    nameSet.data.push_back(data3);
-    nameSet.spares.push_back(spare1);
-    DevName nvm1Id(nvm1), data1Id(data1), data2Id(data2), data3Id(data3), spare1Id(spare1);
-
-    auto nvm1UblockDevPtr = MockUblockDevice(nvm1.c_str(), DeviceType::NVRAM, 805830656); // minNvmSize when logicalChunkCount is 2
-    auto data1UblockDevPtr = MockUblockDevice(data1.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data2UblockDevPtr = MockUblockDevice(data2.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data3UblockDevPtr = MockUblockDevice(data3.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto spare1UblockDevPtr = MockUblockDevice(spare1.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-
-    EXPECT_CALL(mockSysDevMgr, GetDev) // currently, we don't have a good gtest matcher for DevName, hence I'm just simply chaining the expected result
-        .WillOnce(Return(nvm1UblockDevPtr))
-        .WillOnce(Return(data1UblockDevPtr))
-        .WillOnce(Return(data2UblockDevPtr))
-        .WillOnce(Return(data3UblockDevPtr))
-        .WillOnce(Return(spare1UblockDevPtr))
-        .WillOnce(Return(nvm1UblockDevPtr))
-        .WillOnce(Return(data1UblockDevPtr))
-        .WillOnce(Return(data2UblockDevPtr))
-        .WillOnce(Return(data3UblockDevPtr))
-        .WillOnce(Return(spare1UblockDevPtr));
-    SuppressUninterestingCalls({nvm1UblockDevPtr, data1UblockDevPtr, data2UblockDevPtr, data3UblockDevPtr, spare1UblockDevPtr});
-
-    arrDevMgr.ImportByName(nameSet);
-    ArrayMeta arrayMeta;
-    arrayMeta.devs = ArrayDeviceApi::ExportDeviceMeta(arrDevMgr.GetDevs());
-    for (DeviceMeta meta : arrayMeta.devs.data)
-    {
-        meta.state = ArrayDeviceState::FAULT;
-    }
-    arrDevMgr.Clear();
-
-    // When
-    int actual = arrDevMgr.Import(arrayMeta.devs);
-
-    // Then
-    ASSERT_EQ(0, actual);
-    arrDevMgr.Clear(); // to avoid the leakage of mocks
-}
-
-TEST(ArrayDeviceManager, Import_testIfDataDeviceHasNoUblockWithMetaSetInformation)
-{
-    // Used when loading array
-    // Given
-    MockDeviceManager mockSysDevMgr(nullptr);
-    string mockArrayName = "mockArray";
-    ArrayDeviceManager arrDevMgr(&mockSysDevMgr, mockArrayName);
-    DeviceSet<string> nameSet;
-    string nvm1 = "mock-nvm1";
-    string data1 = "mock-data1", data2 = "mock-data2", data3 = "mock-data3";
-    string spare1 = "mock-spare1";
-
-    nameSet.nvm.push_back(nvm1);
-    nameSet.data.push_back(data1);
-    nameSet.data.push_back(data2);
-    nameSet.data.push_back(data3);
-    nameSet.spares.push_back(spare1);
-    DevName nvm1Id(nvm1), data1Id(data1), data2Id(data2), data3Id(data3), spare1Id(spare1);
-
-    auto nvm1UblockDevPtr = MockUblockDevice(nvm1.c_str(), DeviceType::NVRAM, 805830656); // minNvmSize when logicalChunkCount is 2
-    auto data1UblockDevPtr = MockUblockDevice(data1.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data2UblockDevPtr = MockUblockDevice(data2.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto data3UblockDevPtr = MockUblockDevice(data3.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-    auto spare1UblockDevPtr = MockUblockDevice(spare1.c_str(), DeviceType::SSD, ArrayConfig::MINIMUM_SSD_SIZE_BYTE);
-
-    EXPECT_CALL(mockSysDevMgr, GetDev) // currently, we don't have a good gtest matcher for DevName, hence I'm just simply chaining the expected result
-        .WillOnce(Return(nvm1UblockDevPtr))
-        .WillOnce(Return(data1UblockDevPtr))
-        .WillOnce(Return(data2UblockDevPtr))
-        .WillOnce(Return(data3UblockDevPtr))
-        .WillOnce(Return(spare1UblockDevPtr))
-        .WillOnce(Return(nvm1UblockDevPtr))
-        .WillOnce(Return(data1UblockDevPtr))
-        .WillOnce(Return(data2UblockDevPtr))
-        .WillOnce(Return(data3UblockDevPtr))
-        .WillOnce(Return(spare1UblockDevPtr));
-    SuppressUninterestingCalls({nvm1UblockDevPtr, data1UblockDevPtr, data2UblockDevPtr, data3UblockDevPtr, spare1UblockDevPtr});
-
-    arrDevMgr.ImportByName(nameSet);
-    ArrayMeta arrayMeta;
-    arrayMeta.devs = ArrayDeviceApi::ExportDeviceMeta(arrDevMgr.GetDevs());
-    arrDevMgr.Clear();
-
-    // When
-    int actual = arrDevMgr.Import(arrayMeta.devs);
-
-    // Then
-    ASSERT_EQ(0, actual);
-    arrDevMgr.Clear(); // to avoid the leakage of mocks
 }
 
 TEST(ArrayDeviceManager, Clear_testIfNullPtrIsHandled)
@@ -564,7 +100,6 @@ TEST(ArrayDeviceManager, AddSpare_testIfAddingSpareAgainIsHandled)
 
     // Then
     ASSERT_EQ(EID(UNABLE_TO_ADD_SSD_ALREADY_OCCUPIED), actual);
-    arrDevMgr.Clear();
 }
 
 TEST(ArrayDeviceManager, AddSpare_testIfWrongCapacityIsHandled)
@@ -580,8 +115,8 @@ TEST(ArrayDeviceManager, AddSpare_testIfWrongCapacityIsHandled)
     shared_ptr<MockUBlockDevice> ptrMockUblockDev3 = make_shared<MockUBlockDevice>("mock-dataDev3", EXPECTED_DEV_SIZE, nullptr);
     shared_ptr<MockUBlockDevice> ptrMockSpare = make_shared<MockUBlockDevice>(spareName, SMALLER_DEV_SIZE, nullptr);
     MockArrayDevice dataDev1(ptrMockUblockDev1, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::DATA);
-    MockArrayDevice dataDev2(ptrMockUblockDev2, ArrayDeviceState::NORMAL, 1, ArrayDeviceType::DATA);
-    MockArrayDevice dataDev3(ptrMockUblockDev3, ArrayDeviceState::NORMAL, 2, ArrayDeviceType::DATA);
+    MockArrayDevice dataDev2(ptrMockUblockDev2, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::DATA);
+    MockArrayDevice dataDev3(ptrMockUblockDev3, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::DATA);
     vector<ArrayDevice*> deviceSet;
     deviceSet.push_back(&dataDev1);
     deviceSet.push_back(&dataDev2);
@@ -589,14 +124,15 @@ TEST(ArrayDeviceManager, AddSpare_testIfWrongCapacityIsHandled)
 
     MockArrayDeviceList* mockArrayDeviceList = new MockArrayDeviceList;
     arrDevMgr.SetArrayDeviceList(mockArrayDeviceList);
+    arrDevMgr.Import(deviceSet);
 
-    EXPECT_CALL(*mockArrayDeviceList, GetDevs).WillOnce(Return(deviceSet));
+    EXPECT_CALL(*mockArrayDeviceList, GetDevs).WillOnce(ReturnRef(deviceSet));
     EXPECT_CALL(mockSysDevMgr, GetDev).WillRepeatedly(Return(ptrMockSpare));
     EXPECT_CALL(*ptrMockSpare, GetClass).WillOnce(Return(DeviceClass::SYSTEM));
     EXPECT_CALL(*ptrMockSpare, GetSize).WillRepeatedly(Return(SMALLER_DEV_SIZE)); // intentionally passing in smaller capacity
-    EXPECT_CALL(*ptrMockUblockDev1, GetSize).WillRepeatedly(Return(EXPECTED_DEV_SIZE));
-    EXPECT_CALL(*ptrMockUblockDev2, GetSize).WillRepeatedly(Return(EXPECTED_DEV_SIZE));
-    EXPECT_CALL(*ptrMockUblockDev3, GetSize).WillRepeatedly(Return(EXPECTED_DEV_SIZE));
+    EXPECT_CALL(dataDev1, GetSize).WillRepeatedly(Return(EXPECTED_DEV_SIZE));
+    EXPECT_CALL(dataDev2, GetSize).WillRepeatedly(Return(EXPECTED_DEV_SIZE));
+    EXPECT_CALL(dataDev3, GetSize).WillRepeatedly(Return(EXPECTED_DEV_SIZE));
     EXPECT_CALL(dataDev1, GetUblock).WillRepeatedly(Return(ptrMockUblockDev1));
     EXPECT_CALL(dataDev2, GetUblock).WillRepeatedly(Return(ptrMockUblockDev2));
     EXPECT_CALL(dataDev3, GetUblock).WillRepeatedly(Return(ptrMockUblockDev3));
@@ -612,7 +148,6 @@ TEST(ArrayDeviceManager, AddSpare_testIfWrongCapacityIsHandled)
 
     // Then
     ASSERT_EQ(EID(ADD_SPARE_CAPACITY_IS_TOO_SMALL), actual);
-    deviceSet.clear();
 }
 
 TEST(ArrayDeviceManager, AddSpare_testIfSpareIsAddedToArrayDeviceList)
@@ -622,32 +157,32 @@ TEST(ArrayDeviceManager, AddSpare_testIfSpareIsAddedToArrayDeviceList)
     ArrayDeviceManager arrDevMgr(&mockSysDevMgr, "mockArrayName");
     string devName = "spare1";
     int EXPECTED_DEV_SIZE = 121212;
-    auto data1 = MockUblockDevice("data1");
-    auto spare1 = MockUblockDevice(devName.c_str());
+    shared_ptr<MockUBlockDevice> data1 = make_shared<MockUBlockDevice>("mock-dataDev1", EXPECTED_DEV_SIZE, nullptr);
+    shared_ptr<MockUBlockDevice> spare1 = MockUblockDevice(devName.c_str());
 
-    ArrayDevice data1Dev(data1, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::DATA);
+    MockArrayDevice data1Dev(data1, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::DATA);
     vector<ArrayDevice*> deviceSet;
     deviceSet.push_back(&data1Dev);
     MockArrayDeviceList* mockArrayDeviceList = new MockArrayDeviceList;
     arrDevMgr.SetArrayDeviceList(mockArrayDeviceList);
+    arrDevMgr.Import(deviceSet);
 
+    EXPECT_CALL(*mockArrayDeviceList, GetDevs).WillOnce(ReturnRef(deviceSet));
+    auto deleteAndReturnSuccess = [](auto arg){ delete arg; return 0; };
+    EXPECT_CALL(*mockArrayDeviceList, AddSsd).WillOnce(Invoke(deleteAndReturnSuccess));
     EXPECT_CALL(mockSysDevMgr, GetDev).WillOnce(Return(spare1));
+    EXPECT_CALL(data1Dev, GetType).WillRepeatedly(Return(ArrayDeviceType::DATA));
+    EXPECT_CALL(data1Dev, GetState).WillRepeatedly(Return(ArrayDeviceState::NORMAL));
+    EXPECT_CALL(data1Dev, GetSize).WillRepeatedly(Return(EXPECTED_DEV_SIZE));
+    EXPECT_CALL(*data1.get(), GetSize).WillRepeatedly(Return(EXPECTED_DEV_SIZE));
     EXPECT_CALL(*spare1.get(), GetClass).WillOnce(Return(DeviceClass::SYSTEM));
     EXPECT_CALL(*spare1.get(), GetSize).WillRepeatedly(Return(EXPECTED_DEV_SIZE));
-    EXPECT_CALL(*data1.get(), GetSize).WillRepeatedly(Return(EXPECTED_DEV_SIZE));
-    EXPECT_CALL(*mockArrayDeviceList, GetDevs).WillOnce(Return(deviceSet));
-    EXPECT_CALL(*mockArrayDeviceList, AddSsd(_)).WillOnce([](ArrayDevice* dev)
-    {
-        delete dev; // to avoid leakage
-        return 0;
-    });
 
     // When
     int actual = arrDevMgr.AddSpare(devName);
 
     // Then
     ASSERT_EQ(0, actual);
-    deviceSet.clear();
 }
 
 TEST(ArrayDeviceManager, RemoveSpare_testIfSpareDeviceRemovalFails)
@@ -656,10 +191,11 @@ TEST(ArrayDeviceManager, RemoveSpare_testIfSpareDeviceRemovalFails)
     MockDeviceManager mockSysDevMgr;
     ArrayDeviceManager arrDevMgr(&mockSysDevMgr, "mockArrayName");
     MockArrayDeviceList* mockArrayDeviceList = new MockArrayDeviceList;
+    vector<ArrayDevice*> deviceSet;
     arrDevMgr.SetArrayDeviceList(mockArrayDeviceList);
 
-    EXPECT_CALL(*mockArrayDeviceList, GetDevs).Times(1);
-    EXPECT_CALL(*mockArrayDeviceList, RemoveSpare).Times(0);
+    EXPECT_CALL(*mockArrayDeviceList, GetDevs).WillOnce(ReturnRef(deviceSet));
+    EXPECT_CALL(*mockArrayDeviceList, RemoveSsd).Times(0);
 
     // When
     int actual = arrDevMgr.RemoveSpare("spare-that-doesn't-exist");
@@ -675,48 +211,22 @@ TEST(ArrayDeviceManager, RemoveSpare_testIfSpareDeviceRemovalIsSuccessful)
     ArrayDeviceManager arrDevMgr(&mockSysDevMgr, "mockArrayName");
 
     auto spare1 = MockUblockDevice("spare1");
-    ArrayDevice spare1Dev(spare1, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::SPARE);
+    MockArrayDevice spare1Dev(spare1, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::SPARE);
     vector<ArrayDevice*> deviceSet;
     deviceSet.push_back(&spare1Dev);
     MockArrayDeviceList* mockArrayDeviceList = new MockArrayDeviceList;
     arrDevMgr.SetArrayDeviceList(mockArrayDeviceList);
 
-    EXPECT_CALL(*spare1, GetName).WillRepeatedly(Return("spare1"));
-    EXPECT_CALL(*mockArrayDeviceList, GetDevs).WillOnce(Return(deviceSet));
-    EXPECT_CALL(*mockArrayDeviceList, RemoveSpare).WillOnce(Return(0));
+    EXPECT_CALL(*mockArrayDeviceList, GetDevs).WillOnce(ReturnRef(deviceSet));
+    EXPECT_CALL(*mockArrayDeviceList, RemoveSsd).WillOnce(Return(0));
+    EXPECT_CALL(spare1Dev, GetType).WillOnce(Return(ArrayDeviceType::SPARE));
+    EXPECT_CALL(spare1Dev, GetName).WillOnce(Return("spare1"));
 
     // When
     int actual = arrDevMgr.RemoveSpare("spare1");
 
     // Then
     ASSERT_EQ(0, actual);
-    deviceSet.clear();
-}
-
-TEST(ArrayDeviceManager, RemoveSpare_testWithPassingArrayDevice)
-{
-    // Given
-    MockDeviceManager mockSysDevMgr(nullptr);
-    string mockArrayName = "mockArray";
-    ArrayDeviceManager arrDevMgr(&mockSysDevMgr, mockArrayName);
-
-    auto spare1 = MockUblockDevice("spare1");
-    ArrayDevice spare1Dev(spare1, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::SPARE);
-    vector<ArrayDevice*> deviceSet;
-    deviceSet.push_back(&spare1Dev);
-    MockArrayDeviceList* mockArrayDeviceList = new MockArrayDeviceList;
-    arrDevMgr.SetArrayDeviceList(mockArrayDeviceList);
-
-    EXPECT_CALL(*spare1, GetName).WillRepeatedly(Return("spare1"));
-    EXPECT_CALL(*mockArrayDeviceList, RemoveSpare).WillOnce(Return(0));
-    EXPECT_CALL(*mockArrayDeviceList, GetDevs).WillOnce(Return(deviceSet));
-
-    // When
-    int actual = arrDevMgr.RemoveSpare("spare1");
-
-    // Then
-    ASSERT_EQ(0, actual);
-    deviceSet.clear();
 }
 
 TEST(ArrayDeviceManager, ReplaceWithSpare_testIfArrayDeviceListIsQueriedAgainst)
@@ -737,105 +247,4 @@ TEST(ArrayDeviceManager, ReplaceWithSpare_testIfArrayDeviceListIsQueriedAgainst)
     // Then
     ASSERT_EQ(REPLACE_SUCCESS, actual);
 }
-
-TEST(ArrayDeviceManager, GetFaulty_testIfFaultyArrayDeviceIsReturned)
-{
-    // Given
-    ArrayDeviceManager arrDevMgr(nullptr, "mockArrayName");
-    MockArrayDeviceList* mockArrayDeviceList = new MockArrayDeviceList;
-    arrDevMgr.SetArrayDeviceList(mockArrayDeviceList);
-
-    vector<ArrayDevice*> deviceSet;
-    auto nonFaultyUBlockDev = MockUblockDevice("mock-data-nonfaulty");
-    auto faultyUBlockDev = MockUblockDevice("mock-data-faulty");
-    ArrayDevice dataNonFaulty(nonFaultyUBlockDev, ArrayDeviceState::NORMAL);
-    ArrayDevice dataFaulty(faultyUBlockDev, ArrayDeviceState::FAULT);
-    deviceSet.push_back(&dataNonFaulty);
-    deviceSet.push_back(&dataFaulty);
-
-    EXPECT_CALL(*mockArrayDeviceList, GetDevs).WillOnce(Return(deviceSet));
-
-    // When
-    vector<ArrayDevice*> actual = arrDevMgr.GetFaulty();
-
-    // Then
-    ASSERT_TRUE(actual.size() > 0);
-    ASSERT_EQ(&dataFaulty, actual.front());
-    deviceSet.clear();
-}
-
-TEST(ArrayDeviceManager, GetFaulty_testIfEmptyListIsReturnedWhenThereIsNoFaultyDevice)
-{
-    // Given
-    ArrayDeviceManager arrDevMgr(nullptr, "mockArrayName");
-    MockArrayDeviceList* mockArrayDeviceList = new MockArrayDeviceList;
-    arrDevMgr.SetArrayDeviceList(mockArrayDeviceList);
-
-    vector<ArrayDevice*> deviceSet;
-    auto nonFaultyUBlockDev1 = MockUblockDevice("mock-data-nonfaulty1");
-    auto nonFaultyUBlockDev2 = MockUblockDevice("mock-data-nonfaulty2");
-    ArrayDevice dataNonFaulty1(nonFaultyUBlockDev1, ArrayDeviceState::NORMAL);
-    ArrayDevice dataNonFaulty2(nonFaultyUBlockDev2, ArrayDeviceState::NORMAL);
-    deviceSet.push_back(&dataNonFaulty1);
-    deviceSet.push_back(&dataNonFaulty2);
-
-    EXPECT_CALL(*mockArrayDeviceList, GetDevs).WillOnce(Return(deviceSet));
-
-    // When
-    vector<ArrayDevice*> actual = arrDevMgr.GetFaulty();
-
-    // Then
-    ASSERT_EQ(0, actual.size());
-    deviceSet.clear();
-}
-
-TEST(ArrayDeviceManager, GetRebuilding_testIfRebuildDeviceIsReturned)
-{
-    // Given
-    ArrayDeviceManager arrDevMgr(nullptr, "mockArrayName");
-    MockArrayDeviceList* mockArrayDeviceList = new MockArrayDeviceList;
-    arrDevMgr.SetArrayDeviceList(mockArrayDeviceList);
-
-    vector<ArrayDevice*> deviceSet;
-    auto normalUBlockDev = MockUblockDevice("mock-data-normal");
-    auto rebuildUBlockDev = MockUblockDevice("mock-data-rebuild");
-    ArrayDevice normalDev(normalUBlockDev, ArrayDeviceState::NORMAL);
-    ArrayDevice rebuildDev(rebuildUBlockDev, ArrayDeviceState::REBUILD);
-    deviceSet.push_back(&normalDev);
-    deviceSet.push_back(&rebuildDev);
-
-    EXPECT_CALL(*mockArrayDeviceList, GetDevs).WillOnce(Return(deviceSet));
-    // When
-    vector<ArrayDevice*> actual = arrDevMgr.GetRebuilding();
-
-    // Then
-    ASSERT_EQ(&rebuildDev, actual.front());
-    deviceSet.clear();
-}
-
-TEST(ArrayDeviceManager, GetRebuilding_testIfRebuildDeviceIsNotRebuildState)
-{
-    // Given
-    string mockArrayName = "mockArray";
-    ArrayDeviceManager arrDevMgr(nullptr, mockArrayName);
-    MockArrayDeviceList* mockArrayDeviceList = new MockArrayDeviceList;
-    arrDevMgr.SetArrayDeviceList(mockArrayDeviceList);
-
-    vector<ArrayDevice*> deviceSet;
-    auto normalUBlockDev = MockUblockDevice("mock-data-normal");
-    auto rebuildUBlockDev = MockUblockDevice("mock-data-rebuild");
-    ArrayDevice normalDev(normalUBlockDev, ArrayDeviceState::NORMAL);
-    ArrayDevice rebuildDev(rebuildUBlockDev, ArrayDeviceState::NORMAL);
-    deviceSet.push_back(&normalDev);
-    deviceSet.push_back(&rebuildDev);
-
-    EXPECT_CALL(*mockArrayDeviceList, GetDevs).WillOnce(Return(deviceSet));
-    // When
-    vector<ArrayDevice*> actual = arrDevMgr.GetRebuilding();
-
-    // Then
-    ASSERT_EQ(0, actual.size());
-    deviceSet.clear();
-}
-
 } // namespace pos

--- a/test/unit-tests/array/array_mock.h
+++ b/test/unit-tests/array/array_mock.h
@@ -16,7 +16,7 @@ public:
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(void, Shutdown, (), (override));
     MOCK_METHOD(int, Load, (), (override));
-    MOCK_METHOD(int, Create, (DeviceSet<string> nameSet, string metaFt, string dataFt), (override));
+    MOCK_METHOD(int, Create, (const DeviceSet<string>& nameSet, string metaFt, string dataFt), (override));
     MOCK_METHOD(int, Delete, (), (override));
     MOCK_METHOD(int, AddSpare, (string devName), (override));
     MOCK_METHOD(int, RemoveSpare, (string devName), (override));

--- a/test/unit-tests/array/build/CMakeLists.txt
+++ b/test/unit-tests/array/build/CMakeLists.txt
@@ -1,0 +1,4 @@
+POS_ADD_UNIT_TEST(partition_builder_ut partition_builder_test.cpp)
+POS_ADD_UNIT_TEST(array_builder_ut array_builder_test.cpp)
+POS_ADD_UNIT_TEST(device_builder_ut device_builder_test.cpp)
+POS_ADD_UNIT_TEST(array_build_info_ut array_build_info_test.cpp)

--- a/test/unit-tests/array/build/array_build_info_mock.h
+++ b/test/unit-tests/array/build/array_build_info_mock.h
@@ -1,0 +1,15 @@
+#include <gmock/gmock.h>
+#include <string>
+#include <list>
+#include <vector>
+#include "src/array/build/array_build_info.h"
+
+namespace pos
+{
+class MockArrayBuildInfo : public ArrayBuildInfo
+{
+public:
+    using ArrayBuildInfo::ArrayBuildInfo;
+};
+
+} // namespace pos

--- a/test/unit-tests/array/build/array_build_info_test.cpp
+++ b/test/unit-tests/array/build/array_build_info_test.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+#include "src/array/build/array_build_info.h"
+#include "src/array/partition/stripe_partition.h"
+ 
+namespace pos
+{
+
+TEST(ArrayBuildInfo, Dispose_testIfDevsAndPartitionsAreCleared)
+{
+    // Given
+    ArrayBuildInfo buildInfo;
+    ArrayDevice* d1 = new ArrayDevice(nullptr);
+    ArrayDevice* d2 = new ArrayDevice(nullptr);
+    buildInfo.devices = { d1, d2 };
+    StripePartition* p1 = new StripePartition
+        (PartitionType::USER_DATA, buildInfo.devices, RaidTypeEnum::RAID0); // not interesting
+    StripePartition* p2 = new StripePartition(
+        PartitionType::META_SSD, buildInfo.devices, RaidTypeEnum::RAID0); // not interesting
+    buildInfo.partitions = { p1, p2 };
+
+    // When
+    buildInfo.Dispose();
+
+    // Then
+    ASSERT_EQ(0, buildInfo.devices.size());
+    ASSERT_EQ(0, buildInfo.partitions.size());
+}
+
+}  // namespace pos

--- a/test/unit-tests/array/build/array_builder_adapter_mock.h
+++ b/test/unit-tests/array/build/array_builder_adapter_mock.h
@@ -1,0 +1,18 @@
+#include <gmock/gmock.h>
+#include <string>
+#include <list>
+#include <vector>
+#include "src/array/build/array_builder_adapter.h"
+
+namespace pos
+{
+class MockArrayBuilderAdapter : public ArrayBuilderAdapter
+{
+public:
+    using ArrayBuilderAdapter::ArrayBuilderAdapter;
+    MOCK_METHOD(ArrayBuildInfo*, Load, (const DeviceSet<DeviceMeta>& devs,
+        string metaRaid, string dataRaid), (override));
+    MOCK_METHOD(ArrayBuildInfo*, Create, (string name, const DeviceSet<string>& devs,
+        string metaRaid, string dataRaid), (override));
+};
+} // namespace pos

--- a/test/unit-tests/array/build/array_builder_test.cpp
+++ b/test/unit-tests/array/build/array_builder_test.cpp
@@ -1,0 +1,14 @@
+#include <gtest/gtest.h>
+#include "src/array/build/array_builder.h"
+ 
+namespace pos {
+
+TEST(ArrayBuilder, Load_) {
+
+}
+
+TEST(ArrayBuilder, Create_) {
+
+}
+
+}  // namespace pos

--- a/test/unit-tests/array/build/device_builder_mock.h
+++ b/test/unit-tests/array/build/device_builder_mock.h
@@ -1,0 +1,15 @@
+#include <gmock/gmock.h>
+#include <string>
+#include <list>
+#include <vector>
+#include "src/array/build/device_builder.h"
+
+namespace pos
+{
+class MockDeviceBuilder : public DeviceBuilder
+{
+public:
+    using DeviceBuilder::DeviceBuilder;
+};
+
+} // namespace pos

--- a/test/unit-tests/array/build/device_builder_test.cpp
+++ b/test/unit-tests/array/build/device_builder_test.cpp
@@ -1,0 +1,119 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include "src/array/build/device_builder.h"
+#include "test/unit-tests/device/base/ublock_device_mock.h"
+#include "test/unit-tests/device/device_manager_mock.h"
+#include "src/include/pos_event_id.h"
+ 
+using ::testing::Return;
+
+namespace pos
+{
+
+TEST(DeviceBuilder, Create_testIfDeviceListBuiltSuccessfullyWhenInputsAreValid)
+{
+    // Given
+    DeviceSet<string> devs;
+    devs.nvm.push_back("nvm");
+    devs.data.push_back("data1");
+    devs.data.push_back("data2");
+    devs.spares.push_back("spare");
+    uint32_t EXPECTED_DEV_CNT = 4;
+    shared_ptr<MockUBlockDevice> mockUblockDev = make_shared<MockUBlockDevice>("mock-dev", 1024, nullptr);
+    MockDeviceManager mockDevMgr;
+    EXPECT_CALL(mockDevMgr, GetDev).WillRepeatedly(Return(mockUblockDev));
+
+    // When
+    DeviceBuilder builder;
+    vector<ArrayDevice*> devList;
+    int ret = builder.Create(devs, devList, &mockDevMgr);
+
+    // Then
+    ASSERT_EQ(0, ret);
+    ASSERT_EQ(EXPECTED_DEV_CNT, devList.size());
+}
+
+TEST(DeviceBuilder, Create_testIfDeviceBuildingFailsWhenFailedToGetTheDevice)
+{
+    // Given
+    DeviceSet<string> devs;
+    devs.nvm.push_back("nvm");
+    devs.data.push_back("data1");
+    devs.data.push_back("data2");
+    devs.spares.push_back("spare");
+    shared_ptr<MockUBlockDevice> mockUblockDev = make_shared<MockUBlockDevice>("mock-dev", 1024, nullptr);
+    MockDeviceManager mockDevMgr;
+    EXPECT_CALL(mockDevMgr, GetDev).WillRepeatedly(Return(nullptr)); // returns nullptr since there's no matching device
+
+    // When
+    DeviceBuilder builder;
+    vector<ArrayDevice*> devList;
+    int ret = builder.Create(devs, devList, &mockDevMgr);
+
+    // Then
+    ASSERT_EQ(EID(CREATE_ARRAY_SSD_NAME_NOT_FOUND), ret);
+}
+
+TEST(DeviceBuilder, Load_testIfDeviceListBuiltSuccessfullyWhenInputsAreValid)
+{
+    // Given
+    DeviceSet<DeviceMeta> devs;
+    devs.nvm.push_back(DeviceMeta("nvm", ArrayDeviceState::NORMAL));
+    devs.data.push_back(DeviceMeta("data1", ArrayDeviceState::NORMAL));
+    devs.data.push_back(DeviceMeta("data2", ArrayDeviceState::NORMAL));
+    devs.spares.push_back(DeviceMeta("spare1", ArrayDeviceState::NORMAL));
+    uint32_t EXPECTED_DEV_CNT = 4;
+    shared_ptr<MockUBlockDevice> mockUblockDev = make_shared<MockUBlockDevice>("mock-dev", 1024, nullptr);
+    MockDeviceManager mockDevMgr;
+    EXPECT_CALL(mockDevMgr, GetDev).WillRepeatedly(Return(mockUblockDev));
+
+    // When
+    DeviceBuilder builder;
+    vector<ArrayDevice*> devList;
+    int ret = builder.Load(devs, devList, &mockDevMgr);
+
+    // Then
+    ASSERT_EQ(0, ret);
+    ASSERT_EQ(EXPECTED_DEV_CNT, devList.size());
+}
+
+TEST(DeviceBuilder, Load_testIfDataDeviceBuildingSuccessButStateIsFaultWhenFailedToGetTheDevice)
+{
+    // Given
+    DeviceSet<DeviceMeta> devs;
+    devs.nvm.push_back(DeviceMeta("nvm", ArrayDeviceState::NORMAL));
+    devs.data.push_back(DeviceMeta("data1", ArrayDeviceState::NORMAL));
+    devs.data.push_back(DeviceMeta("data2", ArrayDeviceState::NORMAL));
+    devs.spares.push_back(DeviceMeta("spare1", ArrayDeviceState::NORMAL));
+
+    shared_ptr<MockUBlockDevice> mockUblockDev = make_shared<MockUBlockDevice>("mock-dev", 1024, nullptr);
+    MockDeviceManager mockDevMgr;
+    EXPECT_CALL(mockDevMgr, GetDev) // returns nullptr since there's no matching device
+        .WillOnce(Return(nullptr)) // for data1, if the data device is nullptr, It is added, but FAULT
+        .WillOnce(Return(nullptr)) // for data2, if the data device is nullptr, It is added, but FAULT
+        .WillOnce(Return(mockUblockDev)) // for nvm, nvm should not be nullptr
+        .WillOnce(Return(nullptr)); // for spare1, if the spare device is nullptr, it is ignored
+    uint32_t EXPECTED_DEV_CNT = 3; // Four are entered, but only three are added because spare is ignored.
+
+    // When
+    DeviceBuilder builder;
+    vector<ArrayDevice*> devList;
+    int ret = builder.Load(devs, devList, &mockDevMgr);
+
+    // Then
+    ASSERT_EQ(0, ret);
+    ASSERT_EQ(EXPECTED_DEV_CNT, devList.size());
+    for (auto d : devList)
+    {
+        if (d->GetType() == ArrayDeviceType::NVM)
+        {
+            ASSERT_EQ(ArrayDeviceState::NORMAL, d->GetState());
+        }
+        else
+        {
+            ASSERT_EQ(ArrayDeviceState::FAULT, d->GetState());
+        }
+    }
+}
+
+}  // namespace pos

--- a/test/unit-tests/array/build/partition_builder_mock.h
+++ b/test/unit-tests/array/build/partition_builder_mock.h
@@ -1,0 +1,15 @@
+#include <gmock/gmock.h>
+#include <string>
+#include <list>
+#include <vector>
+#include "src/array/build/partition_builder.h"
+
+namespace pos
+{
+class MockPartitionBuilder : public PartitionBuilder
+{
+public:
+    using PartitionBuilder::PartitionBuilder;
+};
+
+} // namespace pos

--- a/test/unit-tests/array/build/partition_builder_test.cpp
+++ b/test/unit-tests/array/build/partition_builder_test.cpp
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+#include "src/array/build/partition_builder.h"
+ 
+namespace pos {
+
+TEST(PartitionBuilder, Load_) {
+
+}
+
+TEST(PartitionBuilder, Create_) {
+
+}
+
+TEST(PartitionBuilder, _CreateNvmPartitions_) {
+
+}
+
+}  // namespace pos

--- a/test/unit-tests/array/device/array_device_list_mock.h
+++ b/test/unit-tests/array/device/array_device_list_mock.h
@@ -1,9 +1,7 @@
 #include <gmock/gmock.h>
-
-#include <list>
 #include <string>
+#include <list>
 #include <vector>
-
 #include "src/array/device/array_device_list.h"
 
 namespace pos
@@ -12,12 +10,12 @@ class MockArrayDeviceList : public ArrayDeviceList
 {
 public:
     using ArrayDeviceList::ArrayDeviceList;
-    MOCK_METHOD(int, SetNvm, (ArrayDevice* nvm), (override));
+    MOCK_METHOD(int, Import, (vector<ArrayDevice*> devs), (override));
     MOCK_METHOD(int, AddSsd, (ArrayDevice* dev), (override));
-    MOCK_METHOD(int, RemoveSpare, (ArrayDevice* target), (override));
+    MOCK_METHOD(int, RemoveSsd, (ArrayDevice* target), (override));
     MOCK_METHOD(int, SpareToData, (ArrayDevice* target, ArrayDevice*& swapOut), (override));
     MOCK_METHOD(void, Clear, (), (override));
-    MOCK_METHOD(vector<ArrayDevice*>, GetDevs, (), (override));
+    MOCK_METHOD(vector<ArrayDevice*>&, GetDevs, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/array/device/array_device_list_test.cpp
+++ b/test/unit-tests/array/device/array_device_list_test.cpp
@@ -19,86 +19,15 @@ TEST(ArrayDeviceList, ArrayDeviceList_testconstructor)
     // Then
 }
 
-TEST(ArrayDeviceList, SetNvm_testWhenArgumentsAreValid)
-{
-    // Given
-    ArrayDeviceList arrayDeviceList;
-    string nvmDevName = "mock-uram";
-    struct spdk_nvme_ns* fakeNs = BuildFakeNvmeNamespace();
-    UblockSharedPtr fakeUblockSharedPtr = make_shared<UnvmeSsd>(nvmDevName, 1024, nullptr, fakeNs, "mock-addr");
-    MockArrayDevice* mockDev = new MockArrayDevice(nullptr, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::NVM);
-    EXPECT_CALL(*mockDev, GetType).WillRepeatedly(Return(ArrayDeviceType::NVM));
-    EXPECT_CALL(*mockDev, GetUblock).WillRepeatedly(Return(fakeUblockSharedPtr));
-    // When
-    int result = arrayDeviceList.SetNvm(mockDev);
-    // Then
-    int SUCCESS = 0;
-    EXPECT_EQ(SUCCESS, result);
-    delete mockDev;
-}
-
-TEST(ArrayDeviceList, SetNvm_testWhenSettingNvmTwice)
-{
-    // Given
-    ArrayDeviceList arrayDeviceList;
-    string nvmDevName = "mock-uram";
-    struct spdk_nvme_ns* fakeNs = BuildFakeNvmeNamespace();
-    UblockSharedPtr fakeUblockSharedPtr = make_shared<UnvmeSsd>(nvmDevName, 1024, nullptr, fakeNs, "mock-addr");
-    MockArrayDevice* mockDev = new MockArrayDevice(nullptr, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::NVM);
-    EXPECT_CALL(*mockDev, GetType).WillRepeatedly(Return(ArrayDeviceType::NVM));
-    EXPECT_CALL(*mockDev, GetUblock).WillRepeatedly(Return(fakeUblockSharedPtr));
-    arrayDeviceList.SetNvm(mockDev);
-    // When
-    int result = arrayDeviceList.SetNvm(mockDev);
-    // Then
-    int ADD_FAIL = EID(UNABLE_TO_SET_NVM_MORE_THAN_ONE);
-    EXPECT_EQ(ADD_FAIL, result);
-    delete mockDev;
-}
-
-TEST(ArrayDeviceList, SetNvm_testWhenSettingNullUblock)
-{
-    // Given
-    ArrayDeviceList arrayDeviceList;
-    string nvmDevName = "mock-uram";
-    MockArrayDevice* mockDev = new MockArrayDevice(nullptr, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::NVM);
-    EXPECT_CALL(*mockDev, GetUblock).WillRepeatedly(Return(nullptr));
-    EXPECT_CALL(*mockDev, GetType).WillRepeatedly(Return(ArrayDeviceType::NVM));
-    // When
-    int result = arrayDeviceList.SetNvm(mockDev);
-    // Then
-    int ADD_FAIL = EID(UNABLE_TO_SET_NVM_NO_OR_NULL);
-    EXPECT_EQ(ADD_FAIL, result);
-    delete mockDev;
-}
-
-TEST(ArrayDeviceList, SetNvm_testWhenSettingNvmWithDataDevice)
+TEST(ArrayDeviceList, AddSsd_testWhenArgumentsAreValid)
 {
     // Given
     ArrayDeviceList arrayDeviceList;
     string dataDevName = "mock-unvme";
     struct spdk_nvme_ns* fakeNs = BuildFakeNvmeNamespace();
     UblockSharedPtr fakeUblockSharedPtr = make_shared<UnvmeSsd>(dataDevName, 1024, nullptr, fakeNs, "mock-addr");
-    MockArrayDevice* mockDev = new MockArrayDevice(fakeUblockSharedPtr, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::DATA);
-    EXPECT_CALL(*mockDev, GetType).WillRepeatedly(Return(ArrayDeviceType::DATA));
-    // When
-    int result = arrayDeviceList.SetNvm(mockDev);
-    // Then
-    int ADD_FAIL = EID(ARRAY_DEVICE_TYPE_NOT_MATCHED);
-    EXPECT_EQ(ADD_FAIL, result);
-    delete mockDev;
-}
-
-TEST(ArrayDeviceList, AddSsd_testWhenAddDataAndArgumentsAreValid)
-{
-    // Given
-    ArrayDeviceList arrayDeviceList;
-    string dataDevName = "mock-unvme";
-    struct spdk_nvme_ns* fakeNs = BuildFakeNvmeNamespace();
-    UblockSharedPtr fakeUblockSharedPtr = make_shared<UnvmeSsd>(dataDevName, 1024, nullptr, fakeNs, "mock-addr");
-    MockArrayDevice* mockDev = new MockArrayDevice(fakeUblockSharedPtr, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::DATA);
+    MockArrayDevice* mockDev = new MockArrayDevice(fakeUblockSharedPtr, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::SPARE);
     EXPECT_CALL(*mockDev, GetUblock).WillRepeatedly(Return(fakeUblockSharedPtr));
-    EXPECT_CALL(*mockDev, GetType).WillRepeatedly(Return(ArrayDeviceType::DATA));
     // When
     int result = arrayDeviceList.AddSsd(mockDev);
     // Then
@@ -107,7 +36,7 @@ TEST(ArrayDeviceList, AddSsd_testWhenAddDataAndArgumentsAreValid)
     delete mockDev;
 }
 
-TEST(ArrayDeviceList, AddSsd_testWhenAddSpareAndArgumentsAreValid)
+TEST(ArrayDeviceList, AddSsd_testWhenAddTwice)
 {
     // Given
     ArrayDeviceList arrayDeviceList;
@@ -116,25 +45,6 @@ TEST(ArrayDeviceList, AddSsd_testWhenAddSpareAndArgumentsAreValid)
     UblockSharedPtr fakeUblockSharedPtr = make_shared<UnvmeSsd>(spareDevName, 1024, nullptr, fakeNs, "mock-addr");
     MockArrayDevice* mockDev = new MockArrayDevice(fakeUblockSharedPtr, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::SPARE);
     EXPECT_CALL(*mockDev, GetUblock).WillRepeatedly(Return(fakeUblockSharedPtr));
-    EXPECT_CALL(*mockDev, GetType).WillRepeatedly(Return(ArrayDeviceType::SPARE));
-    // When
-    int result = arrayDeviceList.AddSsd(mockDev);
-    // Then
-    int SUCCESS = 0;
-    EXPECT_EQ(SUCCESS, result);
-    delete mockDev;
-}
-
-TEST(ArrayDeviceList, AddSsd_testWhenAddTheSameDeviceTwice)
-{
-    // Given
-    ArrayDeviceList arrayDeviceList;
-    string spareDevName = "mock-unvme";
-    struct spdk_nvme_ns* fakeNs = BuildFakeNvmeNamespace();
-    UblockSharedPtr fakeUblockSharedPtr = make_shared<UnvmeSsd>(spareDevName, 1024, nullptr, fakeNs, "mock-addr");
-    MockArrayDevice* mockDev = new MockArrayDevice(fakeUblockSharedPtr, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::DATA);
-    EXPECT_CALL(*mockDev, GetUblock).WillRepeatedly(Return(fakeUblockSharedPtr));
-    EXPECT_CALL(*mockDev, GetType).WillRepeatedly(Return(ArrayDeviceType::DATA));
     arrayDeviceList.AddSsd(mockDev);
     // When
     int result = arrayDeviceList.AddSsd(mockDev);
@@ -144,7 +54,7 @@ TEST(ArrayDeviceList, AddSsd_testWhenAddTheSameDeviceTwice)
     delete mockDev;
 }
 
-TEST(ArrayDeviceList, RemoveSpare_testWhenArgumentsAreValid)
+TEST(ArrayDeviceList, RemoveSsd_testWhenArgumentsAreValid)
 {
     // Given
     ArrayDeviceList arrayDeviceList;
@@ -154,29 +64,27 @@ TEST(ArrayDeviceList, RemoveSpare_testWhenArgumentsAreValid)
     MockArrayDevice* mockDev = new MockArrayDevice(fakeUblockSharedPtr, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::SPARE);
     EXPECT_CALL(*mockDev, GetUblock).WillRepeatedly(Return(fakeUblockSharedPtr));
     EXPECT_CALL(*mockDev, GetType).WillRepeatedly(Return(ArrayDeviceType::SPARE));
-    arrayDeviceList.AddSsd(mockDev);
+    arrayDeviceList.Import(vector<ArrayDevice*> { mockDev });
     // When
-    int result = arrayDeviceList.RemoveSpare(mockDev);
+    int result = arrayDeviceList.RemoveSsd(mockDev);
     // Then
     int SUCCESS = 0;
     EXPECT_EQ(SUCCESS, result);
 }
 
-TEST(ArrayDeviceList, RemoveSpare_testWhenNoSpare)
+TEST(ArrayDeviceList, RemoveSsd_testWhenNotFound)
 {
     // Given
     ArrayDeviceList arrayDeviceList;
-    string spareDevName = "mock-unvme";
+    string devName = "mock-unvme";
     struct spdk_nvme_ns* fakeNs = BuildFakeNvmeNamespace();
-    UblockSharedPtr fakeUblockSharedPtr = make_shared<UnvmeSsd>(spareDevName, 1024, nullptr, fakeNs, "mock-addr");
-    MockArrayDevice* mockDev = new MockArrayDevice(fakeUblockSharedPtr, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::SPARE);
-    EXPECT_CALL(*mockDev, GetType).WillRepeatedly(Return(ArrayDeviceType::SPARE));
+    UblockSharedPtr fakeUblockSharedPtr = make_shared<UnvmeSsd>(devName, 1024, nullptr, fakeNs, "mock-addr");
+    MockArrayDevice* mockDev = new MockArrayDevice(fakeUblockSharedPtr, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::DATA);
     // When
-    int result = arrayDeviceList.RemoveSpare(mockDev);
+    int result = arrayDeviceList.RemoveSsd(mockDev);
     // Then
     int REMOVE_FAIL = EID(REMOVE_DEV_SSD_NAME_NOT_FOUND);
     EXPECT_EQ(REMOVE_FAIL, result);
-    delete mockDev;
 }
 
 TEST(ArrayDeviceList, SpareToData_testReplacingBroken)
@@ -192,11 +100,12 @@ TEST(ArrayDeviceList, SpareToData_testReplacingBroken)
     EXPECT_CALL(*mockDev, GetType).WillRepeatedly(Return(ArrayDeviceType::SPARE));
     EXPECT_CALL(*brokenDataDev, GetUblock).WillRepeatedly(Return(fakeUblockSharedPtr));
     EXPECT_CALL(*brokenDataDev, GetType).WillRepeatedly(Return(ArrayDeviceType::DATA));
-    arrayDeviceList.AddSsd(mockDev);
-    arrayDeviceList.AddSsd(brokenDataDev);
+    arrayDeviceList.Import(vector<ArrayDevice*> { mockDev, brokenDataDev });
+
     // When
     ArrayDevice* out;
     int result = arrayDeviceList.SpareToData(brokenDataDev, out);
+
     // Then
     int SUCCESS = 0;
     EXPECT_EQ(SUCCESS, result);
@@ -214,8 +123,7 @@ TEST(ArrayDeviceList, SpareToData_testIfThereIsNoSpare)
     UblockSharedPtr fakeUblockSharedPtr = make_shared<UnvmeSsd>(spareDevName, 1024, nullptr, fakeNs, "mock-addr");
     MockArrayDevice* brokenDataDev = new MockArrayDevice(nullptr, ArrayDeviceState::FAULT, 0, ArrayDeviceType::DATA);
     EXPECT_CALL(*brokenDataDev, GetUblock).WillRepeatedly(Return(fakeUblockSharedPtr));
-    EXPECT_CALL(*brokenDataDev, GetType).WillRepeatedly(Return(ArrayDeviceType::DATA));
-    arrayDeviceList.AddSsd(brokenDataDev);
+    arrayDeviceList.Import(vector<ArrayDevice*> { brokenDataDev });
     // When
     ArrayDevice* out;
     int result = arrayDeviceList.SpareToData(brokenDataDev, out);
@@ -234,32 +142,11 @@ TEST(ArrayDeviceList, Clear_testWhenArgumentsAreValid)
     UblockSharedPtr fakeUblockSharedPtr = make_shared<UnvmeSsd>(dataDevName, 1024, nullptr, fakeNs, "mock-addr");
     MockArrayDevice* mockDev = new MockArrayDevice(fakeUblockSharedPtr, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::DATA);
     EXPECT_CALL(*mockDev, GetUblock).WillRepeatedly(Return(fakeUblockSharedPtr));
-    EXPECT_CALL(*mockDev, GetType).WillRepeatedly(Return(ArrayDeviceType::DATA));
-    arrayDeviceList.AddSsd(mockDev);
+    arrayDeviceList.Import(vector<ArrayDevice*> { mockDev });
     // When
     arrayDeviceList.Clear();
     // Then
-    auto numOfDevs = arrayDeviceList.GetDevs().size();
-    EXPECT_EQ(0, numOfDevs);
-}
-
-TEST(ArrayDeviceList, GetDevs_testWhenThereIsOneDataDevice)
-{
-    // Given
-    ArrayDeviceList arrayDeviceList;
-    string dataDevName = "mock-unvme";
-    struct spdk_nvme_ns* fakeNs = BuildFakeNvmeNamespace();
-    UblockSharedPtr fakeUblockSharedPtr = make_shared<UnvmeSsd>(dataDevName, 1024, nullptr, fakeNs, "mock-addr");
-    MockArrayDevice* mockDev = new MockArrayDevice(fakeUblockSharedPtr, ArrayDeviceState::NORMAL, 0, ArrayDeviceType::DATA);
-    EXPECT_CALL(*mockDev, GetUblock).WillRepeatedly(Return(fakeUblockSharedPtr));
-    EXPECT_CALL(*mockDev, GetType).WillRepeatedly(Return(ArrayDeviceType::DATA));
-    int actual = arrayDeviceList.AddSsd(mockDev);
-    // When
-    auto devs = arrayDeviceList.GetDevs();
-    // Then
-    ArrayDeviceType type = devs.front()->GetType();
+    int actual = arrayDeviceList.GetDevs().size();
     EXPECT_EQ(0, actual);
-    EXPECT_EQ(ArrayDeviceType::DATA, type);
-    delete mockDev;
 }
 } // namespace pos

--- a/test/unit-tests/array/device/array_device_manager_mock.h
+++ b/test/unit-tests/array/device/array_device_manager_mock.h
@@ -12,18 +12,11 @@ class MockArrayDeviceManager : public ArrayDeviceManager
 {
 public:
     using ArrayDeviceManager::ArrayDeviceManager;
-    MOCK_METHOD(int, ImportByName, (DeviceSet<string> nameSet), (override));
-    MOCK_METHOD(int, Import, (DeviceSet<DeviceMeta> metaSet), (override));
     MOCK_METHOD(void, Clear, (), (override));
+    MOCK_METHOD(int, Import, (vector<ArrayDevice*> devs), (override));
     MOCK_METHOD(int, AddSpare, (string devName), (override));
     MOCK_METHOD(int, RemoveSpare, (string devName), (override));
-    MOCK_METHOD(int, ReplaceWithSpare, (ArrayDevice* target, ArrayDevice*& out), (override));
-    MOCK_METHOD(vector<ArrayDevice*>, GetDevs, (), (override));
-    MOCK_METHOD(vector<ArrayDevice*>, GetFaulty, (), (override));
-    MOCK_METHOD(vector<ArrayDevice*>, GetRebuilding, (), (override));
-    MOCK_METHOD(vector<ArrayDevice*>, GetDataDevices, (), (override));
-    MOCK_METHOD(vector<ArrayDevice*>, GetSpareDevices, (), (override));
-    MOCK_METHOD(vector<ArrayDevice*>, GetAvailableSpareDevices, (), (override));
+    MOCK_METHOD(int, ReplaceWithSpare, (ArrayDevice* target, ArrayDevice*& swapOut), (override));
+    MOCK_METHOD(vector<ArrayDevice*>&, GetDevs, (), (override));
 };
-
 } // namespace pos

--- a/test/unit-tests/include/i_array_device_mock.h
+++ b/test/unit-tests/include/i_array_device_mock.h
@@ -6,6 +6,8 @@
 
 #include "src/include/i_array_device.h"
 
+using namespace std;
+
 namespace pos
 {
 class MockIArrayDevice : public IArrayDevice


### PR DESCRIPTION
Signed-off-by: minjoon.ahn <minjoon.ahn@samsung.com>

목적: Array생성 및 Array Device 구성 관련 business 로직을 별도의 builder로 분리
주요변경사항
- ArrayBuilder도입: ArrayBuilder에서 Device목록과 Partition목록을 구성하고 Validation 후 ArrayBuildInfo를 리턴
- ArrayBuildInfo에 있는 Device목록과 Partition목록을 ArrayDeviceManager와 PartitionManager의 Import(...) method를 통해 각각 주입

배경: ArrayBuilder는 CLI요청(ArrayCreate) 또는 MBR(ArrayLoad)에서 읽은 레시피를 바탕으로 Array를 구성하는 일종의 Adapter 역할을 수행합니다. 이후에 POS Boot Record가 적용되면 또 새로운 자료구조를 통해 Array를 구성해야 하는데, 이러한 Array 생성 로직과  유효성 체크 정책을 외부로 분리하여 Array내부모듈(Array, ArrayDeviceManager, PartitionManager 등)의 기능 복잡성(+UT 복잡성)을 줄이려고 합니다.



