### PR TITLE
Flush proper segment context with only diff by volume deletion applied

### DIFF
--- a/src/allocator/context_manager/context_io_manager.h
+++ b/src/allocator/context_manager/context_io_manager.h
@@ -63,6 +63,7 @@ public:
     virtual int Init(void);
     virtual void Dispose(void);
 
+    virtual int FlushContext(EventSmartPtr callback, ContextSectionBuffer externalBuf);
     virtual int FlushContexts(EventSmartPtr callback, bool sync,
         ContextSectionBuffer externalBuf);
 

--- a/src/allocator/context_manager/context_manager.cpp
+++ b/src/allocator/context_manager/context_manager.cpp
@@ -138,6 +138,12 @@ ContextManager::FlushContexts(EventSmartPtr callback, bool sync, ContextSectionB
     return ioManager->FlushContexts(callback, sync, buffer);
 }
 
+int
+ContextManager::FlushContext(EventSmartPtr callback, ContextSectionBuffer buffer)
+{
+    return ioManager->FlushContext(callback, buffer);
+}
+
 SegmentId
 ContextManager::AllocateFreeSegment(void)
 {

--- a/src/allocator/context_manager/context_manager.h
+++ b/src/allocator/context_manager/context_manager.h
@@ -74,6 +74,7 @@ public:
 
     virtual int FlushContexts(EventSmartPtr callback, bool sync);
     virtual int FlushContexts(EventSmartPtr callback, bool sync, ContextSectionBuffer buffer);
+    virtual int FlushContext(EventSmartPtr callback, ContextSectionBuffer buffer);
     virtual SegmentId AllocateFreeSegment(void);
     virtual SegmentId AllocateGCVictimSegment(void);
     virtual SegmentId AllocateRebuildTargetSegment(void);

--- a/src/allocator/i_context_manager.h
+++ b/src/allocator/i_context_manager.h
@@ -47,6 +47,7 @@ class IContextManager
 public:
     virtual int FlushContexts(EventSmartPtr callback, bool sync) = 0;
     virtual int FlushContexts(EventSmartPtr callback, bool sync, ContextSectionBuffer buffer) = 0;
+    virtual int FlushContext(EventSmartPtr callback, ContextSectionBuffer buffer) = 0;
     virtual uint64_t GetStoredContextVersion(int owner) = 0;
 
     virtual SegmentId AllocateFreeSegment(void) = 0;

--- a/src/journal_manager/checkpoint/checkpoint_handler.cpp
+++ b/src/journal_manager/checkpoint/checkpoint_handler.cpp
@@ -136,6 +136,57 @@ CheckpointHandler::Start(MapList pendingDirtyMaps, EventSmartPtr callback, int l
     return ret;
 }
 
+int
+CheckpointHandler::StartSegmentCtx(EventSmartPtr callback, VersionedSegmentInfo* versionedSegmentInfo)
+{
+    int ret = 0;
+
+    checkpointCompletionCallback = callback;
+    _SetStatus(STARTED);
+
+    assert(numMapsToFlush == 0);
+
+    numMapsToFlush = 0;
+    numMapsFlushed = 0;
+    mapFlushCompleted = true;
+
+    EventSmartPtr allocMetaFlushCallback(new CheckpointMetaFlushCompleted(this, ALLOCATOR_META_ID));
+
+    ContextSectionBuffer segInfoBuffer = INVALID_CONTEXT_SECTION_BUFFER;
+    SegmentInfoData* vscSegInfoData = versionedSegmentCtx->GetUpdatedInfoDataToFlush(versionedSegmentInfo);
+    if (vscSegInfoData != nullptr)
+    {
+        segInfoBuffer.owner = SEGMENT_CTX;
+        segInfoBuffer.sectionId = SC_SEGMENT_INFO,
+        segInfoBuffer.buffer = reinterpret_cast<char*>(vscSegInfoData);
+    }
+    else
+    {
+        POS_TRACE_ERROR(EID(JOURNAL_CHECKPOINT_FAILED),
+            "Failed to start flushing allocator meta pages with versioned segment context, arrayId:{}", arrayId);
+
+        ret = EID(CHECKPOINT_FAILED);
+    }
+
+    if (ret == 0)
+    {
+        ret = contextManager->FlushContexts(allocMetaFlushCallback, false, segInfoBuffer);
+        if (ret != 0)
+        {
+            POS_TRACE_ERROR(EID(JOURNAL_CHECKPOINT_FAILED),
+                "Failed to start flushing allocator meta pages, arrayId:{}", arrayId);
+        }
+
+        std::unique_lock<std::mutex> lock(completionLock);
+        if (status != COMPLETED)
+        {
+            _SetStatus(WAITING_FOR_FLUSH_DONE);
+        }
+    }
+
+    return ret;
+}
+
 void
 CheckpointHandler::_CheckMapFlushCompleted(void)
 {

--- a/src/journal_manager/checkpoint/checkpoint_handler.h
+++ b/src/journal_manager/checkpoint/checkpoint_handler.h
@@ -55,6 +55,7 @@ public:
     virtual void Init(IVersionedSegmentContext* versionedSegCtx, IMapFlush* mapFlushToUse, IContextManager* contextManagerToUse, EventScheduler* eventScheduler);
 
     virtual int Start(MapList pendingDirtyMaps, EventSmartPtr callback, int logGroupIdInProgress);
+    virtual int StartSegmentCtx(EventSmartPtr callback, VersionedSegmentInfo* versionedSegmentInfo);
     virtual int FlushCompleted(int metaId);
 
     virtual CheckpointStatus GetStatus(void);

--- a/src/journal_manager/checkpoint/checkpoint_manager.h
+++ b/src/journal_manager/checkpoint/checkpoint_manager.h
@@ -49,6 +49,7 @@ class CallbackSequenceController;
 class DirtyMapManager;
 class CheckpointHandler;
 class IVersionedSegmentContext;
+class VersionedSegmentInfo;
 class TelemetryPublisher;
 
 class CheckpointManager
@@ -64,7 +65,7 @@ public:
         DirtyMapManager* dMapManager, IVersionedSegmentContext* versionedSegCtx,
         TelemetryPublisher* tp);
     virtual int RequestCheckpoint(int logGroupId, EventSmartPtr callback);
-    virtual int StartCheckpoint(EventSmartPtr callback);
+    virtual int StartCheckpoint(EventSmartPtr callback, VersionedSegmentInfo* versionedSegmentInfo);
 
     virtual CheckpointStatus GetStatus(void);
 
@@ -78,12 +79,19 @@ public:
     int GetNumPendingCheckpointRequests(void);
 
 private:
+    enum CheckpointType
+    {
+        LOG_GROUP,
+        SEGMENT_CTX_ONLY
+    };
+
     struct CheckpointRequest
     {
-        int groupId;
+        CheckpointType type;
         EventSmartPtr callback;
+        int groupId;                         // only valid when it's LOG_GROUP checkpoint
+        VersionedSegmentInfo* versionedInfo; // only valid when it's SEGMENT_CTX_ONLY checkpoint
     };
-    CheckpointRequest invalid{INT32_MAX, nullptr};
 
     int _TryToStartCheckpoint(CheckpointRequest request);
     int _StartCheckpoint(CheckpointRequest request);

--- a/src/journal_manager/journal_manager.cpp
+++ b/src/journal_manager/journal_manager.cpp
@@ -490,7 +490,7 @@ JournalManager::_InitModules(TelemetryClient* tc, IVSAMap* vsaMap, IStripeMap* s
         sequenceController, dirtyMapManager, versionedSegCtx, telemetryPublisher);
 
     const PartitionLogicalSize* udSize = arrayInfo->GetSizeInfo(PartitionType::USER_DATA);
-    versionedSegCtx->Init(config, udSize->totalSegments);
+    versionedSegCtx->Init(config, udSize->totalSegments, udSize->stripesPerSegment);
 
     logWriteContextFactory->Init(config);
     logBufferIoContextFactory->Init(config, logFilledNotifier, sequenceController);
@@ -509,7 +509,7 @@ JournalManager::_InitModules(TelemetryClient* tc, IVSAMap* vsaMap, IStripeMap* s
     logWriteHandler->Init(bufferAllocator, logBuffer, config, EasyTelemetryPublisherSingleton::Instance(),
         arrayInfo->GetIndex(), new ConcurrentMetaFsTimeInterval(config->GetIntervalForMetric()));
     volumeEventHandler->Init(logWriteContextFactory, checkpointManager, dirtyMapManager, logWriteHandler,
-        config, contextManager, eventScheduler);
+        config, contextManager, eventScheduler, udSize->stripesPerSegment);
     journalWriter->Init(logWriteHandler, logWriteContextFactory, eventFactory, &journalingStatus, eventScheduler);
 
     replayHandler->Init(config, logBuffer, vsaMap, stripeMap, mapFlush, segmentCtx, versionedSegCtx,

--- a/src/journal_manager/log_buffer/i_versioned_segment_context.h
+++ b/src/journal_manager/log_buffer/i_versioned_segment_context.h
@@ -48,7 +48,7 @@ class IVersionedSegmentContext: public LogBufferWriteDoneEvent, public ISegmentF
 public:
     virtual ~IVersionedSegmentContext(void) = default;
 
-    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments) = 0;
+    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments, uint32_t numStripesPerSegment) = 0;
     virtual void Load(SegmentInfoData* loadedSegmentInfos) = 0;
     virtual void Dispose(void) = 0;
     virtual void IncreaseValidBlockCount(int logGroupId, SegmentId segId, uint32_t cnt) = 0;

