### PR TITLE
[AWIBOF-8161] backtrace will print its line number and file in abort …

### DIFF
--- a/src/signal_handler/signal_handler.cpp
+++ b/src/signal_handler/signal_handler.cpp
@@ -37,7 +37,6 @@
 #include <sched.h>
 #include <signal.h>
 #include <sys/syscall.h>
-#include <unistd.h>
 
 #include <cstdlib>
 #include <iostream>
@@ -164,17 +163,26 @@ SignalHandler::_ExceptionHandler(int sig)
         case SIGTERM:
         case SIGQUIT:
         {
-            _Log("Quit Signal Handling!");
             sigset_t oldset;
+            // This mask will not restored, this is irreversible.
             SignalMask::MaskQuitSignal(&oldset);
+            std::lock_guard<std::mutex> lock(signalMutex);
+            _Log("Quit Signal Handling!");
             _ShutdownProcess();
             break;
         }
         default:
         {
-            _BacktraceAndInvokeNextThread(sig);
-            signal(sig, SIG_DFL);
-            raise(sig);
+            sigset_t oldset;
+            SignalMask::MaskSignal(&oldset);
+            {
+                std::lock_guard<std::mutex> lock(signalMutex);
+                _Log("Signal Handling! num : " + std::to_string(sig));
+                _BacktraceAndInvokeNextThread(sig);
+                signal(sig, SIG_DFL);
+                raise(sig);
+            }
+            SignalMask::RestoreSignal(&oldset);
         }
     }
 }
@@ -225,10 +233,47 @@ SignalHandler::_BacktraceAndInvokeNextThread(int sig)
     }
 }
 
+bool
+SignalHandler::_RunSystemCmdAndGetResult(char* cmdStr, char* resultStr)
+{
+    char cmdStrTmp[FILE_NAME_LINE];
+    sprintf(cmdStrTmp, "%s > tmpBackTrace", cmdStr);
+    int retValue = system(cmdStrTmp);
+    if (retValue != 0)
+    {
+        return false;
+    }
+    FILE* fp = fopen("tmpBackTrace", "r");
+    if (fp == NULL)
+    {
+        return false;
+    }
+    char *ret;
+    ret = fgets(resultStr, FILE_NAME_LINE - 1, fp);
+    fclose(fp);
+    unlink("tmpBackTrace");
+    // ret will be NULL if file is read to end pointer.
+    if (ret == NULL)
+    {
+        return false;
+    }
+    resultStr[strcspn(resultStr, "\r\n")] = 0;
+    if (!strncmp(resultStr, "??", 2))
+    {
+        resultStr[0] = '\0';
+    }
+    return true;
+}
+
+// This stacktrace mechanism will be supported from c++23
+// So, we just use glibc implmentation.
 void
 SignalHandler::_Backtrace(void)
 {
     void* buffer[MAX_CALL_STACK];
+    char cmdStr[FILE_NAME_LINE + 1];
+    char fileLine[FILE_NAME_LINE + 1];
+    char executeBinary[FILE_NAME_LINE + 1];
     char** strings;
     int nptrs;
     nptrs = backtrace(buffer, MAX_CALL_STACK);
@@ -240,9 +285,26 @@ SignalHandler::_Backtrace(void)
     coreInfoString += " tid : ";
     coreInfoString += std::to_string(gettid());
     _Log(coreInfoString);
+
+    ssize_t result = readlink("/proc/self/exe", executeBinary, FILE_NAME_LINE);
+    executeBinary[result] = '\0';
     for (int index = 0; index < nptrs; index++)
     {
-        _Log(strings[index]);
+        std::string symbolString = "";
+        symbolString += strings[index];
+        if (result > 0 && result < FILE_NAME_LINE)
+        {
+            sprintf(cmdStr, "addr2line %p -e %s", buffer[index], executeBinary);
+            bool ret = _RunSystemCmdAndGetResult(cmdStr, fileLine);
+            if (ret == false)
+            {
+                break;
+            }
+            symbolString += " ";
+            symbolString += fileLine;
+        }
+        _Log(symbolString);
+        
     }
     _Log("", false);
     fflush(btLogFilePtr);

--- a/src/signal_handler/signal_handler.h
+++ b/src/signal_handler/signal_handler.h
@@ -39,6 +39,8 @@
 #include <list>
 #include <string>
 #include <thread>
+#include <unistd.h>
+#include <mutex>
 
 #include "src/lib/singleton.h"
 
@@ -62,16 +64,19 @@ private:
     void _BacktraceAndInvokeNextThread(int sig);
     void _Backtrace(void);
     void _ShutdownProcess(void);
+    bool _RunSystemCmdAndGetResult(char* cmdStr, char* resultStr);
     void _Log(std::string logMsg, bool printTimeStamp = true);
     std::list<long> threadList;
     std::atomic<uint32_t> pendingThreads;
     static const long ATOI_ERR = 0;
     static const int MAX_CALL_STACK = 100;
+    static const int FILE_NAME_LINE = 300;
     std::atomic<bool> listUpdated;
     std::atomic<int> dominantSignal;
     FILE* btLogFilePtr;
     std::thread* shutdownTask;
     std::thread* signalHandler;
+    std::mutex signalMutex;
 };
 
 using SignalHandlerSingleton = Singleton<SignalHandler>;


### PR DESCRIPTION
- Segfault 나 Abort 출력 시, file 과 line number를 출력하게 변경 (/var/log/pos_backtrace.log)
- signal이 여러 thread에서 동시 발생했을 때, backtrace가 제대로 찍히도록 변경 (signal handling 에 lock 추가)