### PR TITLE
[AWIBOF-8118] Add replay task to load Versieond Segment Context from updated segment context

### DIFF
--- a/src/journal_manager/journal_manager.cpp
+++ b/src/journal_manager/journal_manager.cpp
@@ -490,17 +490,7 @@ JournalManager::_InitModules(TelemetryClient* tc, IVSAMap* vsaMap, IStripeMap* s
         sequenceController, dirtyMapManager, versionedSegCtx, telemetryPublisher);
 
     const PartitionLogicalSize* udSize = arrayInfo->GetSizeInfo(PartitionType::USER_DATA);
-
-    SegmentInfoData* loadedSegmentInfos = nullptr;
-    if (nullptr != contextManager)
-    {
-        SegmentCtx* loadedSegmentCtx = contextManager->GetSegmentCtx();
-        if (nullptr != loadedSegmentCtx)
-        {
-            loadedSegmentInfos = loadedSegmentCtx->GetSegmentInfoDataArray();
-        }
-    }
-    versionedSegCtx->Init(config, loadedSegmentInfos, udSize->totalSegments);
+    versionedSegCtx->Init(config, udSize->totalSegments);
 
     logWriteContextFactory->Init(config);
     logBufferIoContextFactory->Init(config, logFilledNotifier, sequenceController);
@@ -522,7 +512,7 @@ JournalManager::_InitModules(TelemetryClient* tc, IVSAMap* vsaMap, IStripeMap* s
         config, contextManager, eventScheduler);
     journalWriter->Init(logWriteHandler, logWriteContextFactory, eventFactory, &journalingStatus, eventScheduler);
 
-    replayHandler->Init(config, logBuffer, vsaMap, stripeMap, mapFlush, segmentCtx,
+    replayHandler->Init(config, logBuffer, vsaMap, stripeMap, mapFlush, segmentCtx, versionedSegCtx,
         wbStripeAllocator, contextManager, contextReplayer, arrayInfo, volumeManager, telemetryPublisher);
 
     statusProvider->Init(bufferAllocator, config, logGroupReleaser);

--- a/src/journal_manager/log_buffer/i_versioned_segment_context.h
+++ b/src/journal_manager/log_buffer/i_versioned_segment_context.h
@@ -48,7 +48,8 @@ class IVersionedSegmentContext: public LogBufferWriteDoneEvent, public ISegmentF
 public:
     virtual ~IVersionedSegmentContext(void) = default;
 
-    virtual void Init(JournalConfiguration* journalConfiguration, SegmentInfoData* loadedSegmentInfos, uint32_t numSegments) = 0;
+    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments) = 0;
+    virtual void Load(SegmentInfoData* loadedSegmentInfos) = 0;
     virtual void Dispose(void) = 0;
     virtual void IncreaseValidBlockCount(int logGroupId, SegmentId segId, uint32_t cnt) = 0;
     virtual void DecreaseValidBlockCount(int logGroupId, SegmentId segId, uint32_t cnt) = 0;
@@ -58,7 +59,7 @@ public:
     virtual int GetNumLogGroups(void) = 0;
 
     // For UT
-    virtual void Init(JournalConfiguration* journalConfiguration, SegmentInfoData* loadedSegmentInfo, uint32_t numSegments,
+    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments,
         std::vector<std::shared_ptr<VersionedSegmentInfo>> inputVersionedSegmentInfo) = 0;
 };
 

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -55,9 +55,9 @@ VersionedSegmentCtx::~VersionedSegmentCtx(void)
 }
 
 void