--- a/src/journal_manager/log_buffer/i_versioned_segment_context.h
+++ b/src/journal_manager/log_buffer/i_versioned_segment_context.h
@@ -55,6 +55,7 @@ public:
     virtual void DecreaseValidBlockCount(int logGroupId, SegmentId segId, uint32_t cnt) = 0;
     virtual void IncreaseOccupiedStripeCount(int logGroupId, SegmentId segId) = 0;
     virtual SegmentInfoData* GetUpdatedInfoDataToFlush(int logGroupId) = 0;
+    virtual SegmentInfoData* GetUpdatedInfoDataToFlush(VersionedSegmentInfo* info) = 0;
     virtual int GetNumSegments(void) = 0;
     virtual int GetNumLogGroups(void) = 0;
 

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -55,13 +55,13 @@ VersionedSegmentCtx::~VersionedSegmentCtx(void)
 }
 
 void
-VersionedSegmentCtx::Init(JournalConfiguration* journalConfiguration, uint32_t numSegments_)
+VersionedSegmentCtx::Init(JournalConfiguration* journalConfiguration, uint32_t numSegments_, uint32_t numStripesPerSegment)
 {
     _Init(journalConfiguration, numSegments_);
 
     for (int index = 0; index < config->GetNumLogGroups(); index++)
     {
-        std::shared_ptr<VersionedSegmentInfo> segmentInfo(new VersionedSegmentInfo());
+        std::shared_ptr<VersionedSegmentInfo> segmentInfo(new VersionedSegmentInfo(numStripesPerSegment));
         segmentInfoDiffs.push_back(segmentInfo);
     }
 }

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.h
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.h
@@ -51,7 +51,7 @@ public:
     DummyVersionedSegmentCtx(void) = default;
     virtual ~DummyVersionedSegmentCtx(void) = default;
 
