### PR TITLE
[AWIBOF-8105] Remove lock on the Segment Context Updater

### DIFF
--- a/script/pkgdep.sh
+++ b/script/pkgdep.sh
@@ -81,6 +81,8 @@ if [ -f /etc/debian_version ]; then
     apt install -y libasan4-dbg
     # for crc
     apt install -y libboost-dev
+    apt install -y libboost-system-dev 
+    apt install -y libboost-thread-dev 
     # for opentelemetry
     apt install -y libssl-dev
 

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -151,7 +151,7 @@ VersionedSegmentCtx::_UpdateSegmentContext(int logGroupId)
     _CheckLogGroupIdValidity(logGroupId);
 
     shared_ptr<VersionedSegmentInfo> targetSegInfo = segmentInfoDiffs[logGroupId];
-    tbb::concurrent_unordered_map<SegmentId, int> changedValidBlkCount = targetSegInfo->GetChangedValidBlockCount();
+    tbb::concurrent_unordered_map<SegmentId, tbb::atomic<int>> changedValidBlkCount = targetSegInfo->GetChangedValidBlockCount();
     for (auto it = changedValidBlkCount.begin(); it != changedValidBlkCount.end(); it++)
     {
         auto segmentId = it->first;
@@ -175,7 +175,7 @@ VersionedSegmentCtx::_UpdateSegmentContext(int logGroupId)
         }
     }
 
-    tbb::concurrent_unordered_map<SegmentId, uint32_t> changedOccupiedCount = targetSegInfo->GetChangedOccupiedStripeCount();
+    tbb::concurrent_unordered_map<SegmentId, tbb::atomic<uint32_t>> changedOccupiedCount = targetSegInfo->GetChangedOccupiedStripeCount();
     for (auto it = changedOccupiedCount.begin(); it != changedOccupiedCount.end(); it++)
     {
         auto segmentId = it->first;

--- a/src/journal_manager/log_buffer/versioned_segment_info.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_info.cpp
@@ -54,19 +54,19 @@ VersionedSegmentInfo::Reset(void)
 void
 VersionedSegmentInfo::IncreaseValidBlockCount(SegmentId segId, uint32_t cnt)
 {
-    changedValidBlockCount[segId] += cnt;
+    changedValidBlockCount[segId].fetch_and_add(cnt);
 }
 
 void
 VersionedSegmentInfo::DecreaseValidBlockCount(SegmentId segId, uint32_t cnt)
 {
-    changedValidBlockCount[segId] -= cnt;
+    changedValidBlockCount[segId].fetch_and_add(-1 * (int)cnt);
 }
 
 void
 VersionedSegmentInfo::IncreaseOccupiedStripeCount(SegmentId segId)
 {
-    changedOccupiedStripeCount[segId]++;
+    changedOccupiedStripeCount[segId].fetch_and_add(1);
 }
 
 void
@@ -81,13 +81,13 @@ VersionedSegmentInfo::ResetValidBlockCount(SegmentId segId)
     changedValidBlockCount[segId] = 0;
 }
 
-tbb::concurrent_unordered_map<SegmentId, int>
+const tbb::concurrent_unordered_map<SegmentId, tbb::atomic<int>>& 
 VersionedSegmentInfo::GetChangedValidBlockCount(void)
 {
     return this->changedValidBlockCount;
 }
 
-tbb::concurrent_unordered_map<SegmentId, uint32_t>
+const tbb::concurrent_unordered_map<SegmentId, tbb::atomic<uint32_t>>& 
 VersionedSegmentInfo::GetChangedOccupiedStripeCount(void)
 {
     return this->changedOccupiedStripeCount;

--- a/src/journal_manager/log_buffer/versioned_segment_info.h
+++ b/src/journal_manager/log_buffer/versioned_segment_info.h
@@ -35,6 +35,7 @@
 #include <atomic>
 #include "src/include/address_type.h"
 #include "tbb/concurrent_unordered_map.h"
+#include "tbb/atomic.h"
 
 namespace pos
 {
@@ -51,12 +52,12 @@ public:
     virtual void ResetOccupiedStripeCount(SegmentId segId);
     virtual void ResetValidBlockCount(SegmentId segId);
     
-    virtual tbb::concurrent_unordered_map<SegmentId, int> GetChangedValidBlockCount(void);
-    virtual tbb::concurrent_unordered_map<SegmentId, uint32_t> GetChangedOccupiedStripeCount(void);
+    virtual const tbb::concurrent_unordered_map<SegmentId, tbb::atomic<int>>&  GetChangedValidBlockCount(void);
+    virtual const tbb::concurrent_unordered_map<SegmentId, tbb::atomic<uint32_t>>&  GetChangedOccupiedStripeCount(void);
 
 private:
-    tbb::concurrent_unordered_map<SegmentId, int> changedValidBlockCount;
-    tbb::concurrent_unordered_map<SegmentId, uint32_t> changedOccupiedStripeCount;
+    tbb::concurrent_unordered_map<SegmentId, tbb::atomic<int>> changedValidBlockCount;
+    tbb::concurrent_unordered_map<SegmentId, tbb::atomic<uint32_t>> changedOccupiedStripeCount;
 };
 
 } // namespace pos

