### PR TITLE
[AWIBOF-8054] Use test configuration instead of config for production…

### DIFF
--- a/test/integration-tests/journal/fixture/journal_manager_test_fixture.cpp
+++ b/test/integration-tests/journal/fixture/journal_manager_test_fixture.cpp
@@ -74,15 +74,20 @@ JournalManagerTestFixture::InitializeJournal(void)
 void
 JournalManagerTestFixture::InitializeJournal(JournalConfigurationSpy* config)
 {
+    // Should reset configuration first
     journal->ResetJournalConfiguration(config);
+
+    journal->ResetVersionedSegmentContext();
     journal->DeleteLogBuffer();
 
     if (journal->IsEnabled() == true)
     {
-        journal->InitializeForTest(telemetryClient, testMapper, testAllocator, volumeManager, segmentContextUpdater);
+        journal->InitializeForTest(telemetryClient, testMapper, testAllocator, volumeManager);
     }
 
     _GetLogBufferSizeInfo();
+
+    segmentContextUpdater->SetVersionedSegmentContext(journal->GetVersionedSegmentContext());
     writeTester->Reset();
 }
 
@@ -117,7 +122,7 @@ JournalManagerTestFixture::SimulateSPORWithoutRecovery(JournalConfigurationBuild
     writeTester->UpdateJournal(journal);
 
     testAllocator->GetSegmentCtxFake()->LoadContext();
-    journal->InitializeForTest(telemetryClient, testMapper, testAllocator, volumeManager, segmentContextUpdater);
+    journal->InitializeForTest(telemetryClient, testMapper, testAllocator, volumeManager);
 }
 
 void
@@ -147,7 +152,7 @@ JournalManagerTestFixture::SimulateRocksDBSPORWithoutRecovery(void)
     writeTester->UpdateJournal(journal);
 
     testAllocator->GetSegmentCtxFake()->LoadContext();
-    journal->InitializeForTest(telemetryClient, testMapper, testAllocator, volumeManager, segmentContextUpdater);
+    journal->InitializeForTest(telemetryClient, testMapper, testAllocator, volumeManager);
 }
 
 void

--- a/test/integration-tests/journal/journal_manager_spy.cpp
+++ b/test/integration-tests/journal/journal_manager_spy.cpp
@@ -66,19 +66,12 @@ JournalManagerSpy::~JournalManagerSpy(void)
 }
 
 int
-JournalManagerSpy::InitializeForTest(TelemetryClient* telemetryClient, Mapper* mapper, Allocator* allocator, IVolumeInfoManager* volumeManager, SegmentContextUpdater* segmentContextUpdater)
+JournalManagerSpy::InitializeForTest(TelemetryClient* telemetryClient, Mapper* mapper, Allocator* allocator, IVolumeInfoManager* volumeManager)
 {
     int ret = JournalManager::_InitConfigAndPrepareLogBuffer(nullptr);
     if (ret < 0)
     {
         return ret;
-    }
-
-    if (config->IsVscEnabled() == true)
-    {
-        delete versionedSegCtx;
-        versionedSegCtx = JournalManager::_CreateVersionedSegmentCtx();
-        segmentContextUpdater->SetVersionedSegmentContext(versionedSegCtx);
     }
 
     _InitModules(telemetryClient, mapper->GetIVSAMap(), mapper->GetIStripeMap(),

--- a/test/integration-tests/journal/journal_manager_spy.h
+++ b/test/integration-tests/journal/journal_manager_spy.h
@@ -30,7 +30,7 @@ public:
     virtual ~JournalManagerSpy(void);
 
     int InitializeForTest(TelemetryClient* telemetryClient, Mapper* mapper, Allocator* allocator,
-        IVolumeInfoManager* volumeManager, SegmentContextUpdater* segmentContextUpdater);
+        IVolumeInfoManager* volumeManager);
     int DoRecoveryForTest(void);
     void DeleteLogBuffer(void);
     void ResetJournalConfiguration(JournalConfiguration* journalConfig);


### PR DESCRIPTION
… code in journal integration test

VSC is initialized when journal manager is constructed, according to the config in production code. (/etc/pos/pos.conf) In integration tests, this should be configured, not at construction time, but when test configuration is set-up.