-    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments) override {}
+    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments, uint32_t numStripesPerSegment) override {}
     virtual void Load(SegmentInfoData* loadedSegmentInfos) override {}
     virtual void Dispose(void) override {}
     virtual void IncreaseValidBlockCount(int logGroupId, SegmentId segId, uint32_t cnt) override {}
@@ -77,7 +77,7 @@ public:
     VersionedSegmentCtx(void);
     virtual ~VersionedSegmentCtx(void);
 
-    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments) override;
+    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments, uint32_t numStripesPerSegment) override;
     virtual void Load(SegmentInfoData* loadedSegmentInfos) override;
     virtual void Dispose(void) override;
 

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.h
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.h
@@ -58,6 +58,10 @@ public:
     virtual void DecreaseValidBlockCount(int logGroupId, SegmentId segId, uint32_t cnt) override {}
     virtual void IncreaseOccupiedStripeCount(int logGroupId, SegmentId segId) override {}
     virtual SegmentInfoData* GetUpdatedInfoDataToFlush(int logGroupId) override { return nullptr; }
+    virtual SegmentInfoData* GetUpdatedInfoDataToFlush(VersionedSegmentInfo* info)
+    {
+        return nullptr;
+    }
     virtual int GetNumSegments(void) override { return 0; }
     virtual int GetNumLogGroups(void) override { return 0; };
     virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments,
