### PR TITLE
Refactoring allocator file I/O

### DIFF
--- a/src/allocator/address/allocator_address_info.cpp
+++ b/src/allocator/address/allocator_address_info.cpp
@@ -50,6 +50,7 @@ AllocatorAddressInfo::Init(IArrayInfo* iArrayInfo)
     blksPerSegment = blksPerStripe * udSize->stripesPerSegment;
     stripesPerSegment = udSize->stripesPerSegment;
     numUserAreaSegments = udSize->totalSegments;
+    arrayId = iArrayInfo->GetIndex();
     isUT = false;
 }
 

--- a/src/allocator/address/allocator_address_info.h
+++ b/src/allocator/address/allocator_address_info.h
@@ -52,6 +52,7 @@ public:
     virtual uint32_t GetblksPerSegment(void) { return blksPerSegment; }
     virtual uint32_t GetstripesPerSegment(void) { return stripesPerSegment; }
     virtual uint32_t GetnumUserAreaSegments(void) { return numUserAreaSegments; }
+    virtual int GetArrayId(void) { return arrayId; }
 
     void SetblksPerStripe(uint32_t value) { blksPerStripe = value; }
     void SetchunksPerStripe(uint32_t value) { chunksPerStripe = value; }
@@ -60,6 +61,7 @@ public:
     void SetblksPerSegment(uint32_t value) { blksPerSegment = value; }
     void SetstripesPerSegment(uint32_t value) { stripesPerSegment = value; }
     void SetnumUserAreaSegments(uint32_t value) { numUserAreaSegments = value; }
+    void SetArrayId(int id) { arrayId = id; }
     void SetUT(bool ut) { isUT = ut; }
     virtual bool IsUT(void) { return isUT; }
 
@@ -71,6 +73,7 @@ private:
     uint32_t blksPerSegment;
     uint32_t stripesPerSegment;
     uint32_t numUserAreaSegments;
+    int arrayId;
     bool isUT;
 };
 

--- a/src/allocator/context_manager/allocator_ctx/allocator_ctx.cpp
+++ b/src/allocator/context_manager/allocator_ctx/allocator_ctx.cpp
@@ -48,23 +48,18 @@ namespace pos
 AllocatorCtx::AllocatorCtx(TelemetryPublisher* tp_, AllocatorCtxHeader* header, BitMapMutex* allocWbLsidBitmap_, AllocatorAddressInfo* info_)
 : ctxStoredVersion(0),
   ctxDirtyVersion(0),
+  initialized(false),
   addrInfo(info_),
-  tp(tp_),
-  initialized(false)
+  tp(tp_)
 {
-    ctxHeader.sig = SIG_ALLOCATOR_CTX;
-    ctxHeader.numValidWbLsid = 0;
-    ctxHeader.ctxVersion = 0;
-    currentSsdLsid = 0;
+    currentSsdLsid.data = 0;
 
     if (header != nullptr)
     {
-        ctxHeader.sig = header->sig;
-        ctxHeader.numValidWbLsid = header->numValidWbLsid;
-        ctxHeader.ctxVersion = header->ctxVersion;
+        ctxHeader.data = *header;
     }
 
-    allocWbLsidBitmap = allocWbLsidBitmap_;
+    allocWbLsidBitmap.data = allocWbLsidBitmap_;
 }
 
 AllocatorCtx::AllocatorCtx(TelemetryPublisher* tp_, AllocatorAddressInfo* info)
@@ -85,18 +80,54 @@ AllocatorCtx::Init(void)
         return;
     }
 
-    allocWbLsidBitmap = new BitMapMutex(addrInfo->GetnumWbStripes());
-    POS_TRACE_DEBUG(EID(ALLOCATOR_INFO), "Init bitmap, allocWbBitmapNumBits: {}, allocWbBitmapNumBits: {}", allocWbLsidBitmap->GetNumBitsSet(), allocWbLsidBitmap->GetNumEntry());
+    if (allocWbLsidBitmap.data == nullptr)
+    {
+        allocWbLsidBitmap.data = new BitMapMutex(addrInfo->GetnumWbStripes());
+        POS_TRACE_DEBUG(EID(ALLOCATOR_INFO),
+            "Init bitmap, allocWbBitmapNumBits: {}, allocWbBitmapNumBits: {}", 
+            allocWbLsidBitmap.data->GetNumBitsSet(), allocWbLsidBitmap.data->GetNumEntry());
+    }
+
     for (ASTailArrayIdx asTailArrayIdx = 0; asTailArrayIdx < ACTIVE_STRIPE_TAIL_ARRAYLEN; ++asTailArrayIdx)
     {
-        activeStripeTail[asTailArrayIdx] = UNMAP_VSA;
+        activeStripeTail.data[asTailArrayIdx] = UNMAP_VSA;
     }
-    currentSsdLsid = STRIPES_PER_SEGMENT - 1;
+    currentSsdLsid.data = STRIPES_PER_SEGMENT - 1;
 
-    ctxHeader.ctxVersion = 0;
+    ctxHeader.data.ctxVersion = 0;
     ctxStoredVersion = 0;
     ctxDirtyVersion = 0;
+
+    _UpdateSectionInfo();
+
     initialized = true;
+}
+
+void
+AllocatorCtx::_UpdateSectionInfo(void)
+{
+    uint64_t currentOffset = 0;
+
+    // AC_HEADER
+    ctxHeader.InitAddressInfoWithItsData(currentOffset);
+    currentOffset += ctxHeader.GetSectionSize();
+
+    // AC_CURRENT_SSD_LSID
+    currentSsdLsid.InitAddressInfoWithItsData(currentOffset);
+    currentOffset += currentSsdLsid.GetSectionSize();
+
+    // AC_ALLOCATE_WBLSID_BITMAP
+    allocWbLsidBitmap.InitAddressInfo(
+        (char*)(allocWbLsidBitmap.data->GetMapAddr()),
+        currentOffset,
+        allocWbLsidBitmap.data->GetNumEntry() * BITMAP_ENTRY_SIZE);
+    currentOffset += allocWbLsidBitmap.GetSectionSize();
+
+    // AC_ACTIVE_STRIPE_TAIL
+    activeStripeTail.InitAddressInfoWithItsData(currentOffset);
+    currentOffset += activeStripeTail.GetSectionSize();
+
+    totalDataSize = currentOffset;
 }
 
 void
@@ -107,10 +138,10 @@ AllocatorCtx::Dispose(void)
         return;
     }
 
