### PR TITLE
[AWIBOF-8158] fix signal test in post commit test

### DIFF
--- a/test/regression/tc_lib_ci.sh
+++ b/test/regression/tc_lib_ci.sh
@@ -355,6 +355,11 @@ normal_shutdown()
                 ps -C poseidonos > /dev/null
             done
             start_pos &
+            ps -C poseidonos > /dev/null
+            while [[ ${?} == 1 ]]
+            do
+                ps -C poseidonos > /dev/null
+            done
             pkill poseidonos
         fi
 


### PR DESCRIPTION
fix Sending the signal timing after process is not initialized.