@@ -91,6 +95,7 @@ public:
     virtual void IncreaseOccupiedStripeCount(int logGroupId, SegmentId segId) override;
 
     virtual SegmentInfoData* GetUpdatedInfoDataToFlush(int logGroupId) override;
+    virtual SegmentInfoData* GetUpdatedInfoDataToFlush(VersionedSegmentInfo* info) override;
     virtual int GetNumSegments(void) override;
     virtual int GetNumLogGroups(void) override;
 
@@ -104,6 +109,7 @@ public:
 private:
     void _Init(JournalConfiguration* journalConfiguration, uint32_t numSegments_);
     void _UpdateSegmentContext(int logGroupId);
+    void _UpdateSegmentContext(VersionedSegmentInfo* targetSegInfo);
     void _CheckLogGroupIdValidity(int logGroupId);
     void _CheckSegIdValidity(int segId);
 

--- a/src/journal_manager/log_write/i_journal_volume_event_handler.h
+++ b/src/journal_manager/log_write/i_journal_volume_event_handler.h
@@ -34,11 +34,14 @@
 
 namespace pos
 {
+class ISegmentCtx;
+
 class IJournalVolumeEventHandler
 {
 public:
     virtual int WriteVolumeDeletedLog(int volId) = 0;
     virtual int TriggerMetadataFlush(void) = 0;
+    virtual ISegmentCtx* AllocateSegmentCtxToUse(void) = 0;
 };
 
 } // namespace pos

--- a/src/journal_manager/log_write/journal_volume_event_handler.cpp
+++ b/src/journal_manager/log_write/journal_volume_event_handler.cpp
@@ -150,7 +150,7 @@ JournalVolumeEventHandler::TriggerMetadataFlush(void)
         "Start checkpoint, triggered by volume deletion");
 
     EventSmartPtr callback(new MetaFlushCompleted(this));
