### PR TITLE
[AWIBOF-7478] Enable NVMe directive cmd for multistream

### DIFF
--- a/src/bio/ubio.h
+++ b/src/bio/ubio.h
@@ -66,7 +66,8 @@ enum class UbioDir
     Abort,
     NvmeCli,
     AdminPassTh,
-    GetLogPage
+    GetLogPage,
+    Directive
 };
 
 struct DeviceLba;

--- a/src/device/directive_cmd.cpp
+++ b/src/device/directive_cmd.cpp
@@ -1,0 +1,183 @@
+/*
+ *   BSD LICENSE
+ *   Copyright (c) 2023 Samsung Electronics Corporation
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Samsung Electronics Corporation nor the names of
+ *       its contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "directive_cmd.h"
+
+#include "src/bio/ubio.h"
+#include "src/io_scheduler/io_dispatcher.h"
+#include "src/logger/logger.h"
+
+namespace pos
+{
+DirectiveContext::DirectiveContext(bool cmd, uint32_t doper, uint32_t dtype, uint32_t dspec,
+        void* payload, uint32_t payloadSize, uint32_t cdw12, uint32_t cdw13)
+: cmd(cmd),
+  doper(doper),
+  dtype(dtype),
+  dspec(dspec),
+  payload(payload),
+  payloadSize(payloadSize),
+  cdw12(cdw12),
+  cdw13(cdw13)
+{
+}
+
+DirectiveCmd::DirectiveCmd(UblockSharedPtr dev, spdk_nvme_ctrlr* ctrlr, IIODispatcher* ioDispatcher)
+: targetDevice(dev),
+  ctrlr(ctrlr),
+  ioDispatcher(ioDispatcher)
+{
+}
+
+DirectiveCmd::~DirectiveCmd(void)
+{
+}
+
+void
+DirectiveCmd::EnableDirective(void)
+{
+    _SubmitUbio(DirReqId::IDENTIFY_DIRECTIVE_SEND_ENABLED);
+}
+
+void
+DirectiveCmd::ReturnIdentifyParameters(void)
+{
+    _SubmitUbio(DirReqId::IDENTIFY_DIRECTIVE_RECEIVE_RETURN_PARAM);
+}
+
+void
+DirectiveCmd::AllocateResources(void)
+{
+    _SubmitUbio(DirReqId::STREAMS_DIRECTIVE_RECEIVE_ALLOCATE_RESOURCE);
+}
+
+void
+DirectiveCmd::ReleaseResources(void)
+{
+    _SubmitUbio(DirReqId::STREAMS_DIRECTIVE_SEND_RELEASE_RESOURCE);
+}
+
+void
+DirectiveCmd::_SubmitUbio(DirReqId reqId)
+{
+    uint32_t payloadSize = 0;
+    void* payload = nullptr;
+    DirectiveContext* directiveContext = nullptr;
+    switch (reqId)
+    {
+        case DirReqId::IDENTIFY_DIRECTIVE_SEND_ENABLED:
+            directiveContext = new DirectiveContext(
+                DIRECTIVE_SEND,
+                SPDK_NVME_IDENTIFY_DIRECTIVE_SEND_ENABLED,
+                SPDK_NVME_DIRECTIVE_TYPE_IDENTIFY,
+                0,
+                payload,
+                payloadSize,
+                ENABLE_DIRECTIVE,
+                0);
+            break;
+
+        case DirReqId::IDENTIFY_DIRECTIVE_RECEIVE_RETURN_PARAM:
+            payloadSize = sizeof(spdk_nvme_ns_identify_directive_param);
+            payload = new struct spdk_nvme_ns_identify_directive_param();
+            directiveContext = new DirectiveContext(
+                DIRECTIVE_RECEIVE,
+                SPDK_NVME_IDENTIFY_DIRECTIVE_RECEIVE_RETURN_PARAM,
+                SPDK_NVME_DIRECTIVE_TYPE_IDENTIFY,
+                0,
+                payload,
+                payloadSize,
+                0,
+                0);
+            break;
+
+        case DirReqId::STREAMS_DIRECTIVE_RECEIVE_ALLOCATE_RESOURCE:
+            directiveContext = new DirectiveContext(
+                DIRECTIVE_RECEIVE,
+                SPDK_NVME_STREAMS_DIRECTIVE_RECEIVE_ALLOCATE_RESOURCE,
+                SPDK_NVME_DIRECTIVE_TYPE_STREAMS,
+                0,
+                payload,
+                payloadSize,
+                STREAM_CNT,
+                0);
+            break;
+
+        case DirReqId::STREAMS_DIRECTIVE_SEND_RELEASE_RESOURCE:
+            directiveContext = new DirectiveContext(
+                DIRECTIVE_SEND,
+                SPDK_NVME_STREAMS_DIRECTIVE_SEND_RELEASE_RESOURCE,
+                SPDK_NVME_DIRECTIVE_TYPE_STREAMS,
+                0,
+                payload,
+                payloadSize,
+                0,
+                0);
+            break;
+
+        default:
+            return;
+    }
+
+    if (0 == payloadSize)
+    {
+        payloadSize = 1;
+    }
+    UbioSmartPtr ubio(new Ubio((void*)directiveContext, payloadSize, 0 /*array index*/));
+    ubio->dir = UbioDir::Directive;
+    ubio->SetUblock(targetDevice);
+
+    int ret = ioDispatcher->Submit(ubio, true);
+    if (ret < 0 || ubio->GetError() != IOErrorType::SUCCESS)
+    {
+        switch (reqId)
+        {
+            case DirReqId::IDENTIFY_DIRECTIVE_SEND_ENABLED:
+                POS_TRACE_INFO(EID(UNVME_OPERATION_NOT_SUPPORTED),
+                    "Failed to Enable directives. result:{} ubio->GetError():{}",
+                    ret, ubio->GetError());
+                break;
+
+            case DirReqId::STREAMS_DIRECTIVE_RECEIVE_ALLOCATE_RESOURCE:
+                POS_TRACE_INFO(EID(UNVME_OPERATION_NOT_SUPPORTED),
+                    "Failed to allocate resources. result:{} ubio->GetError():{}",
+                    ret, ubio->GetError());
+                break;
+
+            default:
+                POS_TRACE_INFO(EID(UNVME_OPERATION_NOT_SUPPORTED),
+                    "Directive Command Failed. result:{} ubio->GetError():{}",
+                    ret, ubio->GetError());
+        }
+    }
+}
+} // namespace pos