-    if (allocWbLsidBitmap != nullptr)
+    if (allocWbLsidBitmap.data != nullptr)
     {
-        delete allocWbLsidBitmap;
-        allocWbLsidBitmap = nullptr;
+        delete allocWbLsidBitmap.data;
+        allocWbLsidBitmap.data = nullptr;
     }
 
     initialized = false;
@@ -119,137 +150,122 @@ AllocatorCtx::Dispose(void)
 void
 AllocatorCtx::SetNextSsdLsid(SegmentId segId)
 {
-    currentSsdLsid = segId * addrInfo->GetstripesPerSegment();
+    currentSsdLsid.data = segId * addrInfo->GetstripesPerSegment();
 }
 
 void
 AllocatorCtx::SetCurrentSsdLsid(StripeId stripe)
 {
-    currentSsdLsid = stripe;
+    currentSsdLsid.data = stripe;
 }
 
 StripeId
 AllocatorCtx::GetCurrentSsdLsid(void)
 {
-    return currentSsdLsid;
+    return currentSsdLsid.data;
 }
 
 void
 AllocatorCtx::AfterLoad(char* buf)
 {
-    POS_TRACE_DEBUG(EID(ALLOCATOR_FILE_ERROR), "AllocatorCtx file loaded:{}", ctxHeader.ctxVersion);
-    ctxStoredVersion = ctxHeader.ctxVersion;
-    ctxDirtyVersion = ctxHeader.ctxVersion + 1;
+    AllocatorCtxHeader* header = reinterpret_cast<AllocatorCtxHeader*>(buf);
+    assert(header->sig == SIG_ALLOCATOR_CTX);
 
-    AllocatorCtxHeader* header = (AllocatorCtxHeader*)buf;
-    allocWbLsidBitmap->SetNumBitsSet(header->numValidWbLsid);
+    // AC_HEADER
+    ctxHeader.CopyFrom(buf);
+
+    // AC_CURRENT_SSD_LSID
+    currentSsdLsid.CopyFrom(buf);
+
+    // AC_ALLOCATE_WBLSID_BITMAP
+    allocWbLsidBitmap.CopyFrom(buf);
+
+    // AC_ACTIVE_STRIPE_TAIL
+    activeStripeTail.CopyFrom(buf);
+
+    POS_TRACE_DEBUG(EID(ALLOCATOR_FILE_ERROR), "AllocatorCtx file loaded:{}", ctxHeader.data.ctxVersion);
+    ctxStoredVersion = ctxHeader.data.ctxVersion;
+    ctxDirtyVersion = ctxHeader.data.ctxVersion + 1;
+
+    allocWbLsidBitmap.data->SetNumBitsSet(header->numValidWbLsid);
 }
 
 void
 AllocatorCtx::BeforeFlush(char* buf)
 {
-    char* currentPtr = buf;
+    std::lock_guard<std::mutex> lock(allocCtxLock);
 
     // AC_HEADER
-    ctxHeader.ctxVersion = ctxDirtyVersion++;
-    AllocatorCtxHeader* header = (AllocatorCtxHeader*)currentPtr;
-    header->numValidWbLsid = allocWbLsidBitmap->GetNumBitsSetWoLock();
-    currentPtr += GetSectionSize(AC_HEADER);
+    ctxHeader.data.ctxVersion = ctxDirtyVersion++;
+    ctxHeader.data.numValidWbLsid = allocWbLsidBitmap.data->GetNumBitsSetWoLock();
+
+    ctxHeader.CopyTo(buf);
+
+    // AC_CURRENT_SSD_LSID
+    currentSsdLsid.CopyTo(buf);
 
     // AC_ALLOCATE_WBLSID_BITMAP
     {
-        std::lock_guard<std::mutex> lock(allocWbLsidBitmap->GetLock());
-        memcpy(currentPtr, GetSectionAddr(AC_ALLOCATE_WBLSID_BITMAP), GetSectionSize(AC_ALLOCATE_WBLSID_BITMAP));
+        std::lock_guard<std::mutex> lock(allocWbLsidBitmap.data->GetLock());
+        allocWbLsidBitmap.CopyTo(buf);
     }
-    currentPtr += GetSectionSize(AC_ALLOCATE_WBLSID_BITMAP);
 
     // AC_ACTIVE_STRIPE_TAIL
-    for (int index = 0; index < ACTIVE_STRIPE_TAIL_ARRAYLEN; index++)
+    for (auto index = 0; index < ACTIVE_STRIPE_TAIL_ARRAYLEN; index++)
     {
-        std::unique_lock<std::mutex> volLock(activeStripeTailLock[index]);
-        int offset = sizeof(VirtualBlkAddr) * index;
-        memcpy(currentPtr + offset, &activeStripeTail[index], sizeof(VirtualBlkAddr));
+        std::lock_guard<std::mutex> lock(activeStripeTailLock[index]);
+        activeStripeTail.CopyToListElement(buf, index);
     }
-    currentPtr += GetSectionSize(AC_ACTIVE_STRIPE_TAIL);
 }
-
 void
-AllocatorCtx::FinalizeIo(char* buf)
+AllocatorCtx::AfterFlush(char* buf)
 {
-    ctxStoredVersion = (reinterpret_cast<AllocatorCtxHeader*>(buf))->ctxVersion;
+    AllocatorCtxHeader* header = reinterpret_cast<AllocatorCtxHeader*>(buf);
+    assert(header->sig == SIG_ALLOCATOR_CTX);
+
+    ctxStoredVersion = header->ctxVersion;
+
+    POS_TRACE_DEBUG(EID(ALLOCATOR_DEBUG),
+        "AllocatorCtx stored, array_id: {}, context_version: {}",
+        addrInfo->GetArrayId(), ctxStoredVersion);
 }
 