-VersionedSegmentCtx::Init(JournalConfiguration* journalConfiguration, SegmentInfoData* loadedSegmentInfo, uint32_t numSegments_)
+VersionedSegmentCtx::Init(JournalConfiguration* journalConfiguration, uint32_t numSegments_)
 {
-    _Init(journalConfiguration, loadedSegmentInfo, numSegments_);
+    _Init(journalConfiguration, numSegments_);
 
     for (int index = 0; index < config->GetNumLogGroups(); index++)
     {
@@ -67,17 +67,17 @@ VersionedSegmentCtx::Init(JournalConfiguration* journalConfiguration, SegmentInf
 }
 
 void
-VersionedSegmentCtx::Init(JournalConfiguration* journalConfiguration, SegmentInfoData* loadedSegmentInfo, uint32_t numSegments_,
+VersionedSegmentCtx::Init(JournalConfiguration* journalConfiguration, uint32_t numSegments_,
     std::vector<std::shared_ptr<VersionedSegmentInfo>> inputVersionedSegmentInfo)
 {
-    _Init(journalConfiguration, loadedSegmentInfo, numSegments_);
+    _Init(journalConfiguration, numSegments_);
 
     assert((int)inputVersionedSegmentInfo.size() == config->GetNumLogGroups());
     segmentInfoDiffs = inputVersionedSegmentInfo;
 }
 
 void
-VersionedSegmentCtx::_Init(JournalConfiguration* journalConfiguration, SegmentInfoData* loadedSegmentInfo, uint32_t numSegments_)
+VersionedSegmentCtx::_Init(JournalConfiguration* journalConfiguration, uint32_t numSegments_)
 {
     config = journalConfiguration;
 
@@ -85,26 +85,31 @@ VersionedSegmentCtx::_Init(JournalConfiguration* journalConfiguration, SegmentIn
     segmentInfoData = new SegmentInfoData[numSegments];
     for (uint32_t segId = 0; segId < numSegments; segId++)
     {
-        if (loadedSegmentInfo != nullptr)
-        {
-            segmentInfoData[segId].validBlockCount = loadedSegmentInfo[segId].validBlockCount.load();
-            segmentInfoData[segId].occupiedStripeCount = loadedSegmentInfo[segId].occupiedStripeCount.load();
-            segmentInfoData[segId].state = loadedSegmentInfo[segId].state;
+        segmentInfoData[segId].Set(0, 0, SegmentState::FREE);
+    }
+}
 
-            if (nullptr != loadedSegmentInfo)
-            {
-                POS_TRACE_INFO(EID(JOURNAL_MANAGER_INITIALIZED), "Loaded segment: segId {}, validcnt {}, stripeCnt {}, state {}",
-                    segId, loadedSegmentInfo[segId].validBlockCount,
-                    loadedSegmentInfo[segId].occupiedStripeCount,
-                    loadedSegmentInfo[segId].state);
-            }
-        }
-        else
+void
+VersionedSegmentCtx::Load(SegmentInfoData* loadedSegmentInfos)
+{
+    if (nullptr != loadedSegmentInfos)
+    {
+        for (uint32_t segId = 0; segId < numSegments; segId++)
         {
-            // For Unit Test
-            // Test should provide loadedSegmentInfo, but some are not, so initialize it here temporally
-            segmentInfoData[segId].Set(0, 0, SegmentState::FREE);
+            segmentInfoData[segId].validBlockCount = loadedSegmentInfos[segId].validBlockCount.load();
+            segmentInfoData[segId].occupiedStripeCount = loadedSegmentInfos[segId].occupiedStripeCount.load();
+            segmentInfoData[segId].state = loadedSegmentInfos[segId].state;
+            POS_TRACE_INFO(EID(JOURNAL_MANAGER_INITIALIZED), "Loaded segment: segId {}, validcnt {}, stripeCnt {}, state {}",
+                segId, loadedSegmentInfos[segId].validBlockCount,
+                loadedSegmentInfos[segId].occupiedStripeCount,
+                loadedSegmentInfos[segId].state);
         }
+    }
+    else
+    {
+        // For Unit Test
+        // Test should provide loadedSegmentInfo, but some are not, so initialize it here temporally
+        POS_TRACE_INFO(EID(JOURNAL_MANAGER_INITIALIZED), "Unable to load Versioned Segment Context because a loaded segment context does not exist.");
     }
 }
 

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.h
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.h
@@ -51,7 +51,8 @@ public:
     DummyVersionedSegmentCtx(void) = default;
     virtual ~DummyVersionedSegmentCtx(void) = default;
 
-    virtual void Init(JournalConfiguration* journalConfiguration, SegmentInfoData* loadedSegmentInfos, uint32_t numSegments) override {}
+    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments) override {}
+    virtual void Load(SegmentInfoData* loadedSegmentInfos) override {}
     virtual void Dispose(void) override {}
     virtual void IncreaseValidBlockCount(int logGroupId, SegmentId segId, uint32_t cnt) override {}
     virtual void DecreaseValidBlockCount(int logGroupId, SegmentId segId, uint32_t cnt) override {}
@@ -59,7 +60,7 @@ public:
     virtual SegmentInfoData* GetUpdatedInfoDataToFlush(int logGroupId) override { return nullptr; }
     virtual int GetNumSegments(void) override { return 0; }
     virtual int GetNumLogGroups(void) override { return 0; };
-    virtual void Init(JournalConfiguration* journalConfiguration, SegmentInfoData* loadedSegmentInfo, uint32_t numSegments,
+    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments,
         std::vector<std::shared_ptr<VersionedSegmentInfo>> inputVersionedSegmentInfo) override {}
 
     // LogBufferWriteDoneEvent
@@ -76,11 +77,12 @@ public:
     VersionedSegmentCtx(void);
     virtual ~VersionedSegmentCtx(void);
 
-    virtual void Init(JournalConfiguration* journalConfiguration, SegmentInfoData* loadedSegmentInfos, uint32_t numSegments) override;
+    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments) override;
+    virtual void Load(SegmentInfoData* loadedSegmentInfos) override;
     virtual void Dispose(void) override;
 
     // For UT
-    virtual void Init(JournalConfiguration* journalConfiguration, SegmentInfoData* loadedSegmentInfo, uint32_t numSegments,
+    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments,
         std::vector<std::shared_ptr<VersionedSegmentInfo>> inputVersionedSegmentInfo);
 
     // Implementation of IVersionedSegmentContext interface
@@ -100,7 +102,7 @@ public:
     virtual void NotifySegmentFreed(SegmentId segmentId) override;
 
 private:
-    void _Init(JournalConfiguration* journalConfiguration, SegmentInfoData* loadedSegmentInfo, uint32_t numSegments_);
+    void _Init(JournalConfiguration* journalConfiguration, uint32_t numSegments_);
     void _UpdateSegmentContext(int logGroupId);
     void _CheckLogGroupIdValidity(int logGroupId);
     void _CheckSegIdValidity(int segId);

--- a/src/journal_manager/replay/load_replayed_segment_context.h
+++ b/src/journal_manager/replay/load_replayed_segment_context.h
@@ -31,50 +31,28 @@
  */
 
 #pragma once
-#include <map>
 
-#include "src/journal_manager/replay/task_progress.h"
+#include "replay_task.h"
 
 namespace pos
 {
-enum class ReplayTaskId
-{
-    READ_LOG_BUFFER,
-    FILTER_LOGS,
-    REPLAY_LOGS,
-    REPLAY_VOLUME_DELETION,
-    FLUSH_METADATA,
-    RESET_LOG_BUFFER,
-    FLUSH_PENDING_STRIPES,
-    LOAD_REPLAYED_SEGMENT_CONTEXT
-};
+class SegmentCtx;
+class IVersionedSegmentContext;
 
-class ReplayProgressReporter
+class LoadReplayedSegmentContext : public ReplayTask
 {
 public:
-    ReplayProgressReporter(void);
-    virtual ~ReplayProgressReporter(void) = default;
-    virtual void RegisterTask(ReplayTaskId taskId, int taskWeight);
-    void TaskStarted(ReplayTaskId taskId, int numSubTasks);
-    void SubTaskCompleted(ReplayTaskId taskId, int numCompleted = 1);
-    void TaskCompleted(ReplayTaskId taskId);
+    LoadReplayedSegmentContext(SegmentCtx* segmentCtx, IVersionedSegmentContext* versionedSegCtx, ReplayProgressReporter* reporter);
+    virtual ~LoadReplayedSegmentContext(void);
 
-    void CompleteAll(void);
-
-    int GetProgress(void);
-    int GetReportedProgress(void);
-    int GetTotalWeight(void);
-    const TaskProgress GetTaskProgress(ReplayTaskId taskId);
+    virtual int Start(void) override;
+    virtual ReplayTaskId GetId(void);
+    virtual int GetWeight(void) override;
+    virtual int GetNumSubTasks(void) override;
 
 private:
-    void _ReportProgress(void);
-
-    std::map<ReplayTaskId, TaskProgress> taskProgressList;
-    int totalWeight;
-
-    int progress;
-    int currentTaskProgress;
-    int reportedProgress;
+    SegmentCtx* segmentCtx;
+    IVersionedSegmentContext* versionedSegCtx;
 };
 
 } // namespace pos

--- a/src/journal_manager/replay/replay_handler.h
+++ b/src/journal_manager/replay/replay_handler.h
@@ -55,23 +55,25 @@ class IVSAMap;
 class IStripeMap;
 class IMapFlush;
 class ISegmentCtx;
+class IVersionedSegmentContext;
 class IWBStripeAllocator;
 class IContextManager;
 class IContextReplayer;
 class IArrayInfo;
 class IVolumeInfoManager;
 class TelemetryPublisher;
-
 class ReplayHandler
 {
 public:
     ReplayHandler(void) = default;
     explicit ReplayHandler(IStateControl* iState);
+    explicit ReplayHandler(IStateControl* iState, LogDeleteChecker* logDeleteChecker, ReplayProgressReporter* reporter);
+
     virtual ~ReplayHandler(void);
 
     virtual void Init(JournalConfiguration* journalConfiguration,
         IJournalLogBuffer* journalLogBuffer, IVSAMap* vsaMap, IStripeMap* stripeMap,
-        IMapFlush* mapFlush, ISegmentCtx* segmentCtx,
+        IMapFlush* mapFlush, ISegmentCtx* segmentCtx, IVersionedSegmentContext* versionedSegCtx,
         IWBStripeAllocator* wbStripeAllocator, IContextManager* contextManager,
         IContextReplayer* contextReplayer, IArrayInfo* arrayInfo, IVolumeInfoManager* volumeManager, TelemetryPublisher* tp);
     virtual void Dispose(void);
@@ -80,7 +82,7 @@ public:
 
 private:
     void _InitializeTaskList(IVSAMap* vsaMap, IStripeMap* stripeMap,
-        IMapFlush* mapFlush, ISegmentCtx* segmentCtx,
+        IMapFlush* mapFlush, ISegmentCtx* segmentCtx, IVersionedSegmentContext* versionedSegCtx,
         IWBStripeAllocator* wbStripeAllocator, IContextManager* contextManager,
         IContextReplayer* contextReplayer, IArrayInfo* arrayInfo, IVolumeInfoManager* volumeManager);
     void _AddTask(ReplayTask* task);

--- a/src/journal_manager/replay/replay_progress_reporter.cpp
+++ b/src/journal_manager/replay/replay_progress_reporter.cpp
@@ -53,6 +53,7 @@ ReplayProgressReporter::RegisterTask(ReplayTaskId taskId, int taskWeight)
     TaskProgress progress(taskWeight);
     taskProgressList.emplace(taskId, progress);
 
+    // TODO (cheolho.kang): Add the task weight table to manage the weight per task while keeping the weight total at 100.
     totalWeight += taskWeight;
 }
 

--- a/test/integration-tests/allocator/context_manager_integration_test.cpp
+++ b/test/integration-tests/allocator/context_manager_integration_test.cpp
@@ -73,8 +73,6 @@ protected:
     JournalManager* journal;
     SegmentInfoData* segInfoDataForSegCtx;
     SegmentCtx* segCtx;
-    SegmentInfo* loadedSegInfos;
-    SegmentInfoData* loadedSegInfoDataForSegCtx;
     ContextManager* ctxManager;
     CheckpointHandler* cpHandler;
 
@@ -174,14 +172,6 @@ ContextManagerIntegrationTest::SetUp(void)
         nullptr, dirtyMapManager, logFilledNotifier,
         callbackSequenceController, replayHandler, arrayInfo, tp);
 
-    loadedSegInfos = new SegmentInfo[numOfSegment];
-    loadedSegInfoDataForSegCtx = new SegmentInfoData[numOfSegment];
-    for(int i=0;i<numOfSegment;++i)
-    {
-        loadedSegInfoDataForSegCtx[i].Set(0, 0, SegmentState::FREE);
-        loadedSegInfos[i].AllocateAndInitSegmentInfoData(&loadedSegInfoDataForSegCtx[i]);
-    }
-
     ctxManager = new ContextManager(tp, allocCtx, segCtx, reCtx,
         gcCtx, blockAllocStatus, ioManager, nullptr, nullptr, 0);
 
@@ -197,9 +187,6 @@ ContextManagerIntegrationTest::SetUp(void)
 void
 ContextManagerIntegrationTest::TearDown(void)
 {
-    delete [] loadedSegInfos;
-    delete [] loadedSegInfoDataForSegCtx;
-
     if (nullptr != arrayInfo)
     {
         delete arrayInfo;

--- a/test/unit-tests/journal_manager/log_buffer/i_versioned_segment_context_mock.h
+++ b/test/unit-tests/journal_manager/log_buffer/i_versioned_segment_context_mock.h
@@ -12,7 +12,8 @@ class MockIVersionedSegmentContext : public IVersionedSegmentContext
 {
 public:
     using IVersionedSegmentContext::IVersionedSegmentContext;
-    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, SegmentInfoData* loadedSegmentInfos, uint32_t numSegments), (override));
+    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments), (override));
+    MOCK_METHOD(void, Load, (SegmentInfoData* loadedSegmentInfos), (override));
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(void, IncreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));
     MOCK_METHOD(void, DecreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));