-    int ret = checkpointManager->StartCheckpoint(callback);
+    int ret = checkpointManager->StartCheckpoint(callback, versionedSegmentInfo);
     if (ret == 0)
     {
         _WaitForAllocatorContextFlushCompleted();

--- a/src/journal_manager/log_write/journal_volume_event_handler.cpp
+++ b/src/journal_manager/log_write/journal_volume_event_handler.cpp
@@ -43,6 +43,7 @@
 #include "src/journal_manager/config/journal_configuration.h"
 #include "src/journal_manager/log_buffer/journal_log_buffer.h"
 #include "src/journal_manager/log_buffer/log_write_context_factory.h"
+#include "src/journal_manager/log_buffer/versioned_segment_info.h"
 #include "src/journal_manager/log_write/log_write_handler.h"
 #include "src/journal_manager/log_write/log_write_request.h"
 #include "src/journal_manager/log_write/volume_deleted_log_write_callback.h"
@@ -60,19 +61,25 @@ JournalVolumeEventHandler::JournalVolumeEventHandler(void)
   dirtyMapManager(nullptr),
   logWriteHandler(nullptr),
   logWriteInProgress(false),
-  flushInProgress(false)
+  flushInProgress(false),
+  versionedSegmentInfo(nullptr)
 {
 }
 
 JournalVolumeEventHandler::~JournalVolumeEventHandler(void)
 {
+    if (versionedSegmentInfo != nullptr)
+    {
+        delete versionedSegmentInfo;
+    }
 }
 
 void
 JournalVolumeEventHandler::Init(LogWriteContextFactory* factory,
     CheckpointManager* cpManager, DirtyMapManager* dirtyManager,
     LogWriteHandler* writter, JournalConfiguration* journalConfiguration,
-    IContextManager* contextManagerToUse, EventScheduler* scheduler)
+    IContextManager* contextManagerToUse, EventScheduler* scheduler,
+    uint32_t numStripesPerSegment_)
 {
     config = journalConfiguration;
     logFactory = factory;
@@ -82,6 +89,8 @@ JournalVolumeEventHandler::Init(LogWriteContextFactory* factory,
 
     contextManager = contextManagerToUse;
     eventScheduler = scheduler;
+
+    numStripesPerSegment = numStripesPerSegment_;
 
     isInitialized = true;
 }
@@ -171,6 +180,20 @@ JournalVolumeEventHandler::_WaitForAllocatorContextFlushCompleted(void)
     flushCondVar.wait(lock, [&] {
         return (flushInProgress == false);
     });
+}
+
+ISegmentCtx*
+JournalVolumeEventHandler::AllocateSegmentCtxToUse(void)
+{
+    if (config->IsVscEnabled() == true)
+    {
+        versionedSegmentInfo = new VersionedSegmentInfo(numStripesPerSegment);
+        return versionedSegmentInfo;
+    }
+    else
+    {
+        return nullptr;
+    }
 }
 
 void

--- a/src/journal_manager/log_write/journal_volume_event_handler.h
+++ b/src/journal_manager/log_write/journal_volume_event_handler.h
@@ -60,10 +60,12 @@ public:
     virtual void Init(LogWriteContextFactory* logFactory,
         CheckpointManager* cpManager, DirtyMapManager* dirtyManager,
         LogWriteHandler* logWritter, JournalConfiguration* journalConfiguration,
-        IContextManager* contextManager, EventScheduler* scheduler);
+        IContextManager* contextManager, EventScheduler* scheduler,
+        uint32_t numStripesPerSegment);
 
     virtual int WriteVolumeDeletedLog(int volId) override;
     virtual int TriggerMetadataFlush(void) override;
+    virtual ISegmentCtx* AllocateSegmentCtxToUse(void) override;
 
     virtual void MetaFlushed(void) override;
 
@@ -94,6 +96,9 @@ private:
     std::mutex flushMutex;
     std::condition_variable flushCondVar;
     bool flushInProgress;
+
+    uint32_t numStripesPerSegment;
+    VersionedSegmentInfo* versionedSegmentInfo;
 };
 
 } // namespace pos

--- a/src/metadata/meta_volume_event_handler.cpp
+++ b/src/metadata/meta_volume_event_handler.cpp
@@ -120,7 +120,17 @@ MetaVolumeEventHandler::VolumeDeleted(VolumeEventBase* volEventBase, VolumeArray
     }
 
     // Invalidate all blocks in the volume