--- a/src/device/directive_cmd.h
+++ b/src/device/directive_cmd.h
@@ -1,0 +1,110 @@
+/*
+ *   BSD LICENSE
+ *   Copyright (c) 2023 Samsung Electronics Corporation
+ *   All rights reserved.
+ *
+ *   Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *   are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *     * Neither the name of Samsung Electronics Corporation nor the names of
+ *       its contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ *   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef DIRECTIVE_CMD_H_
+#define DIRECTIVE_CMD_H_
+
+#include "spdk/include/spdk/nvme.h"
+#include "spdk/include/spdk/nvme_spec.h"
+#include "src/io_scheduler/io_dispatcher.h"
+#include "src/spdk_wrapper/caller/spdk_nvme_caller.h"
+
+enum spdk_nvme_directive_type;
+
+enum spdk_nvme_identify_directive_send_operation;
+enum spdk_nvme_identify_directive_receive_operation;
+struct spdk_nvme_ns_identify_directive_param;
+
+enum spdk_nvme_streams_directive_receive_operation;
+enum spdk_nvme_streams_directive_send_operation;
+
+namespace pos
+{
+class UBlockDevice;
+class IIODispatcher;
+
+enum DirectiveCommmand
+{
+    DIRECTIVE_RECEIVE = 0,
+    DIRECTIVE_SEND
+};
+
+enum class DirReqId
+{
+    IDENTIFY_DIRECTIVE_SEND_ENABLED = 0,
+    IDENTIFY_DIRECTIVE_RECEIVE_RETURN_PARAM,
+    STREAMS_DIRECTIVE_RECEIVE_RETURN_PARAM,
+    STREAMS_DIRECTIVE_RECEIVE_GET_STATUS,
+    STREAMS_DIRECTIVE_RECEIVE_ALLOCATE_RESOURCE,
+    STREAMS_DIRECTIVE_SEND_RELEASE_ID,
+    STREAMS_DIRECTIVE_SEND_RELEASE_RESOURCE
+};
+
+class DirectiveContext
+{
+public:
+    DirectiveContext(bool cmd, uint32_t doper, uint32_t dtype, uint32_t dspec,
+        void* payload, uint32_t payloadSize, uint32_t cdw12, uint32_t cdw13);
+    bool cmd;
+    uint32_t doper;
+    uint32_t dtype;
+    uint32_t dspec;
+    void* payload;
+    uint32_t payloadSize;
+    uint32_t cdw12;
+    uint32_t cdw13;
+};
+
+class DirectiveCmd
+{
+public:
+    DirectiveCmd(UblockSharedPtr dev, spdk_nvme_ctrlr* ctrlr, IIODispatcher* ioDispatcher);
+    virtual ~DirectiveCmd(void);
+
+    void EnableDirective(void);
+    void ReturnIdentifyParameters(void);
+
+    void AllocateResources(void);
+    void ReleaseResources(void);
+
+private:
+    void _SubmitUbio(DirReqId reqId);
+
+    static const uint32_t ENABLE_DIRECTIVE = 0x00000101;
+    static const uint32_t STREAM_CNT = 3;    // user data, meta data, journal data
+
+    UblockSharedPtr targetDevice;
+    spdk_nvme_ctrlr* ctrlr;
+    IIODispatcher* ioDispatcher = nullptr;
+};
+} // namespace pos
+#endif // DIRECTIVE_CMD_H_

--- a/src/device/unvme/unvme_cmd.h
+++ b/src/device/unvme/unvme_cmd.h
@@ -64,6 +64,10 @@ private:
         spdk_nvme_cmd_cb callbackFunc,
         UnvmeIOContext* ioCtx);
 
+    int _RequestDirective(UnvmeDeviceContext* deviceContext,
+        spdk_nvme_cmd_cb callbackFunc,
+        UnvmeIOContext* ioCtx);
+
     int _RequestAdminPassThu(UnvmeDeviceContext* deviceContext,
         spdk_nvme_cmd_cb callbackFunc,
         UnvmeIOContext* ioContext);

--- a/src/spdk_wrapper/caller/spdk_nvme_caller.cpp
+++ b/src/spdk_wrapper/caller/spdk_nvme_caller.cpp
@@ -99,6 +99,22 @@ SpdkNvmeCaller::SpdkNvmeNsCmdWrite(
 }
 
 int
+SpdkNvmeCaller::SpdkNvmeNsCmdWriteWithStream(
+    struct spdk_nvme_ns* ns,
+    struct spdk_nvme_qpair* qpair,
+    void* buffer,
+    uint64_t lba,
+    uint32_t lba_count,
+    spdk_nvme_cmd_cb cb_fn,
+    void* cb_arg,
+    uint32_t io_flags,
+    uint16_t stream_id)
+{
+    return spdk_nvme_ns_cmd_write_with_stream_id(
+        ns, qpair, buffer, lba, lba_count, cb_fn, cb_arg, io_flags, stream_id);
+}
+
+int
 SpdkNvmeCaller::SpdkNvmeCtrlrCmdAbort(
     struct spdk_nvme_ctrlr* ctrlr,
     struct spdk_nvme_qpair* qpair,
@@ -148,6 +164,42 @@ SpdkNvmeCaller::SpdkNvmeCtrlrCmdGetLogPage(
 {
     return spdk_nvme_ctrlr_cmd_get_log_page(
         ctrlr, log_page, nsid, payload, payload_size, offset, cb_fn, cb_arg);
+}
+
+int
+SpdkNvmeCaller::SpdkNvmeCtrlrCmdDirectiveReceive(
+    struct spdk_nvme_ctrlr *ctrlr,
+    uint32_t nsid,
+	uint32_t doper,
+    uint32_t dtype,
+    uint32_t dspec,
+    void *payload,
+    uint32_t payload_size,
+    uint32_t cdw12,
+	uint32_t cdw13,
+    spdk_nvme_cmd_cb cb_fn,
+    void *cb_arg)
+{
+    return spdk_nvme_ctrlr_cmd_directive_receive(
+        ctrlr, nsid, doper, dtype, dspec, payload, payload_size, cdw12, cdw13, cb_fn, cb_arg);
+}
+
+int
+SpdkNvmeCaller::SpdkNvmeCtrlrCmdDirectiveSend(
+    struct spdk_nvme_ctrlr *ctrlr,
+    uint32_t nsid,
+	uint32_t doper,
+    uint32_t dtype,
+    uint32_t dspec,
+    void *payload,
+    uint32_t payload_size,
+    uint32_t cdw12,
+	uint32_t cdw13,
+    spdk_nvme_cmd_cb cb_fn,
+    void *cb_arg)
+{
+    return spdk_nvme_ctrlr_cmd_directive_send(
+        ctrlr, nsid, doper, dtype, dspec, payload, payload_size, cdw12, cdw13, cb_fn, cb_arg);
 }
 
 bool

--- a/src/spdk_wrapper/caller/spdk_nvme_caller.h
+++ b/src/spdk_wrapper/caller/spdk_nvme_caller.h
@@ -72,6 +72,16 @@ public:
         spdk_nvme_cmd_cb cb_fn,
         void* cb_arg,
         uint32_t io_flags);
+    virtual int SpdkNvmeNsCmdWriteWithStream(
+        struct spdk_nvme_ns* ns,
+        struct spdk_nvme_qpair* qpair,
+        void* buffer,
+        uint64_t lba,
+        uint32_t lba_count,
+        spdk_nvme_cmd_cb cb_fn,
+        void* cb_arg,
+        uint32_t io_flags,
+        uint16_t stream_id);
     virtual int SpdkNvmeCtrlrCmdAbort(
         struct spdk_nvme_ctrlr* ctrlr,
         struct spdk_nvme_qpair* qpair,
@@ -102,6 +112,30 @@ public:
         uint64_t offset,
         spdk_nvme_cmd_cb cb_fn,
         void* cb_arg);
+    virtual int SpdkNvmeCtrlrCmdDirectiveReceive(
+        struct spdk_nvme_ctrlr *ctrlr,
+        uint32_t nsid,
+        uint32_t doper,
+        uint32_t dtype,
+        uint32_t dspec,
+        void *payload,
+        uint32_t payload_size,
+        uint32_t cdw12,
+        uint32_t cdw13,
+        spdk_nvme_cmd_cb cb_fn,
+        void *cb_arg);
+    virtual int SpdkNvmeCtrlrCmdDirectiveSend(
+        struct spdk_nvme_ctrlr *ctrlr,
+        uint32_t nsid,
+        uint32_t doper,
+        uint32_t dtype,
+        uint32_t dspec,
+        void *payload,
+        uint32_t payload_size,
+        uint32_t cdw12,
+        uint32_t cdw13,
+        spdk_nvme_cmd_cb cb_fn,
+        void *cb_arg);
     virtual bool SpdkNvmeCtrlrIsFailed(struct spdk_nvme_ctrlr* ctrlr);
     virtual int32_t SpdkNvmeCtrlrProcessAdminCompletions(
         struct spdk_nvme_ctrlr* ctrlr);


### PR DESCRIPTION
enable NVMe directive cmd and divide write streams for user, meta, journal

Signed-off-by: yongjin.lee <yong7.lee@samsung.com>