@@ -20,7 +21,7 @@ public:
     MOCK_METHOD(int, GetNumSegments, (), (override));
     MOCK_METHOD(int, GetNumLogGroups, (), (override));
     MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (int logGroupId), (override));
-    MOCK_METHOD(void, Init, (JournalConfiguration* journalConfiguration, SegmentInfoData* loadedSegmentInfo, uint32_t numSegments,
+    MOCK_METHOD(void, Init, (JournalConfiguration* journalConfiguration, uint32_t numSegments,
         std::vector<std::shared_ptr<VersionedSegmentInfo>> inputVersionedSegmentInfo), (override));
     MOCK_METHOD(void, LogFilled, (int logGroupId, const MapList& dirty), (override));
     MOCK_METHOD(void, LogBufferReseted, (int logGroupId), (override));

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_mock.h
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_mock.h
@@ -42,7 +42,8 @@ class MockDummyVersionedSegmentCtx : public DummyVersionedSegmentCtx
 {
 public:
     using DummyVersionedSegmentCtx::DummyVersionedSegmentCtx;
-    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, SegmentInfoData* loadedSegmentInfos, uint32_t numSegments), (override));
+    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments), (override));
+    MOCK_METHOD(void, Load, (SegmentInfoData* loadedSegmentInfos), (override));
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(void, IncreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));
     MOCK_METHOD(void, DecreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));