-    result = mapper->InvalidateAllBlocksTo(volEventBase->volId, allocator->GetISegmentCtx());
+    auto segmentCtxToUse = allocator->GetISegmentCtx();
+    if (journal != nullptr)
+    {
+        auto toUse = journal->AllocateSegmentCtxToUse();
+        if (toUse != nullptr)
+        {
+            segmentCtxToUse = toUse;
+        }
+    }
+
+    result = mapper->InvalidateAllBlocksTo(volEventBase->volId, segmentCtxToUse);
     if (result != 0)
     {
         return result;

--- a/test/integration-tests/journal/fake/i_context_manager_fake.h
+++ b/test/integration-tests/journal/fake/i_context_manager_fake.h
@@ -26,6 +26,7 @@ public:
     virtual uint64_t GetStoredContextVersion(int owner) override;
     virtual SegmentCtx* GetSegmentCtx(void) override;
 
+    virtual int FlushContext(EventSmartPtr callback, ContextSectionBuffer buffer) { return 0; }
     virtual int FlushContexts(EventSmartPtr callback, bool sync) { return 0; }
     virtual SegmentId AllocateFreeSegment(void) { return 0; }
     virtual SegmentId AllocateGCVictimSegment(void) { return 0; }

--- a/test/unit-tests/allocator/i_context_manager_mock.h
+++ b/test/unit-tests/allocator/i_context_manager_mock.h
@@ -12,6 +12,7 @@ public:
     using IContextManager::IContextManager;
     MOCK_METHOD(int, FlushContexts, (EventSmartPtr callback, bool sync), (override));
     MOCK_METHOD(int, FlushContexts, (EventSmartPtr callback, bool sync, ContextSectionBuffer buffer), (override));
+    MOCK_METHOD(int, FlushContext, (EventSmartPtr callback, ContextSectionBuffer buffer), (override));
     MOCK_METHOD(uint64_t, GetStoredContextVersion, (int owner), (override));
     MOCK_METHOD(SegmentId, AllocateFreeSegment, (), (override));
     MOCK_METHOD(SegmentId, AllocateGCVictimSegment, (), (override));

--- a/test/unit-tests/journal_manager/checkpoint/checkpoint_handler_mock.h
+++ b/test/unit-tests/journal_manager/checkpoint/checkpoint_handler_mock.h
@@ -14,6 +14,7 @@ public:
     using CheckpointHandler::CheckpointHandler;
     MOCK_METHOD(void, Init, (IVersionedSegmentContext* versionedSegCtx, IMapFlush * mapFlush, IContextManager* contextManager, EventScheduler* scheduler), (override));
     MOCK_METHOD(int, Start, (MapList pendingDirtyMaps, EventSmartPtr callback, int logGroupIdInProgress), (override));
+    MOCK_METHOD(int, StartSegmentCtx, (EventSmartPtr callback, VersionedSegmentInfo* versionedSegmentInfo), (override));
     MOCK_METHOD(int, FlushCompleted, (int metaId), (override));
     MOCK_METHOD(CheckpointStatus, GetStatus, (), (override));
 };

--- a/test/unit-tests/journal_manager/checkpoint/checkpoint_manager_mock.h
+++ b/test/unit-tests/journal_manager/checkpoint/checkpoint_manager_mock.h
@@ -12,7 +12,7 @@ public:
     using CheckpointManager::CheckpointManager;
     MOCK_METHOD(void, Init, (IMapFlush* mapFlush, IContextManager* ctxManager, EventScheduler* scheduler, CallbackSequenceController* seqController, DirtyMapManager* dMapManager, IVersionedSegmentContext* versionedSegCtx, TelemetryPublisher* tp), (override));
     MOCK_METHOD(int, RequestCheckpoint, (int logGroupId, EventSmartPtr callback), (override));
-    MOCK_METHOD(int, StartCheckpoint, (EventSmartPtr callback), (override));
+    MOCK_METHOD(int, StartCheckpoint, (EventSmartPtr callback, VersionedSegmentInfo* versionedSegmentInfo), (override));
     MOCK_METHOD(CheckpointStatus, GetStatus, (), (override));
     MOCK_METHOD(void, CheckpointCompleted, (), (override));
     MOCK_METHOD(void, BlockCheckpointAndWaitToBeIdle, (), (override));

