### PR TITLE
[AWIBOF-8031] Change log write done sequence

### DIFF
--- a/src/journal_manager/log_buffer/log_write_io_context.cpp
+++ b/src/journal_manager/log_buffer/log_write_io_context.cpp
@@ -66,10 +66,13 @@ LogWriteIoContext::GetLogGroupId(void)
 void
 LogWriteIoContext::IoDone(void)
 {
+    // Should call LogBufferIoContext::IoDone first
+    // to update in-memory meta data update
+    // and then notify journal sub-modules that log write is done
+    LogBufferIoContext::IoDone();
+
     auto dirty = logWriteContext->GetDirtyMapList();
     logFilledNotifier->NotifyLogFilled(logWriteContext->GetLogGroupId(), dirty);
-
-    LogBufferIoContext::IoDone();
 }
 
 } // namespace pos


### PR DESCRIPTION
Call client callback event first and then notify journal sub-modules that log write is done when journal log write is completed, so that journal internal events(e.g., checkpoint) can be triggered after all log write is completely done.