--- a/src/metadata/segment_context_updater.cpp
+++ b/src/metadata/segment_context_updater.cpp
@@ -43,43 +43,35 @@ SegmentContextUpdater::SegmentContextUpdater(ISegmentCtx* segmentCtx_, IVersione
   activeSegmentCtx(segmentCtx_),
   versionedContext(versionedContext_)
 {
-    pthread_rwlock_init(&lock, nullptr);
 }
 
 SegmentContextUpdater::~SegmentContextUpdater(void)
 {
-    pthread_rwlock_destroy(&lock);
 }
 
 void
 SegmentContextUpdater::ValidateBlocksWithGroupId(VirtualBlks blks, int logGroupId)
 {
-    pthread_rwlock_wrlock(&lock);
     activeSegmentCtx->ValidateBlks(blks);
     SegmentId segmentId = blks.startVsa.stripeId / addrInfo->stripesPerSegment;
     versionedContext->IncreaseValidBlockCount(logGroupId, segmentId, blks.numBlks);
-    pthread_rwlock_unlock(&lock);
 }
 
 bool
 SegmentContextUpdater::InvalidateBlocksWithGroupId(VirtualBlks blks, bool isForced, int logGroupId)
 {
-    pthread_rwlock_wrlock(&lock);
     SegmentId segmentId = blks.startVsa.stripeId / addrInfo->stripesPerSegment;
     bool ret = activeSegmentCtx->InvalidateBlks(blks, isForced);
     versionedContext->DecreaseValidBlockCount(logGroupId, segmentId, blks.numBlks);
-    pthread_rwlock_unlock(&lock);
     return ret;
 }
 
 bool
 SegmentContextUpdater::UpdateOccupiedStripeCountWithGroupId(StripeId lsid, int logGroupId)
 {
-    pthread_rwlock_wrlock(&lock);
     SegmentId segmentId = lsid / addrInfo->stripesPerSegment;
     bool ret = activeSegmentCtx->UpdateOccupiedStripeCount(lsid);
     versionedContext->IncreaseOccupiedStripeCount(logGroupId, segmentId);
-    pthread_rwlock_unlock(&lock);
     return ret;
 }
 

--- a/src/metadata/segment_context_updater.h
+++ b/src/metadata/segment_context_updater.h
@@ -55,7 +55,6 @@ private:
     const PartitionLogicalSize* addrInfo;
     ISegmentCtx* activeSegmentCtx;
     IVersionedSegmentContext* versionedContext;
-    pthread_rwlock_t lock;
 };
 
 } // namespace pos

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -493,7 +493,7 @@ SET(DEP_LIBRARIES
     stdc++fs
     isal
 )
-
+find_package(Boost COMPONENTS system thread REQUIRED)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PROTOBUF REQUIRED protobuf)
 pkg_check_modules(GRPC REQUIRED grpc++)
@@ -501,7 +501,7 @@ pkg_check_modules(GRPC REQUIRED grpc++)
 list(APPEND DEP_LIBRARIES opentelemetry_common opentelemetry_trace opentelemetry_exporter_otlp_http opentelemetry_exporter_otlp_http_client opentelemetry_otlp_recordable opentelemetry_proto opentelemetry_resources opentelemetry_http_client_curl pthread curl)
 list(APPEND DEP_LIBRARIES ${PROTOBUF_LIBRARIES} ${GRPC_LIBRARIES})
 list(APPEND DEP_LIBRARIES grpc++_reflection)
-
+list(APPEND DEP_LIBRARIES boost_system boost_thread)
 
 # For on-demand execution
 add_custom_target(

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_info_mock.h
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_info_mock.h
@@ -49,8 +49,8 @@ public:
     MOCK_METHOD(void, IncreaseValidBlockCount, (SegmentId segId, uint32_t cnt), (override));
     MOCK_METHOD(void, DecreaseValidBlockCount, (SegmentId segId, uint32_t cnt), (override));
     MOCK_METHOD(void, IncreaseOccupiedStripeCount, (SegmentId segId), (override));
-    MOCK_METHOD((tbb::concurrent_unordered_map<SegmentId, int>), GetChangedValidBlockCount, (), (override));
-    MOCK_METHOD((tbb::concurrent_unordered_map<SegmentId, uint32_t>), GetChangedOccupiedStripeCount, (), (override));
+    MOCK_METHOD((const tbb::concurrent_unordered_map<SegmentId, tbb::atomic<int>>&), GetChangedValidBlockCount, (), (override));
+    MOCK_METHOD((const tbb::concurrent_unordered_map<SegmentId, tbb::atomic<uint32_t>>&), GetChangedOccupiedStripeCount, (), (override));
     MOCK_METHOD(void, ResetOccupiedStripeCount, (SegmentId segId), (override));
     MOCK_METHOD(void, ResetValidBlockCount, (SegmentId segId), (override));
 };


### PR DESCRIPTION
- Changed variables in Versioned Segment Context Info to atomic
- Added unit test to modify Versioned Segment Context Info on multi-thread