--- a/test/unit-tests/journal_manager/config/journal_configuration_mock.h
+++ b/test/unit-tests/journal_manager/config/journal_configuration_mock.h
@@ -13,6 +13,7 @@ public:
     MOCK_METHOD(void, Init, (bool isWriteThroughEnabled), (override));
     MOCK_METHOD(int, SetLogBufferSize, (uint64_t loadedLogBufferSize, MetaFs* metaFs), (override));
     MOCK_METHOD(bool, IsEnabled, (), (override));
+    MOCK_METHOD(bool, IsVscEnabled, (), (override));
     MOCK_METHOD(bool, IsDebugEnabled, (), (override));
     MOCK_METHOD(bool, AreReplayWbStripesInUserArea, (), (override));
     MOCK_METHOD(bool, IsRocksdbEnabled, (), (override));

--- a/test/unit-tests/journal_manager/log_buffer/i_versioned_segment_context_mock.h
+++ b/test/unit-tests/journal_manager/log_buffer/i_versioned_segment_context_mock.h
@@ -21,6 +21,7 @@ public:
     MOCK_METHOD(int, GetNumSegments, (), (override));
     MOCK_METHOD(int, GetNumLogGroups, (), (override));
     MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (int logGroupId), (override));
+    MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (VersionedSegmentInfo * info), (override));
     MOCK_METHOD(void, Init, (JournalConfiguration* journalConfiguration, uint32_t numSegments,
         std::vector<std::shared_ptr<VersionedSegmentInfo>> inputVersionedSegmentInfo), (override));
     MOCK_METHOD(void, LogFilled, (int logGroupId, const MapList& dirty), (override));

--- a/test/unit-tests/journal_manager/log_buffer/i_versioned_segment_context_mock.h
+++ b/test/unit-tests/journal_manager/log_buffer/i_versioned_segment_context_mock.h
@@ -12,7 +12,7 @@ class MockIVersionedSegmentContext : public IVersionedSegmentContext
 {
 public:
     using IVersionedSegmentContext::IVersionedSegmentContext;
-    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments), (override));
+    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments, uint32_t numStripesPerSegment), (override));
     MOCK_METHOD(void, Load, (SegmentInfoData* loadedSegmentInfos), (override));
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(void, IncreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_mock.h
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_mock.h
@@ -42,7 +42,7 @@ class MockDummyVersionedSegmentCtx : public DummyVersionedSegmentCtx
 {
 public:
     using DummyVersionedSegmentCtx::DummyVersionedSegmentCtx;
-    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments), (override));
+    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments, uint32_t numStripesPerSegment), (override));
     MOCK_METHOD(void, Load, (SegmentInfoData* loadedSegmentInfos), (override));
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(void, IncreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));
@@ -60,7 +60,7 @@ class MockVersionedSegmentCtx : public VersionedSegmentCtx
 {
 public:
     using VersionedSegmentCtx::VersionedSegmentCtx;
-    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments), (override));
+    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments, uint32_t numStripesPerSegment), (override));
     MOCK_METHOD(void, Load, (SegmentInfoData* loadedSegmentInfos), (override));
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(void, IncreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_mock.h
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_mock.h
@@ -49,6 +49,7 @@ public:
     MOCK_METHOD(void, DecreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));
     MOCK_METHOD(void, IncreaseOccupiedStripeCount, (int logGroupId, SegmentId segId), (override));
     MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (int logGroupId), (override));
+    MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (VersionedSegmentInfo * info), (override));
     MOCK_METHOD(int, GetNumSegments, (), (override));
     MOCK_METHOD(int, GetNumLogGroups, (), (override));
     MOCK_METHOD(void, LogFilled, (int logGroupId, const MapList& dirty), (override));
@@ -67,6 +68,7 @@ public:
     MOCK_METHOD(void, DecreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));
     MOCK_METHOD(void, IncreaseOccupiedStripeCount, (int logGroupId, SegmentId segId), (override));
     MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (int logGroupId), (override));
