### PR TITLE
[AWIBOF-8163] Add option to enable save/restore function

### DIFF
--- a/config/pos.conf
+++ b/config/pos.conf
@@ -116,6 +116,9 @@
         "collector_endpoint": "http://localhost:3418/v1/traces"
     },
     "rebuild": {
-      "auto_start": true
+        "auto_start": true
+    },
+    "save_restore": {
+        "enable": false
     }
 }

--- a/src/main/poseidonos.cpp
+++ b/src/main/poseidonos.cpp
@@ -85,7 +85,6 @@
 
 namespace pos
 {
-
 PoseidonosInterface* PoseidonosInterface::instance;
 
 int
@@ -176,8 +175,7 @@ Poseidonos::_InitReplicatorManager(void)
 void
 Poseidonos::Run(void)
 {
-    // Enable after the restore policy decision
-    // _RestoreState();
+    _RestoreState();
     curr_init_seq_num++;
     POS_REPORT_TRACE(EID(POS_INITIALIZING_CLI_SERVER), "POS Initialize Sequence In Progress({}/{}): CLI Server...", curr_init_seq_num, total_init_seq_cnt);
     _RunCLIService();
@@ -424,15 +422,22 @@ Poseidonos::_SetupThreadModel(void)
 void
 Poseidonos::_RestoreState(void)
 {
-    if (RestoreManagerSingleton::Instance()->Restore())
+    bool enabled = false;
+    ConfigManagerSingleton::Instance()->GetValue("save_restore", "enable", &enabled, ConfigType::CONFIG_TYPE_BOOL);
+    if (enabled)
     {
-        cout << "The previous state has been restored.\n";
-        RestoreManagerSingleton::Instance()->EnableStateSave();
+        if (RestoreManagerSingleton::Instance()->Restore())
+        {
+            cout << "The previous state has been restored.\n";
+            RestoreManagerSingleton::Instance()->EnableStateSave();
+            return;
+        }
+        else
+        {
+            cout << "Faild to restore previous state.\n";
+        }
     }
-    else
-    {
-        cout << "Faild to restore previous state.\n";
-    }
+    POS_TRACE_INFO(EID(RESTORE_MSG), "Saving state disabled.");
 }
 
 void


### PR DESCRIPTION
If the save_restore option is true in pos.conf, it will look for the /etc/pos/restore.json file and try to restore it, and save the CLI command if the file does not exist or if it succeeds.