-char*
-AllocatorCtx::GetSectionAddr(int section)
+ContextSectionAddr
+AllocatorCtx::GetSectionInfo(int section)
 {
-    char* ret = nullptr;
-    switch (section)
+    if (section == AC_HEADER)
     {
-        case AC_HEADER:
-        {
-            ret = (char*)&ctxHeader;
-            break;
-        }
-        case AC_CURRENT_SSD_LSID:
-        {
-            ret = (char*)&currentSsdLsid;
-            break;
-        }
-        case AC_ALLOCATE_WBLSID_BITMAP:
-        {
-            ret = (char*)allocWbLsidBitmap->GetMapAddr();
-            break;
-        }
-        case AC_ACTIVE_STRIPE_TAIL:
-        {
-            ret = (char*)activeStripeTail;
-            break;
-        }
+        return ctxHeader.GetSectionInfo();
     }
-    return ret;
-}
-
-int
-AllocatorCtx::GetSectionSize(int section)
-{
-    int ret = 0;
-    switch (section)
+    else if (section == AC_CURRENT_SSD_LSID)
     {
-        case AC_HEADER:
-        {
-            ret = sizeof(AllocatorCtxHeader);
-            break;
-        }
-        case AC_CURRENT_SSD_LSID:
-        {
-            ret = sizeof(currentSsdLsid);
-            break;
-        }
-        case AC_ALLOCATE_WBLSID_BITMAP:
-        {
-            ret = allocWbLsidBitmap->GetNumEntry() * BITMAP_ENTRY_SIZE;
-            break;
-        }
-        case AC_ACTIVE_STRIPE_TAIL:
-        {
-            ret = sizeof(activeStripeTail);
-            break;
-        }
+        return currentSsdLsid.GetSectionInfo();
     }
-    return ret;
+    else if (section == AC_ALLOCATE_WBLSID_BITMAP)
+    {
+        return allocWbLsidBitmap.GetSectionInfo();
+    }
+    else if (section == AC_ACTIVE_STRIPE_TAIL)
+    {
+        return activeStripeTail.GetSectionInfo();
+    }
+    else
+    {
+        assert(false);
+    }
 }
 
 void
 AllocatorCtx::AllocWbStripe(StripeId stripeId)
 {
-    allocWbLsidBitmap->SetBit(stripeId);
+    allocWbLsidBitmap.data->SetBit(stripeId);
 }
 
 StripeId
 AllocatorCtx::AllocFreeWbStripe(void)
 {
-    StripeId stripe = allocWbLsidBitmap->SetNextZeroBit();
-    if (allocWbLsidBitmap->IsValidBit(stripe) == false)
+    StripeId stripe = allocWbLsidBitmap.data->SetNextZeroBit();
+    if (allocWbLsidBitmap.data->IsValidBit(stripe) == false)
     {
         stripe = UNMAP_STRIPE;
     }
@@ -259,25 +275,59 @@ AllocatorCtx::AllocFreeWbStripe(void)
 void
 AllocatorCtx::ReleaseWbStripe(StripeId stripeId)
 {
-    allocWbLsidBitmap->ClearBit(stripeId);
+    allocWbLsidBitmap.data->ClearBit(stripeId);
 }
 
 void
 AllocatorCtx::SetAllocatedWbStripeCount(int count)
 {
-    allocWbLsidBitmap->SetNumBitsSet(count);
+    allocWbLsidBitmap.data->SetNumBitsSet(count);
 }
 
 uint64_t
 AllocatorCtx::GetAllocatedWbStripeCount(void)
 {
-    return allocWbLsidBitmap->GetNumBitsSet();
+    return allocWbLsidBitmap.data->GetNumBitsSet();
 }
 
 uint64_t
 AllocatorCtx::GetNumTotalWbStripe(void)
 {
-    return allocWbLsidBitmap->GetNumBits();
+    return allocWbLsidBitmap.data->GetNumBits();
+}
+
+void
+AllocatorCtx::CopyContextSectionToBufferforWBT(int sectionId, char* dstBuf)
+{
+    if (sectionId == AC_CURRENT_SSD_LSID)
+    {
+        currentSsdLsid.CopyTo(dstBuf);
+    }
+    else if (sectionId == AC_ALLOCATE_WBLSID_BITMAP)
+    {
+        allocWbLsidBitmap.CopyTo(dstBuf);
+    }
+    else if (sectionId == AC_ACTIVE_STRIPE_TAIL)
+    {
+        activeStripeTail.CopyTo(dstBuf);
+    }
+}
+
+void
+AllocatorCtx::CopyContextSectionFromBufferforWBT(int sectionId, char* srcBuf)
+{
+    if (sectionId == AC_CURRENT_SSD_LSID)
+    {
+        currentSsdLsid.CopyFrom(srcBuf);
+    }
+    else if (sectionId == AC_ALLOCATE_WBLSID_BITMAP)
+    {
+        allocWbLsidBitmap.CopyFrom(srcBuf);
+    }
+    else if (sectionId == AC_ACTIVE_STRIPE_TAIL)
+    {
+        activeStripeTail.CopyFrom(srcBuf);
+    }
 }
 
 std::vector<VirtualBlkAddr>
@@ -286,7 +336,7 @@ AllocatorCtx::GetAllActiveStripeTail(void)
     std::vector<VirtualBlkAddr> asTails;
     for (ASTailArrayIdx asTailArrayIdx = 0; asTailArrayIdx < ACTIVE_STRIPE_TAIL_ARRAYLEN; ++asTailArrayIdx)
     {
-        asTails.push_back(activeStripeTail[asTailArrayIdx]);
+        asTails.push_back(activeStripeTail.data[asTailArrayIdx]);
     }
     return asTails;
 }
@@ -294,13 +344,13 @@ AllocatorCtx::GetAllActiveStripeTail(void)
 VirtualBlkAddr
 AllocatorCtx::GetActiveStripeTail(ASTailArrayIdx asTailArrayIdx)
 {
-    return activeStripeTail[asTailArrayIdx];
+    return activeStripeTail.data[asTailArrayIdx];
 }
 
 void
 AllocatorCtx::SetActiveStripeTail(ASTailArrayIdx asTailArrayIdx, VirtualBlkAddr vsa)
 {
-    activeStripeTail[asTailArrayIdx] = vsa;
+    activeStripeTail.data[asTailArrayIdx] = vsa;
 }
 
 std::mutex&
@@ -321,21 +371,16 @@ AllocatorCtx::ResetDirtyVersion(void)
     ctxDirtyVersion = 0;
 }
 
-std::string
-AllocatorCtx::GetFilename(void)
-{
-    return "AllocatorContexts";
-}
-
-uint32_t
-AllocatorCtx::GetSignature(void)
-{
-    return SIG_ALLOCATOR_CTX;
-}
-
 int
 AllocatorCtx::GetNumSections(void)
 {
     return NUM_ALLOCATOR_CTX_SECTION;
+}
+
+uint64_t
+AllocatorCtx::GetTotalDataSize(void)
+{
+    return ctxHeader.GetSectionSize() + currentSsdLsid.GetSectionSize()
+        + allocWbLsidBitmap.GetSectionSize() + activeStripeTail.GetSectionSize();
 }
 }  // namespace pos