+    MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (VersionedSegmentInfo * info), (override));
     MOCK_METHOD(int, GetNumSegments, (), (override));
     MOCK_METHOD(int, GetNumLogGroups, (), (override));
     MOCK_METHOD(void, Init, (JournalConfiguration* journalConfiguration, uint32_t numSegments,

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_test.cpp
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_test.cpp
@@ -79,7 +79,7 @@ protected:
 TEST_F(VersionedSegmentCtxTestFixture, Init_testIfInitWhenNumberOfLogGroupsIsTwo)
 {
     // When
-    versionedSegCtx.Init(&config, 3);
+    versionedSegCtx.Init(&config, 3, 1024 /* not interested */);
 }
 
 TEST_F(VersionedSegmentCtxTestFixture, Dispose_testIfContextIsDeleted)
@@ -88,7 +88,7 @@ TEST_F(VersionedSegmentCtxTestFixture, Dispose_testIfContextIsDeleted)
     versionedSegCtx.Dispose();
 
     // When : Init and Dispose
-    versionedSegCtx.Init(&config, 3);
+    versionedSegCtx.Init(&config, 3, 1024 /*not interested*/);
     versionedSegCtx.Dispose();
 }
 

--- a/test/unit-tests/journal_manager/log_write/i_journal_volume_event_handler_mock.h
+++ b/test/unit-tests/journal_manager/log_write/i_journal_volume_event_handler_mock.h
@@ -12,6 +12,7 @@ public:
     using IJournalVolumeEventHandler::IJournalVolumeEventHandler;
     MOCK_METHOD(int, WriteVolumeDeletedLog, (int volId), (override));
     MOCK_METHOD(int, TriggerMetadataFlush, (), (override));
+    MOCK_METHOD(ISegmentCtx*, AllocateSegmentCtxToUse, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/journal_manager/log_write/journal_volume_event_handler_mock.h
+++ b/test/unit-tests/journal_manager/log_write/journal_volume_event_handler_mock.h
@@ -10,7 +10,7 @@ class MockJournalVolumeEventHandler : public JournalVolumeEventHandler
 {
 public:
     using JournalVolumeEventHandler::JournalVolumeEventHandler;
-    MOCK_METHOD(void, Init, (LogWriteContextFactory* logFactory, CheckpointManager* cpManager, DirtyMapManager* dirtyManager, LogWriteHandler* logWritter, JournalConfiguration* journalConfiguration, IContextManager* contextManager, EventScheduler* scheduler), (override));
+    MOCK_METHOD(void, Init, (LogWriteContextFactory * logFactory, CheckpointManager* cpManager, DirtyMapManager* dirtyManager, LogWriteHandler* logWritter, JournalConfiguration* journalConfiguration, IContextManager* contextManager, EventScheduler* scheduler, uint32_t numStripesPerSegment), (override));
     MOCK_METHOD(int, WriteVolumeDeletedLog, (int volId), (override));
     MOCK_METHOD(int, TriggerMetadataFlush, (), (override));
     MOCK_METHOD(void, MetaFlushed, (), (override));


### PR DESCRIPTION
Volume Deletion으로 인해 발생한 segmentCtx 변경점(valid block count 감소분)을 안전하게 checkpoint 하기 위한 변경점 입니다. 

코드 수정점은 다음과 같습니다.

1. Volume Deletion 시 mapper의 invalidateBlks를 segmentCtx에 직접 하지 않도록 수정

VersionedSegmentInfo를 ISegmentCtx 상속받도록 하고, delete 용 VersionedSegmentInfo를 생성하고 이를 mapper에게 전달하여 여기에 업데이트
2. Volume Delete 으로 인한 checkpoint 시 1번에서 기록된 변경점만 반영하여 SegmentCtx flush 

Last checkpointed segment context + Volume deletion으로 인한 diff 반영한 것을 flush 함