@@ -59,7 +60,8 @@ class MockVersionedSegmentCtx : public VersionedSegmentCtx
 {
 public:
     using VersionedSegmentCtx::VersionedSegmentCtx;
-    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, SegmentInfoData* loadedSegmentInfos, uint32_t numSegments), (override));
+    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments), (override));
+    MOCK_METHOD(void, Load, (SegmentInfoData* loadedSegmentInfos), (override));
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(void, IncreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));
     MOCK_METHOD(void, DecreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));
@@ -67,7 +69,7 @@ public:
     MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (int logGroupId), (override));
     MOCK_METHOD(int, GetNumSegments, (), (override));
     MOCK_METHOD(int, GetNumLogGroups, (), (override));
-    MOCK_METHOD(void, Init, (JournalConfiguration* journalConfiguration, SegmentInfoData* loadedSegmentInfo, uint32_t numSegments,
+    MOCK_METHOD(void, Init, (JournalConfiguration* journalConfiguration, uint32_t numSegments,
         std::vector<std::shared_ptr<VersionedSegmentInfo>> inputVersionedSegmentInfo), (override));
     MOCK_METHOD(void, LogFilled, (int logGroupId, const MapList& dirty), (override));
     MOCK_METHOD(void, LogBufferReseted, (int logGroupId), (override));

--- a/test/unit-tests/journal_manager/replay/replay_handler_mock.h
+++ b/test/unit-tests/journal_manager/replay/replay_handler_mock.h
@@ -10,7 +10,7 @@ class MockReplayHandler : public ReplayHandler
 {
 public:
     using ReplayHandler::ReplayHandler;
-    MOCK_METHOD(void, Init, (JournalConfiguration* journalConfiguration, IJournalLogBuffer* journalLogBuffer, IVSAMap* vsaMap, IStripeMap* stripeMap, IMapFlush* mapFlush, ISegmentCtx* segmentCtx, IWBStripeAllocator* wbStripeAllocator, IContextManager* contextManager, IContextReplayer* contextReplayer, IArrayInfo* arrayInfo, IVolumeInfoManager* volumeManager, TelemetryPublisher* tp), (override));
+    MOCK_METHOD(void, Init, (JournalConfiguration* journalConfiguration, IJournalLogBuffer* journalLogBuffer, IVSAMap* vsaMap, IStripeMap* stripeMap, IMapFlush* mapFlush, ISegmentCtx* segmentCtx, IVersionedSegmentContext* versionedSegCtx, IWBStripeAllocator* wbStripeAllocator, IContextManager* contextManager, IContextReplayer* contextReplayer, IArrayInfo* arrayInfo, IVolumeInfoManager* volumeManager, TelemetryPublisher* tp), (override));
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(int, Start, (), (override));
 };

--- a/test/unit-tests/journal_manager/replay/replay_handler_test.cpp
+++ b/test/unit-tests/journal_manager/replay/replay_handler_test.cpp
@@ -2,14 +2,55 @@
 
 #include <gtest/gtest.h>
 
+#include <vector>
+
+#include "src/journal_manager/replay/log_delete_checker.h"
+#include "test/unit-tests/allocator/i_context_replayer_mock.h"
+#include "test/unit-tests/journal_manager/config/journal_configuration_mock.h"
+#include "test/unit-tests/journal_manager/replay/log_delete_checker_mock.h"
+#include "test/unit-tests/journal_manager/replay/replay_progress_reporter_mock.h"
+#include "test/unit-tests/state/interface/i_state_control_mock.h"
+
+using ::testing::InSequence;
+using ::testing::NiceMock;
+using ::testing::Return;
+
 namespace pos
 {
 TEST(ReplayHandler, ReplayHandler_)
 {
 }
 
-TEST(ReplayHandler, Init_)
+TEST(ReplayHandler, Init_testIfAllTasksRegisteredSuccessfully)
 {
+    // Given
+    NiceMock<MockIStateControl> iStateControl;
+    NiceMock<MockLogDeleteChecker>* logDeleteChecker = new NiceMock<MockLogDeleteChecker>;
+    NiceMock<MockReplayProgressReporter>* replayProgressReporter = new NiceMock<MockReplayProgressReporter>;
+    NiceMock<MockJournalConfiguration> journalConfiguration;
+    NiceMock<MockIContextReplayer> iContextReplayer;
+
+    int numLogGroups = 2;
+    EXPECT_CALL(iStateControl, Subscribe);
+    ReplayHandler replayHandler(&iStateControl, logDeleteChecker, replayProgressReporter);
+
+    EXPECT_CALL(journalConfiguration, GetNumLogGroups).WillOnce(Return(numLogGroups));
+    EXPECT_CALL(iContextReplayer, GetAllActiveStripeTail);
+    {
+        // Then: All replay tasks will be registered in this sequence
+        InSequence s;
+        EXPECT_CALL(*replayProgressReporter, RegisterTask(ReplayTaskId::READ_LOG_BUFFER, 40));
+        EXPECT_CALL(*replayProgressReporter, RegisterTask(ReplayTaskId::FILTER_LOGS, 10));
+        EXPECT_CALL(*replayProgressReporter, RegisterTask(ReplayTaskId::REPLAY_LOGS, 30));
+        EXPECT_CALL(*replayProgressReporter, RegisterTask(ReplayTaskId::REPLAY_VOLUME_DELETION, 10));
+        EXPECT_CALL(*replayProgressReporter, RegisterTask(ReplayTaskId::FLUSH_METADATA, 20));
+        EXPECT_CALL(*replayProgressReporter, RegisterTask(ReplayTaskId::RESET_LOG_BUFFER, 10));
+        EXPECT_CALL(*replayProgressReporter, RegisterTask(ReplayTaskId::LOAD_REPLAYED_SEGMENT_CONTEXT, 10));
+        EXPECT_CALL(*replayProgressReporter, RegisterTask(ReplayTaskId::FLUSH_PENDING_STRIPES, 10));
+    }
+
+    // When
+    replayHandler.Init(&journalConfiguration, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, &iContextReplayer, nullptr, nullptr, nullptr);
 }
 
 TEST(ReplayHandler, Start_)

--- a/test/unit-tests/journal_manager/replay/replay_progress_reporter_mock.h
+++ b/test/unit-tests/journal_manager/replay/replay_progress_reporter_mock.h
@@ -10,6 +10,7 @@ class MockReplayProgressReporter : public ReplayProgressReporter
 {
 public:
     using ReplayProgressReporter::ReplayProgressReporter;
+    MOCK_METHOD(void, RegisterTask, (ReplayTaskId taskId, int taskWeight), (override));
 };
 
 } // namespace pos


### PR DESCRIPTION
[Revieweee]
- Review 목적: VSC Load 시점을 Replay 가 모두 끝난 뒤로 옮기기
- 참고 문서: IMS
- 주요 review 파일: versioned_segment_ctx.cpp, load_versioned_segment_context.cpp
- 검증 방법 또는 TC: UT/IT

[Reviewer]
- Checklist
 