--- a/src/allocator/context_manager/context/context.h
+++ b/src/allocator/context_manager/context/context.h
@@ -1,0 +1,151 @@
+/*
+*   BSD LICENSE
+*   Copyright (c) 2022 Samsung Electronics Corporation
+*   All rights reserved.
+*
+*   Redistribution and use in source and binary forms, with or without
+*   modification, are permitted provided that the following conditions
+*   are met:
+*
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in
+*       the documentation and/or other materials provided with the
+*       distribution.
+*     * Neither the name of Samsung Electronics Corporation nor the names of
+*       its contributors may be used to endorse or promote products derived
+*       from this software without specific prior written permission.
+*
+*   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "src/allocator/include/allocator_const.h"
+#include "src/include/address_type.h"
+
+namespace pos
+{
+enum FileOwner
+{
+    SEGMENT_CTX,
+    ALLOCATOR_CTX,
+    NUM_ALLOCATOR_FILES,
+    REBUILD_CTX = NUM_ALLOCATOR_FILES,
+    NUM_FILES
+};
+
+constexpr auto
+ToFilename(FileOwner owner)
+{
+    const char* names[] = {
+        "SegmentContext",
+        "AllocatorContexts",
+        "RebuildContext"};
+    return names[owner];
+}
+
+enum SegmentCtxSection
+{
+    SC_HEADER = 0,
+    SC_SEGMENT_INFO,
+    NUM_SEGMENT_CTX_SECTION,
+};
+
+enum AllocatorCtxSection
+{
+    AC_HEADER = 0,
+    AC_CURRENT_SSD_LSID,
+    AC_ALLOCATE_WBLSID_BITMAP,
+    AC_ACTIVE_STRIPE_TAIL,
+    NUM_ALLOCATOR_CTX_SECTION,
+};
+
+enum RebuildCtxSection
+{
+    RC_HEADER = 0,
+    RC_REBUILD_SEGMENT_LIST,
+    NUM_REBUILD_CTX_SECTION
+};
+
+constexpr int
+WbtTypeToAllocatorSectionId(WBTAllocatorMetaType type)
+{
+    if (type == WBT_CURRENT_SSD_LSID)
+        return AC_CURRENT_SSD_LSID;
+    else if (type == WBT_WBLSID_BITMAP)
+        return AC_ALLOCATE_WBLSID_BITMAP;
+    else if (type == WBT_ACTIVE_STRIPE_TAIL)
+        return AC_ACTIVE_STRIPE_TAIL;
+    else
+        return -1; // should not reach here
+}
+
+static const uint32_t SIG_SEGMENT_CTX = 0xAFAFAFAF;
+static const uint32_t SIG_ALLOCATOR_CTX = 0xBFBFBFBF;
+static const uint32_t SIG_REBUILD_CTX = 0xCFCFCFCF;
+
+struct CtxHeader
+{
+    uint32_t sig;
+    uint64_t ctxVersion;
+
+    CtxHeader(uint32_t signature): sig(signature), ctxVersion(0) {}
+};
+
+struct AllocatorCtxHeader : CtxHeader
+{
+    uint32_t numValidWbLsid = 0;
+
+    AllocatorCtxHeader(void): CtxHeader(SIG_ALLOCATOR_CTX) {}
+};
+
+struct SegmentCtxHeader : CtxHeader
+{
+    uint32_t numValidSegment = 0;
+
+    SegmentCtxHeader(void): CtxHeader(SIG_SEGMENT_CTX) {}
+};
+
+struct RebuildCtxHeader : CtxHeader
+{
+    uint32_t numTargetSegments = 0;
+
+    RebuildCtxHeader(void): CtxHeader(SIG_REBUILD_CTX) {}
+};
+
+struct ContextSectionAddr
+{
+    uint64_t offset = 0;
+    uint64_t size = 0;
+};
+
+const int INVALID_CONTEXT_ID = -1;
+const int INVALID_SECTION_ID = -1;
+
+struct ContextSectionBuffer
+{
+    int owner;
+    int sectionId;
+    char* buffer;
+};
+
+static const ContextSectionBuffer INVALID_CONTEXT_SECTION_BUFFER = {
+    .owner = INVALID_CONTEXT_ID,
+    .sectionId = INVALID_SECTION_ID,
+    .buffer = nullptr};
+} // namespace pos

--- a/src/allocator/context_manager/context_io_manager.h
+++ b/src/allocator/context_manager/context_io_manager.h
@@ -36,7 +36,6 @@
 #include "src/allocator/context_manager/allocator_file_io.h"
 #include "src/allocator/context_manager/rebuild_ctx/rebuild_ctx.h"
 #include "src/allocator/context_manager/segment_ctx/segment_ctx.h"
-#include "src/allocator/include/allocator_const.h"
 #include "src/event_scheduler/event_scheduler.h"
 
 namespace pos
@@ -65,20 +64,18 @@ public:
     virtual void Dispose(void);
 
     virtual int FlushContexts(EventSmartPtr callback, bool sync,
-        char* externalBuf = nullptr);
+        ContextSectionBuffer externalBuf);
 
     virtual void WaitPendingIo(IOTYPE type);
 
     virtual uint64_t GetStoredContextVersion(int owner);
-
-    virtual char* GetContextSectionAddr(int owner, int section);
     virtual int GetContextSectionSize(int owner, int section);
 
 private:
     void _FlushCompleted(void);
 
-    int _GetNumFilesReading(void);
-    int _GetNumFilesFlushing(void);
+    int _GetTotalNumOutstandingRead(void);
+    int _GetTotalNumOutstandingFlush(void);
     int _GetNumRebuildFlush(void);
     uint32_t _GetPendingIoCount(uint32_t checkType);
 

--- a/src/allocator/context_manager/context_manager.h
+++ b/src/allocator/context_manager/context_manager.h
@@ -88,7 +88,6 @@ public:
     virtual uint64_t GetStoredContextVersion(int owner);
 
     virtual int SetNextSsdLsid(void);
-    virtual char* GetContextSectionAddr(int owner, int section);
     virtual int GetContextSectionSize(int owner, int section);
 
     virtual RebuildCtx* GetRebuildCtx(void) { return rebuildCtx; }

--- a/src/allocator/context_manager/context_replayer.cpp
+++ b/src/allocator/context_manager/context_replayer.cpp
@@ -37,8 +37,8 @@
 
 #include "src/allocator/address/allocator_address_info.h"
 #include "src/allocator/context_manager/allocator_ctx/allocator_ctx.h"
+#include "src/allocator/context_manager/context/context.h"
 #include "src/allocator/context_manager/segment_ctx/segment_ctx.h"
-#include "src/allocator/include/allocator_const.h"
 #include "src/include/pos_event_id.h"
 #include "src/logger/logger.h"
 

--- a/src/allocator/context_manager/i_allocator_file_io_client.h
+++ b/src/allocator/context_manager/i_allocator_file_io_client.h
@@ -35,7 +35,7 @@
 #include <mutex>
 #include <string>
 
-#include "src/allocator/include/allocator_const.h"
+#include "src/allocator/context_manager/context/context.h"
 #include "src/meta_file_intf/async_context.h"
 
 namespace pos
@@ -45,15 +45,12 @@ class IAllocatorFileIoClient
 public:
     virtual void AfterLoad(char* buf) = 0;
     virtual void BeforeFlush(char* buf) = 0;
-    virtual std::mutex& GetCtxLock(void) = 0;
-    virtual void FinalizeIo(char* buf) = 0;
-    virtual char* GetSectionAddr(int section) = 0;
-    virtual int GetSectionSize(int section) = 0;
+    virtual void AfterFlush(char* buf) = 0;
+    virtual ContextSectionAddr GetSectionInfo(int section) = 0;
     virtual uint64_t GetStoredVersion(void) = 0;
     virtual void ResetDirtyVersion(void) = 0;
-    virtual std::string GetFilename(void) = 0;
-    virtual uint32_t GetSignature(void) = 0;
     virtual int GetNumSections(void) = 0;
+    virtual uint64_t GetTotalDataSize(void) = 0;
 };
 
 } // namespace pos

--- a/src/allocator/i_context_manager.h
+++ b/src/allocator/i_context_manager.h
@@ -35,9 +35,9 @@
 #include <mutex>
 #include <vector>
 
-#include "src/allocator/include/allocator_const.h"
-#include "src/allocator/context_manager/segment_ctx/segment_ctx.h"
+#include "src/allocator/context_manager/context/context.h"
 #include "src/allocator/context_manager/gc_ctx/gc_ctx.h"
+#include "src/allocator/context_manager/segment_ctx/segment_ctx.h"
 #include "src/journal_manager/log_buffer/versioned_segment_ctx.h"
 
 namespace pos

--- a/src/allocator/i_context_replayer.h
+++ b/src/allocator/i_context_replayer.h
@@ -32,10 +32,9 @@
 
 #pragma once
 
-#include <mutex>
 #include <vector>
 
-#include "src/allocator/include/allocator_const.h"
+#include "src/include/address_type.h"
 
 namespace pos
 {

--- a/src/allocator/include/allocator_const.h
+++ b/src/allocator/include/allocator_const.h
@@ -34,7 +34,6 @@
 
 #include <cstdint>
 #include <set>
-#include <string>
 
 #include "src/include/address_type.h"
 #include "src/volume/volume_list.h"
@@ -46,39 +45,6 @@ using RTSegmentIter = std::set<SegmentId>::iterator;
 
 const int ACTIVE_STRIPE_TAIL_ARRAYLEN = MAX_VOLUME_COUNT;
 
-enum FileOwner
-{
-    SEGMENT_CTX,
-    ALLOCATOR_CTX,
-    NUM_ALLOCATOR_FILES,
-    REBUILD_CTX = NUM_ALLOCATOR_FILES,
-    NUM_FILES
-};
-
-enum SegmentCtxSection
-{
-    SC_HEADER = 0,
-    SC_SEGMENT_INFO,
-    NUM_SEGMENT_CTX_SECTION,
-};
-
-enum AllocatorCtxSection
-{
-    AC_HEADER = 0,
-    AC_CURRENT_SSD_LSID,
-    NUM_ALLOCATION_INFO,
-    AC_ALLOCATE_WBLSID_BITMAP = NUM_ALLOCATION_INFO,
-    AC_ACTIVE_STRIPE_TAIL,
-    NUM_ALLOCATOR_CTX_SECTION,
-};
-
-enum RebuildCtxSection
-{
-    RC_HEADER = 0,
-    RC_REBUILD_SEGMENT_LIST,
-    NUM_REBUILD_CTX_SECTION
-};
-
 enum WBTAllocatorMetaType
 {
     WBT_CURRENT_SSD_LSID,
@@ -89,31 +55,6 @@ enum WBTAllocatorMetaType
     WBT_SEGMENT_VALID_COUNT,
     WBT_SEGMENT_OCCUPIED_STRIPE,
     WBT_NUM_ALLOCATOR_META
-};
-
-class CtxHeader
-{
-public:
-    uint32_t sig;
-    uint64_t ctxVersion;
-};
-
-class AllocatorCtxHeader : public CtxHeader
-{
-public:
-    uint32_t numValidWbLsid;
-};
-
-class SegmentCtxHeader : public CtxHeader
-{
-public:
-    uint32_t numValidSegment;
-};
-
-class RebuildCtxHeader : public CtxHeader
-{
-public:
-    uint32_t numTargetSegments;
 };
 
 enum GcMode

--- a/src/event/pos_event.yaml
+++ b/src/event/pos_event.yaml
@@ -4285,7 +4285,7 @@ Root:
     Solution: but it's not the rebuilding target.
   -
     Id: 3199
-    Name: ALLOCATOR_RESERVED
+    Name: ALLOCATOR_WBT_WRONG_PARAMETER
     Severity:
     Description:
     Cause:
@@ -4313,7 +4313,7 @@ Root:
     Solution:
   -
     Id: 3203
-    Name: ALLOCATOR_FILE_IO_INITIALIZED
+    Name: RESERVED
     Severity:
     Description:
     Cause:
@@ -4446,9 +4446,9 @@ Root:
     Solution: none
   -
     Id: 3222
-    Name: SUCCEED_TO_OPEN_WITHOUT_CREATION
+    Name: RESERVED
     Severity:
-    Description: succeeded to open a meta file existed already
+    Description:
     Cause: none
     Solution: none
   # Metadata: 3300 - 3399
@@ -4476,6 +4476,13 @@ Root:
   -
     Id: 3303
     Name: META_STRIPE_FAILED_TO_ASSIGN
+    Severity:
+    Description:
+    Cause:
+    Solution:
+  -
+    Id: 3304
+    Name: META_FILE_INTF_INITIALIZED
     Severity:
     Description:
     Cause:

--- a/src/meta_file_intf/meta_file_intf.h
+++ b/src/meta_file_intf/meta_file_intf.h
@@ -82,18 +82,18 @@ public:
     virtual int IssueIO(MetaFsIoOpcode opType, uint64_t fileOffset, uint64_t length, char* buffer);
     virtual int AppendIO(MetaFsIoOpcode opType, uint64_t& offset, uint64_t length, char* buffer);
 
+    static MetaFileIntf* CreateFileIntf(std::string filename, int arrayId, MetaFileType type);
+
 protected:
     virtual int _Read(int fd, uint64_t fileOffset, uint64_t length, char* buffer) = 0;
     virtual int _Write(int fd, uint64_t fileOffset, uint64_t length, char* buffer) = 0;
 
     std::string fileName;
     int arrayId;
-    uint64_t size;
     bool isOpened;
     int fd;
     MetaFileType fileType;
     MetaVolumeType volumeType;
     MetaFilePropertySet fileProperty;
 };
-
 } // namespace pos

--- a/src/meta_file_intf/mock_file_intf.h
+++ b/src/meta_file_intf/mock_file_intf.h
@@ -65,6 +65,8 @@ private:
     void _MockAsyncIo(AsyncMetaFileIoCtx* ctx);
     void _MockAsyncRead(AsyncMetaFileIoCtx* ctx);
     void _MockAsyncWrite(AsyncMetaFileIoCtx* ctx);
+
+    uint64_t size;
 };
 
 } // namespace pos

--- a/src/meta_file_intf/rocksdb_metafs_intf.h
+++ b/src/meta_file_intf/rocksdb_metafs_intf.h
@@ -92,6 +92,8 @@ private:
     virtual int _AsyncIORead(AsyncMetaFileIoCtx* ctx);
     rocksdb::DB* rocksMeta;
     FileDescriptorAllocator* fileDescriptorAllocator;
+    uint64_t size;
+
     inline std::string
     _MakeRocksDbKey(FileDescriptorType fd, FileOffsetType offset)
     {

--- a/src/metafs/metafs_file_intf.cpp
+++ b/src/metafs/metafs_file_intf.cpp
@@ -214,8 +214,6 @@ MetaFsFileIntf::Create(uint64_t fileSize)
         return -(int)rc;
     }
 
-    size = fileSize;
-
     return (int)rc;
 }
 

--- a/test/integration-tests/allocator/address/allocator_address_info_tester.h
+++ b/test/integration-tests/allocator/address/allocator_address_info_tester.h
@@ -38,5 +38,6 @@ public:
     MOCK_METHOD(uint32_t, GetblksPerStripe, ());
     MOCK_METHOD(uint32_t, GetnumWbStripes, ());
     MOCK_METHOD(uint32_t, GetnumUserAreaStripes, ());
+    MOCK_METHOD(int, GetArrayId, ());
 };
 }

--- a/test/integration-tests/journal/fake/i_context_replayer_mock.h
+++ b/test/integration-tests/journal/fake/i_context_replayer_mock.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "src/allocator/i_context_replayer.h"
+#include "src/allocator/include/allocator_const.h"
 
 namespace pos
 {

--- a/test/integration-tests/journal/fake/i_segment_ctx_fake.cpp
+++ b/test/integration-tests/journal/fake/i_segment_ctx_fake.cpp
@@ -52,6 +52,7 @@ ISegmentCtxFake::ISegmentCtxFake(AllocatorAddressInfo* addrInfo, MetaFileIntf* s
   segmentContextFile(segmentContextFile)
 {
     numSegments = addrInfo->GetnumUserAreaSegments();
+    segmentContextWriteDone = false;
     segmentContextReadDone = false;
     isFlushedBefore = false;
     ctxStoredVersion = 0;

--- a/test/integration-tests/segmentCtx/segment_ctx_tester.h
+++ b/test/integration-tests/segmentCtx/segment_ctx_tester.h
@@ -22,7 +22,9 @@ public:
         rebuildContext = new NiceMock<MockRebuildCtx>;
         tp = new NiceMock<MockTelemetryPublisher>;
 
-        realCtx = new SegmentCtx(tp, rebuildContext, addressInfo, gcContext, arrayId, nullptr);;
+        ON_CALL(*addressInfo, GetArrayId).WillByDefault(Return(arrayId));
+
+        realCtx = new SegmentCtx(tp, rebuildContext, addressInfo, gcContext, nullptr);
 
         MakeStubs();
     };

--- a/test/unit-tests/allocator/address/allocator_address_info_mock.h
+++ b/test/unit-tests/allocator/address/allocator_address_info_mock.h
@@ -22,6 +22,7 @@ public:
     MOCK_METHOD(uint32_t, GetblksPerSegment, (), (override));
     MOCK_METHOD(uint32_t, GetstripesPerSegment, (), (override));
     MOCK_METHOD(uint32_t, GetnumUserAreaSegments, (), (override));
+    MOCK_METHOD(int, GetArrayId, (), (override));
     MOCK_METHOD(bool, IsUT, (), (override));
 };
 } // namespace pos

--- a/test/unit-tests/allocator/context_manager/allocator_ctx/allocator_ctx_mock.h
+++ b/test/unit-tests/allocator/context_manager/allocator_ctx/allocator_ctx_mock.h
@@ -14,14 +14,10 @@ public:
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(void, AfterLoad, (char* buf), (override));
     MOCK_METHOD(void, BeforeFlush, (char* buf), (override));
-    MOCK_METHOD(std::mutex&, GetCtxLock, (), (override));
-    MOCK_METHOD(void, FinalizeIo, (char* buf), (override));
-    MOCK_METHOD(char*, GetSectionAddr, (int section), (override));
-    MOCK_METHOD(int, GetSectionSize, (int section), (override));
+    MOCK_METHOD(void, AfterFlush, (char* buf), (override));
+    MOCK_METHOD(ContextSectionAddr, GetSectionInfo, (int section), (override));
     MOCK_METHOD(uint64_t, GetStoredVersion, (), (override));
     MOCK_METHOD(void, ResetDirtyVersion, (), (override));
-    MOCK_METHOD(std::string, GetFilename, (), (override));
-    MOCK_METHOD(uint32_t, GetSignature, (), (override));
     MOCK_METHOD(int, GetNumSections, (), (override));
     MOCK_METHOD(void, SetCurrentSsdLsid, (StripeId stripe), (override));
     MOCK_METHOD(StripeId, GetCurrentSsdLsid, (), (override));
@@ -33,6 +29,7 @@ public:
     MOCK_METHOD(uint64_t, GetAllocatedWbStripeCount, (), (override));
     MOCK_METHOD(uint64_t, GetNumTotalWbStripe, (), (override));
     MOCK_METHOD(std::vector<VirtualBlkAddr>, GetAllActiveStripeTail, (), (override));
+    MOCK_METHOD(std::mutex&, GetCtxLock, (), (override));
     MOCK_METHOD(VirtualBlkAddr, GetActiveStripeTail, (ASTailArrayIdx asTailArrayIdx), (override));
     MOCK_METHOD(void, SetActiveStripeTail, (ASTailArrayIdx asTailArrayIdx, VirtualBlkAddr vsa), (override));
     MOCK_METHOD(std::mutex&, GetActiveStripeTailLock, (ASTailArrayIdx asTailArrayIdx), (override));

--- a/test/unit-tests/allocator/context_manager/allocator_file_io_mock.h
+++ b/test/unit-tests/allocator/context_manager/allocator_file_io_mock.h
@@ -13,12 +13,11 @@ public:
     MOCK_METHOD(void, Init, (), (override));
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(int, LoadContext, (), (override));
-    MOCK_METHOD(int, Flush, (FnAllocatorCtxIoCompletion clientCallback, int dstSectionId, char* externalBuf), (override));
+    MOCK_METHOD(int, Flush, (FnAllocatorCtxIoCompletion clientCallback, ContextSectionBuffer externalBuf), (override));
     MOCK_METHOD(uint64_t, GetStoredVersion, (), (override));
-    MOCK_METHOD(char*, GetSectionAddr, (int section), (override));
     MOCK_METHOD(int, GetSectionSize, (int section), (override));
-    MOCK_METHOD(int, GetNumFilesReading, (), (override));
-    MOCK_METHOD(int, GetNumFilesFlushing, (), (override));
+    MOCK_METHOD(int, GetNumOutstandingRead, (), (override));
+    MOCK_METHOD(int, GetNumOutstandingFlush, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/allocator/context_manager/context_io_manager_mock.h
+++ b/test/unit-tests/allocator/context_manager/context_io_manager_mock.h
@@ -12,10 +12,9 @@ public:
     using ContextIoManager::ContextIoManager;
     MOCK_METHOD(int, Init, (), (override));
     MOCK_METHOD(void, Dispose, (), (override));
-    MOCK_METHOD(int, FlushContexts, (EventSmartPtr callback, bool sync, char* externalBuf), (override));
+    MOCK_METHOD(int, FlushContexts, (EventSmartPtr callback, bool sync, ContextSectionBuffer externalBuf), (override));
     MOCK_METHOD(void, WaitPendingIo, (IOTYPE type), (override));
     MOCK_METHOD(uint64_t, GetStoredContextVersion, (int owner), (override));
-    MOCK_METHOD(char*, GetContextSectionAddr, (int owner, int section), (override));
     MOCK_METHOD(int, GetContextSectionSize, (int owner, int section), (override));
 };
 

--- a/test/unit-tests/allocator/context_manager/context_manager_mock.h
+++ b/test/unit-tests/allocator/context_manager/context_manager_mock.h
@@ -27,7 +27,6 @@ public:
     MOCK_METHOD(int, GetGcThreshold, (GcMode mode), (override));
     MOCK_METHOD(uint64_t, GetStoredContextVersion, (int owner), (override));
     MOCK_METHOD(int, SetNextSsdLsid, (), (override));
-    MOCK_METHOD(char*, GetContextSectionAddr, (int owner, int section), (override));
     MOCK_METHOD(int, GetContextSectionSize, (int owner, int section), (override));
     MOCK_METHOD(RebuildCtx*, GetRebuildCtx, (), (override));
     MOCK_METHOD(SegmentCtx*, GetSegmentCtx, (), (override));

--- a/test/unit-tests/allocator/context_manager/context_manager_test.cpp
+++ b/test/unit-tests/allocator/context_manager/context_manager_test.cpp
@@ -305,27 +305,6 @@ TEST(ContextManager, NeedRebuildAgain_TestSimpleByPassFunc)
     EXPECT_EQ(true, ret);
 }
 
-TEST(ContextManager, GetContextSectionAddr_TestSimpleGetter)
-{
-    // given
-    NiceMock<MockAllocatorCtx>* allocCtx = new NiceMock<MockAllocatorCtx>();
-    NiceMock<MockSegmentCtx>* segCtx = new NiceMock<MockSegmentCtx>();
-    NiceMock<MockRebuildCtx>* reCtx = new NiceMock<MockRebuildCtx>();
-    NiceMock<MockGcCtx>* gcCtx = new NiceMock<MockGcCtx>();
-    NiceMock<MockBlockAllocationStatus>* blockAllocStatus = new NiceMock<MockBlockAllocationStatus>();
-    NiceMock<MockContextIoManager>* ioManager = new NiceMock<MockContextIoManager>;
-    NiceMock<MockTelemetryPublisher> tc;
-    ContextManager ctxManager(&tc, allocCtx, segCtx, reCtx, nullptr, gcCtx, blockAllocStatus, ioManager, nullptr, nullptr, 0);
-
-    EXPECT_CALL(*ioManager, GetContextSectionAddr).WillOnce(Return((char*)100));
-
-    // when
-    char* ret = ctxManager.GetContextSectionAddr(0, 0);
-
-    // then
-    EXPECT_EQ((char*)100, ret);
-}
-
 TEST(ContextManager, GetContextSectionSize_TestSimpleGetter)
 {
     // given
@@ -624,19 +603,19 @@ TEST(ContextManager, FlushContexts_testIfCallbackHasNullptr)
     });
 
     ON_CALL(*segmentFileIo, Flush)
-        .WillByDefault([&](FnAllocatorCtxIoCompletion completion, int dstSectionId, char* externalBuf)
+        .WillByDefault([&](FnAllocatorCtxIoCompletion completion, ContextSectionBuffer externalBuf)
         {
             completion();
             return 0;
         });
     ON_CALL(*allocatorFileIo, Flush)
-        .WillByDefault([&](FnAllocatorCtxIoCompletion completion, int dstSectionId, char* externalBuf)
+        .WillByDefault([&](FnAllocatorCtxIoCompletion completion, ContextSectionBuffer externalBuf)
         {
             completion();
             return 0;
         });
     ON_CALL(*rebuildFileIo, Flush)
-        .WillByDefault([&](FnAllocatorCtxIoCompletion completion, int dstSectionId, char* externalBuf)
+        .WillByDefault([&](FnAllocatorCtxIoCompletion completion, ContextSectionBuffer externalBuf)
         {
             completion();
             return 0;

--- a/test/unit-tests/allocator/context_manager/i_allocator_file_io_client_mock.h
+++ b/test/unit-tests/allocator/context_manager/i_allocator_file_io_client_mock.h
@@ -12,15 +12,12 @@ public:
     using IAllocatorFileIoClient::IAllocatorFileIoClient;
     MOCK_METHOD(void, AfterLoad, (char* buf), (override));
     MOCK_METHOD(void, BeforeFlush, (char* buf), (override));
-    MOCK_METHOD(std::mutex&, GetCtxLock, (), (override));
-    MOCK_METHOD(void, FinalizeIo, (char* buf), (override));
-    MOCK_METHOD(char*, GetSectionAddr, (int section), (override));
-    MOCK_METHOD(int, GetSectionSize, (int section), (override));
+    MOCK_METHOD(void, AfterFlush, (char* buf), (override));
+    MOCK_METHOD(ContextSectionAddr, GetSectionInfo, (int section), (override));
     MOCK_METHOD(uint64_t, GetStoredVersion, (), (override));
     MOCK_METHOD(void, ResetDirtyVersion, (), (override));
-    MOCK_METHOD(std::string, GetFilename, (), (override));
-    MOCK_METHOD(uint32_t, GetSignature, (), (override));
     MOCK_METHOD(int, GetNumSections, (), (override));
+    MOCK_METHOD(uint64_t, GetTotalDataSize, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/allocator/context_manager/i_allocator_file_io_client_test.cpp
+++ b/test/unit-tests/allocator/context_manager/i_allocator_file_io_client_test.cpp
@@ -12,11 +12,7 @@ TEST(IAllocatorFileIoClient, BeforeFlush_)
 {
 }
 
-TEST(IAllocatorFileIoClient, FinalizeIo_)
-{
-}
-
-TEST(IAllocatorFileIoClient, GetSectionAddr_)
+TEST(IAllocatorFileIoClient, AfterFlush_)
 {
 }
 

--- a/test/unit-tests/allocator/context_manager/rebuild_ctx/rebuild_ctx_mock.h
+++ b/test/unit-tests/allocator/context_manager/rebuild_ctx/rebuild_ctx_mock.h
@@ -16,14 +16,10 @@ public:
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(void, AfterLoad, (char* buf), (override));
     MOCK_METHOD(void, BeforeFlush, (char* buf), (override));
-    MOCK_METHOD(std::mutex&, GetCtxLock, (), (override));
-    MOCK_METHOD(void, FinalizeIo, (char* buf), (override));
-    MOCK_METHOD(char*, GetSectionAddr, (int section), (override));
-    MOCK_METHOD(int, GetSectionSize, (int section), (override));
+    MOCK_METHOD(void, AfterFlush, (char* buf), (override));
+    MOCK_METHOD(ContextSectionAddr, GetSectionInfo, (int section), (override));
     MOCK_METHOD(uint64_t, GetStoredVersion, (), (override));
     MOCK_METHOD(void, ResetDirtyVersion, (), (override));
-    MOCK_METHOD(std::string, GetFilename, (), (override));
-    MOCK_METHOD(uint32_t, GetSignature, (), (override));
     MOCK_METHOD(int, GetNumSections, (), (override));
     MOCK_METHOD(int, FlushRebuildSegmentList, (std::set<SegmentId> segIdSet), (override));
     MOCK_METHOD(std::set<SegmentId>, GetList, (), (override));

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_mock.h
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_mock.h
@@ -20,14 +20,10 @@ public:
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(void, AfterLoad, (char* buf), (override));
     MOCK_METHOD(void, BeforeFlush, (char* buf), (override));
-    MOCK_METHOD(std::mutex&, GetCtxLock, (), (override));
-    MOCK_METHOD(void, FinalizeIo, (char* buf), (override));
-    MOCK_METHOD(char*, GetSectionAddr, (int section), (override));
-    MOCK_METHOD(int, GetSectionSize, (int section), (override));
+    MOCK_METHOD(void, AfterFlush, (char* buf), (override));
+    MOCK_METHOD(ContextSectionAddr, GetSectionInfo, (int section), (override));
     MOCK_METHOD(uint64_t, GetStoredVersion, (), (override));
     MOCK_METHOD(void, ResetDirtyVersion, (), (override));
-    MOCK_METHOD(std::string, GetFilename, (), (override));
-    MOCK_METHOD(uint32_t, GetSignature, (), (override));
     MOCK_METHOD(int, GetNumSections, (), (override));
     MOCK_METHOD(void, MoveToFreeState, (SegmentId segId), (override));
     MOCK_METHOD(uint32_t, GetValidBlockCount, (SegmentId segId), (override));

--- a/test/unit-tests/journal_manager/replay/active_wb_stripe_replayer_test.cpp
+++ b/test/unit-tests/journal_manager/replay/active_wb_stripe_replayer_test.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "active_wb_stripe_replayer_spy.h"
+#include "src/allocator/include/allocator_const.h"
 #include "test/unit-tests/allocator/i_context_replayer_mock.h"
 #include "test/unit-tests/allocator/i_wbstripe_allocator_mock.h"
 #include "test/unit-tests/array_models/interface/i_array_info_mock.h"


### PR DESCRIPTION
Allocator File I/O와 각 Allocator Context 의 관계를 리팩토링 했습니다.

이번 리팩토링의 포인트는..
"Buffer Address와 memcpy 동작을 Context 내부로 옮겨, private member variable의 주소와 lock을 노출하지 않도록 수정"
한 것 입니다.

변경점이 많아 수정하면서 만든 작은 commit을 그대로 두었는데, 커밋단위로 보시면 더 편하실지 모르겠습니다..;_; 
(머지는 스쿼시해서 넣을 예정입니다)