### PR TITLE
[AWIBOF-7524] Add reactor utilization metric to telemetry

### DIFF
--- a/doc/development/telemetry/ID_RULES.md
+++ b/doc/development/telemetry/ID_RULES.md
@@ -110,6 +110,8 @@ Resource monitoring ID Range : 100000 ~ 100099
 
 100000 Available host memory size
 
+100010 reactor utilization
+
 ---
 
 ## **Disk**

--- a/doc/development/telemetry/METRICS.md
+++ b/doc/development/telemetry/METRICS.md
@@ -76,6 +76,7 @@
   - [_**VolumeUsageBlockCount**_](#volumeusageblockcount)
 - [**Resource**](#resource)
   - [_**AvailableMemorySize**_](#availablememorysize)
+  - [_**ReactorUtilization**_](#reactorutilization)
 - [**Disk**](#disk)
   - [_**softMediaErrorLower**_](#softmediaerrorlower)
   - [_**softMediaErrorUpper**_](#softmediaerrorupper)
@@ -1273,6 +1274,21 @@ Resource group contains the metrics of the pos resource.
 **Introduced**: v0.10.0
 
 Available memory size
+
+---
+### _**ReactorUtilization**_
+
+**ID**: 100010
+
+**Type**: Gauge
+
+**Monitoring**: Mandatory
+
+**Labels**: {"index": Integer, "thread_id": Integer, "thread_name": String}
+
+**Introduced**: v0.13.0
+
+Reactor Utilization by CPU tick (idle, busy)
 
 ---
 ## **Disk**

--- a/src/telemetry/telemetry_air/telemetry_air_delegator.cpp
+++ b/src/telemetry/telemetry_air/telemetry_air_delegator.cpp
@@ -355,7 +355,8 @@ TelemetryAirDelegator::RegisterAirEvent(void)
             "PartialWriteProcess", "UserFailIo", "InternalIoPendingCnt", "TimeOutIoCnt",
             "TotalRequestedFlushCnt", "TotalRequestedTrimCmdCnt", "TotalRequestedWriteSectorCnt"
             "Feqos_Global_BW_Throttling", "Feqos_Dynamic_BW_Throttling", "Feqos_Global_Iops_Throttling",
-            "Feqos_Dynamic_Iops_Throttling", "Feqos_Volume_Q_Count", "Q_EventQueue"},
+            "Feqos_Dynamic_Iops_Throttling", "Feqos_Volume_Q_Count", "Q_EventQueue",
+            "UTIL_REACTOR"},
         std::move(dataHandler));
 }
 

--- a/src/telemetry/telemetry_air/telemetry_air_delegator.h
+++ b/src/telemetry/telemetry_air/telemetry_air_delegator.h
@@ -121,6 +121,8 @@ private:
 
         {"CNT_PendingIO", "", true, "count", TEL80000_DEVICE_PENDING_IO_COUNT, POSMetricTypes::MT_GAUGE},
 
+        {"UTIL_REACTOR", "", true, "usage", TEL100010_REACTOR_UTILIZATION, POSMetricTypes::MT_GAUGE},
+
         {"Feqos_Global_BW_Throttling", "", true, "qd_avg", TEL120000_FEQOS_GLOBAL_BW, POSMetricTypes::MT_GAUGE},
         {"Feqos_Dynamic_BW_Throttling", "", true, "qd_avg", TEL120001_FEQOS_DYNAMIC_BW, POSMetricTypes::MT_GAUGE, CustomLabel::ArrayIdVolumeId},
         {"Feqos_Global_Iops_Throttling", "", true, "qd_avg", TEL120002_FEQOS_GLOBAL_IOPS, POSMetricTypes::MT_GAUGE},

--- a/src/telemetry/telemetry_id.h
+++ b/src/telemetry/telemetry_id.h
@@ -146,6 +146,7 @@ static const std::string TEL90005_GC_STRIPE_COUNT_MAP_UPDATE_COMPLETED  = "gc_st
 static const std::string TEL90006_GC_STRIPE_COUNT_FORCE_FLUSH_REQUESTED  = "gc_stripe_count_force_flush_requested";
 
 static const std::string TEL100000_RESOURCE_CHECKER_AVAILABLE_MEMORY = "available_memory_size";
+static const std::string TEL100010_REACTOR_UTILIZATION = "reactor_utilization";
 
 static const std::string TEL110000_MEDIA_ERROR_COUNT_LOWER = "soft_media_error_lower";
 static const std::string TEL110001_MEDIA_ERROR_COUNT_UPPER = "soft_media_error_upper";


### PR DESCRIPTION
Add reactor utilzation metric to telemetry

It shows reactor virtual time spent on (idle, busy) and collected by AIR as metric name UTIL_REACTOR