### PR TITLE
Flush proper segment context with only diff by volume deletion applied #754

### DIFF
--- a/proto/generated/cpp/pos_bc.pb.cc
+++ b/proto/generated/cpp/pos_bc.pb.cc
@@ -19,8 +19,8 @@ PROTOBUF_PRAGMA_INIT_SEG
 namespace pos_bc {
 constexpr SegmentInfoDataProto::SegmentInfoDataProto(
   ::PROTOBUF_NAMESPACE_ID::internal::ConstantInitialized)
-  : valid_block_count_(0u)
-  , occupied_stripe_count_(0u)
+  : valid_block_count_(0)
+  , occupied_stripe_count_(0)
   , state_(0)
 {}
 struct SegmentInfoDataProtoDefaultTypeInternal {
@@ -386,8 +386,8 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
 
 const char descriptor_table_protodef_pos_5fbc_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
   "\n\014pos_bc.proto\022\006pos_bc\"{\n\024SegmentInfoDat"
-  "aProto\022\031\n\021valid_block_count\030\001 \001(\r\022\035\n\025occ"
-  "upied_stripe_count\030\002 \001(\r\022#\n\005state\030\003 \001(\0162"
+  "aProto\022\031\n\021valid_block_count\030\001 \001(\005\022\035\n\025occ"
+  "upied_stripe_count\030\002 \001(\005\022#\n\005state\030\003 \001(\0162"
   "\024.pos_bc.SegmentStateJ\004\010\004\020\025\" \n\027SegmentCt"
   "xExtendedProtoJ\005\010\001\020\351\007\"\"\n\031AllocatorCtxExt"
   "endedProtoJ\005\010\001\020\351\007\" \n\027RebuildCtxExtendedP"
@@ -617,17 +617,17 @@ const char* SegmentInfoDataProto::_InternalParse(const char* ptr, ::PROTOBUF_NAM
     ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
     CHK_(ptr);
     switch (tag >> 3) {
-      // uint32 valid_block_count = 1;
+      // int32 valid_block_count = 1;
       case 1:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
-          valid_block_count_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          valid_block_count_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
-      // uint32 occupied_stripe_count = 2;
+      // int32 occupied_stripe_count = 2;
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 16)) {
-          occupied_stripe_count_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
+          occupied_stripe_count_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -667,16 +667,16 @@ failure:
   ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // uint32 valid_block_count = 1;
+  // int32 valid_block_count = 1;
   if (this->valid_block_count() != 0) {
     target = stream->EnsureSpace(target);
-    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt32ToArray(1, this->_internal_valid_block_count(), target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(1, this->_internal_valid_block_count(), target);
   }
 
-  // uint32 occupied_stripe_count = 2;
+  // int32 occupied_stripe_count = 2;
   if (this->occupied_stripe_count() != 0) {
     target = stream->EnsureSpace(target);
-    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteUInt32ToArray(2, this->_internal_occupied_stripe_count(), target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(2, this->_internal_occupied_stripe_count(), target);
   }
 
   // .pos_bc.SegmentState state = 3;
@@ -702,17 +702,17 @@ size_t SegmentInfoDataProto::ByteSizeLong() const {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  // uint32 valid_block_count = 1;
+  // int32 valid_block_count = 1;
   if (this->valid_block_count() != 0) {
     total_size += 1 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt32Size(
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
         this->_internal_valid_block_count());
   }
 
-  // uint32 occupied_stripe_count = 2;
+  // int32 occupied_stripe_count = 2;
   if (this->occupied_stripe_count() != 0) {
     total_size += 1 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::UInt32Size(
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
         this->_internal_occupied_stripe_count());
   }
 

--- a/proto/generated/cpp/pos_bc.pb.h
+++ b/proto/generated/cpp/pos_bc.pb.h
@@ -352,22 +352,22 @@ class SegmentInfoDataProto PROTOBUF_FINAL :
     kOccupiedStripeCountFieldNumber = 2,
     kStateFieldNumber = 3,
   };
-  // uint32 valid_block_count = 1;
+  // int32 valid_block_count = 1;
   void clear_valid_block_count();
-  ::PROTOBUF_NAMESPACE_ID::uint32 valid_block_count() const;
-  void set_valid_block_count(::PROTOBUF_NAMESPACE_ID::uint32 value);
+  ::PROTOBUF_NAMESPACE_ID::int32 valid_block_count() const;
+  void set_valid_block_count(::PROTOBUF_NAMESPACE_ID::int32 value);
   private:
-  ::PROTOBUF_NAMESPACE_ID::uint32 _internal_valid_block_count() const;
-  void _internal_set_valid_block_count(::PROTOBUF_NAMESPACE_ID::uint32 value);
+  ::PROTOBUF_NAMESPACE_ID::int32 _internal_valid_block_count() const;
+  void _internal_set_valid_block_count(::PROTOBUF_NAMESPACE_ID::int32 value);
   public:
 
-  // uint32 occupied_stripe_count = 2;
+  // int32 occupied_stripe_count = 2;
   void clear_occupied_stripe_count();
-  ::PROTOBUF_NAMESPACE_ID::uint32 occupied_stripe_count() const;
-  void set_occupied_stripe_count(::PROTOBUF_NAMESPACE_ID::uint32 value);
+  ::PROTOBUF_NAMESPACE_ID::int32 occupied_stripe_count() const;
+  void set_occupied_stripe_count(::PROTOBUF_NAMESPACE_ID::int32 value);
   private:
-  ::PROTOBUF_NAMESPACE_ID::uint32 _internal_occupied_stripe_count() const;
-  void _internal_set_occupied_stripe_count(::PROTOBUF_NAMESPACE_ID::uint32 value);
+  ::PROTOBUF_NAMESPACE_ID::int32 _internal_occupied_stripe_count() const;
+  void _internal_set_occupied_stripe_count(::PROTOBUF_NAMESPACE_ID::int32 value);
   public:
 
   // .pos_bc.SegmentState state = 3;
@@ -386,8 +386,8 @@ class SegmentInfoDataProto PROTOBUF_FINAL :
   template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
   typedef void InternalArenaConstructable_;
   typedef void DestructorSkippable_;
-  ::PROTOBUF_NAMESPACE_ID::uint32 valid_block_count_;
-  ::PROTOBUF_NAMESPACE_ID::uint32 occupied_stripe_count_;
+  ::PROTOBUF_NAMESPACE_ID::int32 valid_block_count_;
+  ::PROTOBUF_NAMESPACE_ID::int32 occupied_stripe_count_;
   int state_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_pos_5fbc_2eproto;
@@ -2758,42 +2758,42 @@ class MapHeaderExtendedProto PROTOBUF_FINAL :
 #endif  // __GNUC__
 // SegmentInfoDataProto
 
-// uint32 valid_block_count = 1;
+// int32 valid_block_count = 1;
 inline void SegmentInfoDataProto::clear_valid_block_count() {
-  valid_block_count_ = 0u;
+  valid_block_count_ = 0;
 }
-inline ::PROTOBUF_NAMESPACE_ID::uint32 SegmentInfoDataProto::_internal_valid_block_count() const {
+inline ::PROTOBUF_NAMESPACE_ID::int32 SegmentInfoDataProto::_internal_valid_block_count() const {
   return valid_block_count_;
 }
-inline ::PROTOBUF_NAMESPACE_ID::uint32 SegmentInfoDataProto::valid_block_count() const {
+inline ::PROTOBUF_NAMESPACE_ID::int32 SegmentInfoDataProto::valid_block_count() const {
   // @@protoc_insertion_point(field_get:pos_bc.SegmentInfoDataProto.valid_block_count)
   return _internal_valid_block_count();
 }
-inline void SegmentInfoDataProto::_internal_set_valid_block_count(::PROTOBUF_NAMESPACE_ID::uint32 value) {
+inline void SegmentInfoDataProto::_internal_set_valid_block_count(::PROTOBUF_NAMESPACE_ID::int32 value) {
   
   valid_block_count_ = value;
 }
-inline void SegmentInfoDataProto::set_valid_block_count(::PROTOBUF_NAMESPACE_ID::uint32 value) {
+inline void SegmentInfoDataProto::set_valid_block_count(::PROTOBUF_NAMESPACE_ID::int32 value) {
   _internal_set_valid_block_count(value);
   // @@protoc_insertion_point(field_set:pos_bc.SegmentInfoDataProto.valid_block_count)
 }
 
-// uint32 occupied_stripe_count = 2;
+// int32 occupied_stripe_count = 2;
 inline void SegmentInfoDataProto::clear_occupied_stripe_count() {
-  occupied_stripe_count_ = 0u;
+  occupied_stripe_count_ = 0;
 }
-inline ::PROTOBUF_NAMESPACE_ID::uint32 SegmentInfoDataProto::_internal_occupied_stripe_count() const {
+inline ::PROTOBUF_NAMESPACE_ID::int32 SegmentInfoDataProto::_internal_occupied_stripe_count() const {
   return occupied_stripe_count_;
 }
-inline ::PROTOBUF_NAMESPACE_ID::uint32 SegmentInfoDataProto::occupied_stripe_count() const {
+inline ::PROTOBUF_NAMESPACE_ID::int32 SegmentInfoDataProto::occupied_stripe_count() const {
   // @@protoc_insertion_point(field_get:pos_bc.SegmentInfoDataProto.occupied_stripe_count)
   return _internal_occupied_stripe_count();
 }
-inline void SegmentInfoDataProto::_internal_set_occupied_stripe_count(::PROTOBUF_NAMESPACE_ID::uint32 value) {
+inline void SegmentInfoDataProto::_internal_set_occupied_stripe_count(::PROTOBUF_NAMESPACE_ID::int32 value) {
   
   occupied_stripe_count_ = value;
 }
-inline void SegmentInfoDataProto::set_occupied_stripe_count(::PROTOBUF_NAMESPACE_ID::uint32 value) {
+inline void SegmentInfoDataProto::set_occupied_stripe_count(::PROTOBUF_NAMESPACE_ID::int32 value) {
   _internal_set_occupied_stripe_count(value);
   // @@protoc_insertion_point(field_set:pos_bc.SegmentInfoDataProto.occupied_stripe_count)
 }

--- a/proto/pos_bc.proto
+++ b/proto/pos_bc.proto
@@ -13,8 +13,8 @@ enum SegmentState {
 
 // MAX: 128 bytes
 message SegmentInfoDataProto {
-    uint32 valid_block_count = 1;
-    uint32 occupied_stripe_count = 2;
+    int32 valid_block_count = 1;
+    int32 occupied_stripe_count = 2;
     SegmentState state = 3;
 
     // reserved fields

--- a/src/allocator/context_manager/context_io_manager.h
+++ b/src/allocator/context_manager/context_io_manager.h
@@ -63,6 +63,7 @@ public:
     virtual int Init(void);
     virtual void Dispose(void);
 
+    virtual int FlushContext(EventSmartPtr callback, ContextSectionBuffer externalBuf);
     virtual int FlushContexts(EventSmartPtr callback, bool sync,
         ContextSectionBuffer externalBuf);
 

--- a/src/allocator/context_manager/context_manager.cpp
+++ b/src/allocator/context_manager/context_manager.cpp
@@ -140,6 +140,12 @@ ContextManager::FlushContexts(EventSmartPtr callback, bool sync, ContextSectionB
     return ioManager->FlushContexts(callback, sync, buffer);
 }
 
+int
+ContextManager::FlushContext(EventSmartPtr callback, ContextSectionBuffer buffer)
+{
+    return ioManager->FlushContext(callback, buffer);
+}
+
 SegmentId
 ContextManager::AllocateFreeSegment(void)
 {

--- a/src/allocator/context_manager/context_manager.h
+++ b/src/allocator/context_manager/context_manager.h
@@ -75,6 +75,7 @@ public:
 
     virtual int FlushContexts(EventSmartPtr callback, bool sync);
     virtual int FlushContexts(EventSmartPtr callback, bool sync, ContextSectionBuffer buffer);
+    virtual int FlushContext(EventSmartPtr callback, ContextSectionBuffer buffer);
     virtual SegmentId AllocateFreeSegment(void);
     virtual SegmentId AllocateGCVictimSegment(void);
     virtual SegmentId AllocateRebuildTargetSegment(void);

--- a/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
@@ -290,10 +290,10 @@ SegmentCtx::ValidateBlks(VirtualBlks blks)
 }
 
 void
-SegmentCtx::_IncreaseValidBlockCount(SegmentId segId, uint32_t cnt)
+SegmentCtx::_IncreaseValidBlockCount(SegmentId segId, int cnt)
 {
-    uint32_t increasedValue = segmentInfos[segId].IncreaseValidBlockCount(cnt);
-    if (increasedValue > addrInfo->GetblksPerSegment())
+    int increasedValue = segmentInfos[segId].IncreaseValidBlockCount(cnt);
+    if ((uint32_t)increasedValue > addrInfo->GetblksPerSegment())
     {
         POS_TRACE_CRITICAL(EID(ALLOCATOR_VALID_BLOCK_COUNT_OVERFLOW),
             "segment_id:{} increase_count:{} total_valid_block_count:{}", segId, cnt, increasedValue);
@@ -309,7 +309,7 @@ SegmentCtx::InvalidateBlks(VirtualBlks blks, bool allowVictimSegRelease)
 }
 
 bool
-SegmentCtx::_DecreaseValidBlockCount(SegmentId segId, uint32_t cnt, bool allowVictimSegRelease)
+SegmentCtx::_DecreaseValidBlockCount(SegmentId segId, int cnt, bool allowVictimSegRelease)
 {
     auto result = segmentInfos[segId].DecreaseValidBlockCount(cnt, allowVictimSegRelease);
 
@@ -335,7 +335,7 @@ SegmentCtx::_DecreaseValidBlockCount(SegmentId segId, uint32_t cnt, bool allowVi
     return segmentFreed;
 }
 
-uint32_t
+int
 SegmentCtx::GetValidBlockCount(SegmentId segId)
 {
     return segmentInfos[segId].GetValidBlockCount();
@@ -351,10 +351,10 @@ SegmentCtx::UpdateOccupiedStripeCount(StripeId lsid)
 bool
 SegmentCtx::_IncreaseOccupiedStripeCount(SegmentId segId)
 {
-    uint32_t occupiedStripeCount = segmentInfos[segId].IncreaseOccupiedStripeCount();
+    int occupiedStripeCount = segmentInfos[segId].IncreaseOccupiedStripeCount();
     bool segmentFreed = false;
 
-    if (occupiedStripeCount == addrInfo->GetstripesPerSegment())
+    if ((uint32_t)occupiedStripeCount == addrInfo->GetstripesPerSegment())
     {
         // Only 1 thread reaches here
         SegmentState prevState = segmentInfos[segId].GetState();
@@ -374,7 +374,7 @@ SegmentCtx::_IncreaseOccupiedStripeCount(SegmentId segId)
     return segmentFreed;
 }
 
-uint32_t
+int
 SegmentCtx::GetOccupiedStripeCount(SegmentId segId)
 {
     return segmentInfos[segId].GetOccupiedStripeCount();
@@ -973,7 +973,7 @@ void
 SegmentCtx::CopySegmentInfoToBufferforWBT(WBTAllocatorMetaType type, char* dstBuf)
 {
     uint32_t numSegs = addrInfo->GetnumUserAreaSegments(); // for ut
-    uint32_t* dst = reinterpret_cast<uint32_t*>(dstBuf);
+    int* dst = reinterpret_cast<int*>(dstBuf);
     for (uint32_t segId = 0; segId < numSegs; segId++)
     {
         if (type == WBT_SEGMENT_VALID_COUNT)
@@ -991,7 +991,7 @@ void
 SegmentCtx::CopySegmentInfoFromBufferforWBT(WBTAllocatorMetaType type, char* srcBuf)
 {
     uint32_t numSegs = addrInfo->GetnumUserAreaSegments(); // for ut
-    uint32_t* src = reinterpret_cast<uint32_t*>(srcBuf);
+    int* src = reinterpret_cast<int*>(srcBuf);
     for (uint32_t segId = 0; segId < numSegs; segId++)
     {
         if (type == WBT_SEGMENT_VALID_COUNT)

--- a/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
@@ -166,9 +166,9 @@ SegmentCtx::Init(EventScheduler* eventScheduler_)
         {
             // This time, SegmentInfoData needs to be newly created "and initialized", hence we use AllocateAndInitSegmentInfoData()
             SegmentInfoData* infoData = infoDataArray + i;
-            this->segmentInfos[i].AllocateAndInitSegmentInfoData(infoData);
             this->segmentInfos[i].SetArrayId(addrInfo->GetArrayId());
             this->segmentInfos[i].SetSegmentId((SegmentId)i);
+            this->segmentInfos[i].AllocateAndInitSegmentInfoData(infoData);
 
             // Initialize context section for SegmentInfoData
             // "infoData" here has been already initialized to (0, 0, FREE) by AllocateAndInitSegmentInfoData() in the above.
@@ -294,7 +294,7 @@ void
 SegmentCtx::_IncreaseValidBlockCount(SegmentId segId, int cnt)
 {
     int increasedValue = segmentInfos[segId].IncreaseValidBlockCount(cnt);
-    if (segmentStateRebuilt == true && (uint32_t)increasedValue > addrInfo->GetblksPerSegment())
+    if (segmentStateRebuilt == true && increasedValue > (int)(addrInfo->GetblksPerSegment()))
     {
         POS_TRACE_CRITICAL(EID(ALLOCATOR_VALID_BLOCK_COUNT_OVERFLOW),
             "segment_id:{} increase_count:{} total_valid_block_count:{}", segId, cnt, increasedValue);
@@ -355,7 +355,7 @@ SegmentCtx::_IncreaseOccupiedStripeCount(SegmentId segId)
     int occupiedStripeCount = segmentInfos[segId].IncreaseOccupiedStripeCount();
     bool segmentFreed = false;
 
-    if ((uint32_t)occupiedStripeCount == addrInfo->GetstripesPerSegment())
+    if (occupiedStripeCount == (int)(addrInfo->GetstripesPerSegment()))
     {
         // Only 1 thread reaches here
         SegmentState prevState = segmentInfos[segId].GetState();

--- a/src/allocator/context_manager/segment_ctx/segment_ctx.h
+++ b/src/allocator/context_manager/segment_ctx/segment_ctx.h
@@ -166,6 +166,7 @@ protected:
     std::mutex segCtxLock;
 
     bool initialized;
+    bool segmentStateRebuilt;
 
     // Dependencies
     AllocatorAddressInfo* addrInfo;

--- a/src/allocator/context_manager/segment_ctx/segment_ctx.h
+++ b/src/allocator/context_manager/segment_ctx/segment_ctx.h
@@ -83,8 +83,8 @@ public:
     virtual uint64_t GetTotalDataSize(void) override;
 
     virtual bool MoveToFreeState(SegmentId segId);
-    virtual uint32_t GetValidBlockCount(SegmentId segId);
-    virtual uint32_t GetOccupiedStripeCount(SegmentId segId);
+    virtual int GetValidBlockCount(SegmentId segId);
+    virtual int GetOccupiedStripeCount(SegmentId segId);
     virtual SegmentState GetSegmentState(SegmentId segId);
     virtual void ResetSegmentsStates(void);
 
@@ -133,8 +133,8 @@ protected:
     void _BuildRebuildSegmentListFromTheList(SegmentState state);
     void _UpdateTelemetryOnVictimSegmentAllocation(SegmentId victimSegment);
 
-    void _IncreaseValidBlockCount(SegmentId segId, uint32_t cnt);
-    bool _DecreaseValidBlockCount(SegmentId segId, uint32_t cnt, bool allowVictimSegRelease);
+    void _IncreaseValidBlockCount(SegmentId segId, int cnt);
+    bool _DecreaseValidBlockCount(SegmentId segId, int cnt, bool allowVictimSegRelease);
     bool _IncreaseOccupiedStripeCount(SegmentId segId);
 
     int _OnNumFreeSegmentChanged(void);

--- a/src/allocator/context_manager/segment_ctx/segment_info.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_info.cpp
@@ -67,27 +67,27 @@ SegmentInfo::AllocateAndInitSegmentInfoData(SegmentInfoData* segmentInfoData)
     SetState(SegmentState::FREE);
 }
 
-uint32_t
+int
 SegmentInfo::GetValidBlockCount(void)
 {
     return data->validBlockCount;
 }
 
 void
-SegmentInfo::SetValidBlockCount(uint32_t cnt)
+SegmentInfo::SetValidBlockCount(int cnt)
 {
     // for wbt
     data->validBlockCount = cnt;
 }
 
-uint32_t
-SegmentInfo::IncreaseValidBlockCount(uint32_t inc)
+int
+SegmentInfo::IncreaseValidBlockCount(int inc)
 {
     return data->validBlockCount.fetch_add(inc) + inc;
 }
 
 std::pair<bool, SegmentState>
-SegmentInfo::DecreaseValidBlockCount(uint32_t dec, bool allowVictimSegRelease)
+SegmentInfo::DecreaseValidBlockCount(int dec, bool allowVictimSegRelease)
 {
     std::lock_guard<std::mutex> lock(seglock);
     int32_t decreased = data->validBlockCount.fetch_sub(dec) - dec;
@@ -126,18 +126,18 @@ SegmentInfo::DecreaseValidBlockCount(uint32_t dec, bool allowVictimSegRelease)
 }
 
 void
-SegmentInfo::SetOccupiedStripeCount(uint32_t cnt)
+SegmentInfo::SetOccupiedStripeCount(int cnt)
 {
     data->occupiedStripeCount = cnt;
 }
 
-uint32_t
+int
 SegmentInfo::GetOccupiedStripeCount(void)
 {
     return data->occupiedStripeCount;
 }
 
-uint32_t
+int
 SegmentInfo::IncreaseOccupiedStripeCount(void)
 {
     // ++ is equivalent to fetch_add(1) + 1
@@ -259,7 +259,7 @@ SegmentInfo::MoveToVictimState(void)
     }
 }
 
-uint32_t
+int
 SegmentInfo::GetValidBlockCountIfSsdState(void)
 {
     std::lock_guard<std::mutex> lock(seglock);

--- a/src/allocator/context_manager/segment_ctx/segment_info.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_info.cpp
@@ -90,7 +90,7 @@ std::pair<bool, SegmentState>
 SegmentInfo::DecreaseValidBlockCount(int dec, bool allowVictimSegRelease)
 {
     std::lock_guard<std::mutex> lock(seglock);
-    int32_t decreased = data->validBlockCount.fetch_sub(dec) - dec;
+    int decreased = data->validBlockCount.fetch_sub(dec) - dec;
 
     if (decreased == 0)
     {

--- a/src/allocator/context_manager/segment_ctx/segment_info.h
+++ b/src/allocator/context_manager/segment_ctx/segment_info.h
@@ -55,8 +55,8 @@ enum SegmentState : int
 struct SegmentInfoData
 {
 public:
-    std::atomic<uint32_t> validBlockCount;
-    std::atomic<uint32_t> occupiedStripeCount;
+    std::atomic<int> validBlockCount;
+    std::atomic<int> occupiedStripeCount;
     SegmentState state;
     // TODO(sang7.park) : add reserved field here.
     // DO NOT ADD ANY VIRTUAL METHODS HERE TO SUPPORT BACKWARD COMPATIBILITY
@@ -69,12 +69,12 @@ public:
         SegmentInfoData(target.validBlockCount, target.occupiedStripeCount, target.state);
     }
 
-    SegmentInfoData(uint32_t validBlockCount, uint32_t occupiedStripeCount, SegmentState segmentState)
+    SegmentInfoData(int validBlockCount, int occupiedStripeCount, SegmentState segmentState)
     {
         this->Set(validBlockCount, occupiedStripeCount, segmentState);
     }
 
-    void Set(uint32_t validBlockCount, uint32_t occupiedStripeCount, SegmentState segmentState)
+    void Set(int validBlockCount, int occupiedStripeCount, SegmentState segmentState)
     {
         this->validBlockCount = validBlockCount;
         this->occupiedStripeCount = occupiedStripeCount;
@@ -104,14 +104,14 @@ public:
 
     virtual void AllocateSegmentInfoData(SegmentInfoData* segmentInfoData);
     virtual void AllocateAndInitSegmentInfoData(SegmentInfoData* segmentInfoData);
-    virtual uint32_t GetValidBlockCount(void);
-    virtual void SetValidBlockCount(uint32_t cnt);
-    virtual uint32_t IncreaseValidBlockCount(uint32_t inc);
-    virtual std::pair<bool, SegmentState> DecreaseValidBlockCount(uint32_t dec, bool allowVictimSegRelease);
+    virtual int GetValidBlockCount(void);
+    virtual void SetValidBlockCount(int cnt);
+    virtual int IncreaseValidBlockCount(int inc);
+    virtual std::pair<bool, SegmentState> DecreaseValidBlockCount(int dec, bool allowVictimSegRelease);
 
-    virtual void SetOccupiedStripeCount(uint32_t cnt);
-    virtual uint32_t GetOccupiedStripeCount(void);
-    virtual uint32_t IncreaseOccupiedStripeCount(void);
+    virtual void SetOccupiedStripeCount(int cnt);
+    virtual int GetOccupiedStripeCount(void);
+    virtual int IncreaseOccupiedStripeCount(void);
 
     virtual void SetState(SegmentState newState);
     virtual SegmentState GetState(void);
@@ -125,7 +125,7 @@ public:
     virtual bool MoveToVictimState(void);
     virtual bool MoveVictimToFree(void);
 
-    virtual uint32_t GetValidBlockCountIfSsdState(void);
+    virtual int GetValidBlockCountIfSsdState(void);
     virtual void UpdateFrom(SegmentInfo &segmentInfo);
     static std::string ToSegmentStateString(SegmentState state);
 

--- a/src/allocator/i_context_manager.h
+++ b/src/allocator/i_context_manager.h
@@ -47,6 +47,7 @@ class IContextManager
 public:
     virtual int FlushContexts(EventSmartPtr callback, bool sync) = 0;
     virtual int FlushContexts(EventSmartPtr callback, bool sync, ContextSectionBuffer buffer) = 0;
+    virtual int FlushContext(EventSmartPtr callback, ContextSectionBuffer buffer) = 0;
     virtual uint64_t GetStoredContextVersion(int owner) = 0;
 
     virtual SegmentId AllocateFreeSegment(void) = 0;

--- a/src/journal_manager/checkpoint/checkpoint_handler.cpp
+++ b/src/journal_manager/checkpoint/checkpoint_handler.cpp
@@ -78,6 +78,7 @@ CheckpointHandler::Start(MapList pendingDirtyMaps, EventSmartPtr callback, int l
 {
     int ret = 0;
 
+    assert(checkpointCompletionCallback == nullptr);
     checkpointCompletionCallback = callback;
     _SetStatus(STARTED);
 
@@ -141,6 +142,7 @@ CheckpointHandler::StartSegmentCtx(EventSmartPtr callback, VersionedSegmentInfo*
 {
     int ret = 0;
 
+    assert(checkpointCompletionCallback == nullptr);
     checkpointCompletionCallback = callback;
     _SetStatus(STARTED);
 

--- a/src/journal_manager/checkpoint/checkpoint_handler.h
+++ b/src/journal_manager/checkpoint/checkpoint_handler.h
@@ -55,6 +55,7 @@ public:
     virtual void Init(IVersionedSegmentContext* versionedSegCtx, IMapFlush* mapFlushToUse, IContextManager* contextManagerToUse, EventScheduler* eventScheduler);
 
     virtual int Start(MapList pendingDirtyMaps, EventSmartPtr callback, int logGroupIdInProgress);
+    virtual int StartSegmentCtx(EventSmartPtr callback, VersionedSegmentInfo* versionedSegmentInfo);
     virtual int FlushCompleted(int metaId);
 
     virtual CheckpointStatus GetStatus(void);

--- a/src/journal_manager/checkpoint/checkpoint_manager.h
+++ b/src/journal_manager/checkpoint/checkpoint_manager.h
@@ -49,6 +49,7 @@ class CallbackSequenceController;
 class DirtyMapManager;
 class CheckpointHandler;
 class IVersionedSegmentContext;
+class VersionedSegmentInfo;
 class TelemetryPublisher;
 
 class CheckpointManager
@@ -64,7 +65,7 @@ public:
         DirtyMapManager* dMapManager, IVersionedSegmentContext* versionedSegCtx,
         TelemetryPublisher* tp);
     virtual int RequestCheckpoint(int logGroupId, EventSmartPtr callback);
-    virtual int StartCheckpoint(EventSmartPtr callback);
+    virtual int StartCheckpoint(EventSmartPtr callback, VersionedSegmentInfo* versionedSegmentInfo);
 
     virtual CheckpointStatus GetStatus(void);
 
@@ -78,12 +79,19 @@ public:
     int GetNumPendingCheckpointRequests(void);
 
 private:
+    enum CheckpointType
+    {
+        LOG_GROUP,
+        SEGMENT_CTX_ONLY
+    };
+
     struct CheckpointRequest
     {
-        int groupId;
+        CheckpointType type;
         EventSmartPtr callback;
+        int groupId;                         // only valid when it's LOG_GROUP checkpoint
+        VersionedSegmentInfo* versionedInfo; // only valid when it's SEGMENT_CTX_ONLY checkpoint
     };
-    CheckpointRequest invalid{INT32_MAX, nullptr};
 
     int _TryToStartCheckpoint(CheckpointRequest request);
     int _StartCheckpoint(CheckpointRequest request);

--- a/src/journal_manager/journal_manager.cpp
+++ b/src/journal_manager/journal_manager.cpp
@@ -240,7 +240,7 @@ JournalManager::_CreateVersionedSegmentCtx(void)
 {
     if ((true == config->IsEnabled()) && (true == config->IsVscEnabled()))
     {
-        return new VersionedSegmentCtx(arrayInfo);
+        return new VersionedSegmentCtx();
     }
     else
     {
@@ -490,7 +490,7 @@ JournalManager::_InitModules(TelemetryClient* tc, IVSAMap* vsaMap, IStripeMap* s
         sequenceController, dirtyMapManager, versionedSegCtx, telemetryPublisher);
 
     const PartitionLogicalSize* udSize = arrayInfo->GetSizeInfo(PartitionType::USER_DATA);
-    versionedSegCtx->Init(config, udSize->totalSegments);
+    versionedSegCtx->Init(config, udSize->totalSegments, udSize->stripesPerSegment);
 
     logWriteContextFactory->Init(config);
     logBufferIoContextFactory->Init(config, logFilledNotifier, sequenceController);
@@ -509,7 +509,7 @@ JournalManager::_InitModules(TelemetryClient* tc, IVSAMap* vsaMap, IStripeMap* s
     logWriteHandler->Init(bufferAllocator, logBuffer, config, EasyTelemetryPublisherSingleton::Instance(),
         arrayInfo->GetIndex(), new ConcurrentMetaFsTimeInterval(config->GetIntervalForMetric()));
     volumeEventHandler->Init(logWriteContextFactory, checkpointManager, dirtyMapManager, logWriteHandler,
-        config, contextManager, eventScheduler);
+        config, contextManager, eventScheduler, udSize->stripesPerSegment);
     journalWriter->Init(logWriteHandler, logWriteContextFactory, eventFactory, &journalingStatus, eventScheduler);
 
     replayHandler->Init(config, logBuffer, vsaMap, stripeMap, mapFlush, segmentCtx, versionedSegCtx,

--- a/src/journal_manager/log_buffer/i_versioned_segment_context.h
+++ b/src/journal_manager/log_buffer/i_versioned_segment_context.h
@@ -48,7 +48,7 @@ class IVersionedSegmentContext: public LogBufferWriteDoneEvent, public ISegmentF
 public:
     virtual ~IVersionedSegmentContext(void) = default;
 
-    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments) = 0;
+    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments, uint32_t numStripesPerSegment) = 0;
     virtual void Load(SegmentInfoData* loadedSegmentInfos) = 0;
     virtual void Dispose(void) = 0;
     virtual void IncreaseValidBlockCount(int logGroupId, SegmentId segId, uint32_t cnt) = 0;

--- a/src/journal_manager/log_buffer/i_versioned_segment_context.h
+++ b/src/journal_manager/log_buffer/i_versioned_segment_context.h
@@ -55,6 +55,7 @@ public:
     virtual void DecreaseValidBlockCount(int logGroupId, SegmentId segId, uint32_t cnt) = 0;
     virtual void IncreaseOccupiedStripeCount(int logGroupId, SegmentId segId) = 0;
     virtual SegmentInfoData* GetUpdatedInfoDataToFlush(int logGroupId) = 0;
+    virtual SegmentInfoData* GetUpdatedInfoDataToFlush(VersionedSegmentInfo* info) = 0;
     virtual int GetNumSegments(void) = 0;
     virtual int GetNumLogGroups(void) = 0;
 

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.cpp
@@ -35,7 +35,6 @@
 #include <unordered_map>
 
 #include "src/allocator/context_manager/segment_ctx/segment_info.h"
-#include "src/array_models/interface/i_array_info.h"
 #include "src/include/pos_event_id.h"
 #include "src/journal_manager/config/journal_configuration.h"
 #include "src/journal_manager/log_buffer/versioned_segment_info.h"
@@ -43,9 +42,8 @@
 
 namespace pos
 {
-VersionedSegmentCtx::VersionedSegmentCtx(IArrayInfo* arrayInfo)
+VersionedSegmentCtx::VersionedSegmentCtx(void)
 : config(nullptr),
-  arrayInfo(arrayInfo),
   numSegments(0),
   segmentInfoData(nullptr)
 {
@@ -57,13 +55,13 @@ VersionedSegmentCtx::~VersionedSegmentCtx(void)
 }
 
 void
-VersionedSegmentCtx::Init(JournalConfiguration* journalConfiguration, uint32_t numSegments_)
+VersionedSegmentCtx::Init(JournalConfiguration* journalConfiguration, uint32_t numSegments_, uint32_t numStripesPerSegment)
 {
     _Init(journalConfiguration, numSegments_);
 
     for (int index = 0; index < config->GetNumLogGroups(); index++)
     {
-        std::shared_ptr<VersionedSegmentInfo> segmentInfo(new VersionedSegmentInfo(arrayInfo));
+        std::shared_ptr<VersionedSegmentInfo> segmentInfo(new VersionedSegmentInfo(numStripesPerSegment));
         segmentInfoDiffs.push_back(segmentInfo);
     }
 }

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.h
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.h
@@ -57,6 +57,7 @@ public:
     virtual void DecreaseValidBlockCount(int logGroupId, SegmentId segId, uint32_t cnt) override {}
     virtual void IncreaseOccupiedStripeCount(int logGroupId, SegmentId segId) override {}
     virtual SegmentInfoData* GetUpdatedInfoDataToFlush(int logGroupId) override { return nullptr; }
+    virtual SegmentInfoData* GetUpdatedInfoDataToFlush(VersionedSegmentInfo* info) override { return nullptr; }
     virtual int GetNumSegments(void) override { return 0; }
     virtual int GetNumLogGroups(void) override { return 0; };
     virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments,
@@ -90,6 +91,7 @@ public:
     virtual void IncreaseOccupiedStripeCount(int logGroupId, SegmentId segId) override;
 
     virtual SegmentInfoData* GetUpdatedInfoDataToFlush(int logGroupId) override;
+    virtual SegmentInfoData* GetUpdatedInfoDataToFlush(VersionedSegmentInfo* info) override;
     virtual int GetNumSegments(void) override;
     virtual int GetNumLogGroups(void) override;
 
@@ -103,6 +105,7 @@ public:
 private:
     void _Init(JournalConfiguration* journalConfiguration, uint32_t numSegments_);
     void _UpdateSegmentContext(int logGroupId);
+    void _UpdateSegmentContext(VersionedSegmentInfo* targetSegInfo);
     void _CheckLogGroupIdValidity(int logGroupId);
     void _CheckSegIdValidity(int segId);
 

--- a/src/journal_manager/log_buffer/versioned_segment_ctx.h
+++ b/src/journal_manager/log_buffer/versioned_segment_ctx.h
@@ -41,7 +41,6 @@
 
 namespace pos
 {
-class IArrayInfo;
 class VersionedSegmentInfo;
 class JournalConfiguration;
 class SegmentInfoData;
@@ -49,10 +48,9 @@ class DummyVersionedSegmentCtx : public IVersionedSegmentContext
 {
 public:
     DummyVersionedSegmentCtx(void) = default;
-    DummyVersionedSegmentCtx(IArrayInfo* arrayInfo) {}
     virtual ~DummyVersionedSegmentCtx(void) = default;
 
-    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments) override {}
+    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments, uint32_t numStripesPerSegment) override {}
     virtual void Load(SegmentInfoData* loadedSegmentInfos) override {}
     virtual void Dispose(void) override {}
     virtual void IncreaseValidBlockCount(int logGroupId, SegmentId segId, uint32_t cnt) override {}
@@ -75,11 +73,10 @@ public:
 class VersionedSegmentCtx : public IVersionedSegmentContext
 {
 public:
-    VersionedSegmentCtx(void) = default;
-    VersionedSegmentCtx(IArrayInfo* arrayInfo);
+    VersionedSegmentCtx(void);
     virtual ~VersionedSegmentCtx(void);
 
-    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments) override;
+    virtual void Init(JournalConfiguration* journalConfiguration, uint32_t numSegments, uint32_t numStripesPerSegment) override;
     virtual void Load(SegmentInfoData* loadedSegmentInfos) override;
     virtual void Dispose(void) override;
 
@@ -110,7 +107,6 @@ private:
     void _CheckSegIdValidity(int segId);
 
     JournalConfiguration* config;
-    IArrayInfo* arrayInfo;
     uint32_t numSegments;
     std::vector<std::shared_ptr<VersionedSegmentInfo>> segmentInfoDiffs;
     SegmentInfoData* segmentInfoData;

--- a/src/journal_manager/log_buffer/versioned_segment_info.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_info.cpp
@@ -39,8 +39,8 @@
 
 namespace pos
 {
-VersionedSegmentInfo::VersionedSegmentInfo(IArrayInfo* arrayInfo)
-: arrayInfo(arrayInfo)
+VersionedSegmentInfo::VersionedSegmentInfo(uint32_t stripesPerSegment)
+: numStripesPerSegment(stripesPerSegment)
 {
 }
 
@@ -77,7 +77,6 @@ VersionedSegmentInfo::IncreaseOccupiedStripeCount(SegmentId segId)
 void
 VersionedSegmentInfo::ResetOccupiedStripeCount(SegmentId segId)
 {
-    uint32_t numStripesPerSegment = arrayInfo->GetSizeInfo(PartitionType::USER_DATA)->stripesPerSegment;
     changedOccupiedStripeCount[segId] -= numStripesPerSegment;
 }
 
@@ -92,4 +91,30 @@ VersionedSegmentInfo::GetChangedOccupiedStripeCount(void)
 {
     return this->changedOccupiedStripeCount;
 }
+
+void
+VersionedSegmentInfo::ValidateBlks(VirtualBlks blks)
+{
+    SegmentId segmentId = _StripeIdToSegmentId(blks.startVsa.stripeId);
+    changedValidBlockCount[segmentId].fetch_and_add(blks.numBlks);
+}
+
+bool
+VersionedSegmentInfo::InvalidateBlks(VirtualBlks blks, bool isForced)
+{
+    SegmentId segmentId = _StripeIdToSegmentId(blks.startVsa.stripeId);
+    changedValidBlockCount[segmentId].fetch_and_add(-1 * (int)blks.numBlks);
+
+    return false;
+}
+
+bool
+VersionedSegmentInfo::UpdateOccupiedStripeCount(StripeId lsid)
+{
+    SegmentId segmentId = _StripeIdToSegmentId(lsid);
+    changedOccupiedStripeCount[segmentId].fetch_and_add(1);
+
+    return false;
+}
+    
 } // namespace pos

--- a/src/journal_manager/log_write/i_journal_volume_event_handler.h
+++ b/src/journal_manager/log_write/i_journal_volume_event_handler.h
@@ -34,11 +34,14 @@
 
 namespace pos
 {
+class ISegmentCtx;
+
 class IJournalVolumeEventHandler
 {
 public:
     virtual int WriteVolumeDeletedLog(int volId) = 0;
     virtual int TriggerMetadataFlush(void) = 0;
+    virtual ISegmentCtx* AllocateSegmentCtxToUse(void) = 0;
 };
 
 } // namespace pos

--- a/src/journal_manager/log_write/journal_volume_event_handler.cpp
+++ b/src/journal_manager/log_write/journal_volume_event_handler.cpp
@@ -151,7 +151,7 @@ JournalVolumeEventHandler::TriggerMetadataFlush(void)
         "Start checkpoint, triggered by volume deletion");
 
     EventSmartPtr callback(new MetaFlushCompleted(this));
-    int ret = checkpointManager->StartCheckpoint(callback);
+    int ret = checkpointManager->StartCheckpoint(callback, versionedSegmentInfo);
     if (ret == 0)
     {
         _WaitForAllocatorContextFlushCompleted();

--- a/src/journal_manager/log_write/journal_volume_event_handler.h
+++ b/src/journal_manager/log_write/journal_volume_event_handler.h
@@ -60,10 +60,12 @@ public:
     virtual void Init(LogWriteContextFactory* logFactory,
         CheckpointManager* cpManager, DirtyMapManager* dirtyManager,
         LogWriteHandler* logWritter, JournalConfiguration* journalConfiguration,
-        IContextManager* contextManager, EventScheduler* scheduler);
+        IContextManager* contextManager, EventScheduler* scheduler,
+        uint32_t numStripesPerSegment);
 
     virtual int WriteVolumeDeletedLog(int volId) override;
     virtual int TriggerMetadataFlush(void) override;
+    virtual ISegmentCtx* AllocateSegmentCtxToUse(void) override;
 
     virtual void MetaFlushed(void) override;
 
@@ -94,6 +96,9 @@ private:
     std::mutex flushMutex;
     std::condition_variable flushCondVar;
     bool flushInProgress;
+
+    uint32_t numStripesPerSegment;
+    VersionedSegmentInfo* versionedSegmentInfo;
 };
 
 } // namespace pos

--- a/src/journal_manager/replay/replay_block_map_update.cpp
+++ b/src/journal_manager/replay/replay_block_map_update.cpp
@@ -116,7 +116,7 @@ ReplayBlockMapUpdate::_InvalidateOldBlock(uint32_t offset)
         VirtualBlks blksToInvalidate = {
             .startVsa = read,
             .numBlks = 1};
-        bool allowVictimSegRelease = true;
+        bool allowVictimSegRelease = false;
         segmentCtx->InvalidateBlks(blksToInvalidate, allowVictimSegRelease);
         status->BlockInvalidated(blksToInvalidate.numBlks);
     }

--- a/src/journal_manager/replay/replay_block_map_update.cpp
+++ b/src/journal_manager/replay/replay_block_map_update.cpp
@@ -65,7 +65,14 @@ ReplayBlockMapUpdate::_ReadBlockMap(void)
 
     for (uint32_t offset = 0; offset < numBlks; offset++)
     {
-        readMap[offset] = vsaMap->GetVSAWithSyncOpen(volId, startRba + offset);
+        if (needToReplayBlockMap == true)
+        {
+            readMap[offset] = vsaMap->GetVSAWithSyncOpen(volId, startRba + offset);
+        }
+        else
+        {
+            readMap[offset] = UNMAP_VSA;
+        }
     }
 }
 
@@ -91,7 +98,7 @@ ReplayBlockMapUpdate::Replay(void)
         result = _UpdateMapAndValidate(offset);
     }
 
-    if (status->IsFlushed() == false)
+    if (status->IsFlushed() == false && needToReplayBlockMap == true)
     {
         for (uint32_t offset = 0; offset < numBlks; offset++)
         {

--- a/src/journal_manager/replay/replay_block_map_update.h
+++ b/src/journal_manager/replay/replay_block_map_update.h
@@ -46,6 +46,7 @@ class ActiveWBStripeReplayer;
 class ReplayBlockMapUpdate : public ReplayEvent
 {
 public:
+    ReplayBlockMapUpdate(void) = default;
     ReplayBlockMapUpdate(IVSAMap* ivsaMa, ISegmentCtx* segmentCtx,
         StripeReplayStatus* status, ActiveWBStripeReplayer* wbReplayer,
         int volId, BlkAddr startRba, VirtualBlkAddr startVsa, uint64_t numBlks,
@@ -60,11 +61,13 @@ public:
         return ReplayEventType::BLOCK_MAP_UPDATE;
     }
 
+    virtual void MarkNotToReplayMap(void);
+
 private:
     void _ReadBlockMap(void);
 
     void _InvalidateOldBlock(uint32_t offset);
-    int _UpdateMap(uint32_t offset);
+    int _UpdateMapAndValidate(uint32_t offset);
     void _UpdateReverseMap(uint32_t offset);
 
     inline VirtualBlkAddr
@@ -92,6 +95,7 @@ private:
     std::vector<VirtualBlkAddr> readMap;
 
     bool needToReplaySegmentInfo;
+    bool needToReplayBlockMap;
     ActiveWBStripeReplayer* wbStripeReplayer;
 };
 } // namespace pos

--- a/src/journal_manager/replay/replay_logs.cpp
+++ b/src/journal_manager/replay/replay_logs.cpp
@@ -234,7 +234,7 @@ ReplayLogs::_ReplayStripe(ReplayStripe* stripe)
 {
     if (logDeleteChecker->IsDeleted(stripe->GetVolumeId()))
     {
-        stripe->DeleteBlockMapReplayEvents();
+        stripe->MarkBlockMapUpdateToSkip();
     }
 
     return stripe->Replay();

--- a/src/journal_manager/replay/replay_stripe.h
+++ b/src/journal_manager/replay/replay_stripe.h
@@ -75,7 +75,7 @@ public:
     int GetVolumeId(void) { return status->GetVolumeId(); }
     bool IsFlushed(void) { return status->IsFlushed(); }
 
-    void DeleteBlockMapReplayEvents(void);
+    void MarkBlockMapUpdateToSkip(void);
 
 protected:
     void _CreateSegmentAllocationEvent(void);

--- a/src/metadata/meta_volume_event_handler.cpp
+++ b/src/metadata/meta_volume_event_handler.cpp
@@ -120,7 +120,17 @@ MetaVolumeEventHandler::VolumeDeleted(VolumeEventBase* volEventBase, VolumeArray
     }
 
     // Invalidate all blocks in the volume
-    result = mapper->InvalidateAllBlocksTo(volEventBase->volId, allocator->GetISegmentCtx());
+    auto segmentCtxToUse = allocator->GetISegmentCtx();
+    if (journal != nullptr)
+    {
+        auto toUse = journal->AllocateSegmentCtxToUse();
+        if (toUse != nullptr)
+        {
+            segmentCtxToUse = toUse;
+        }
+    }
+
+    result = mapper->InvalidateAllBlocksTo(volEventBase->volId, segmentCtxToUse);
     if (result != 0)
     {
         return result;

--- a/src/metadata/metadata.cpp
+++ b/src/metadata/metadata.cpp
@@ -195,8 +195,10 @@ Metadata::Init(void)
         return result;
     }
 
+    auto segmentCtx = allocator->GetIContextManager()->GetSegmentCtx();
+    segmentCtx->ResetSegmentsStates();
+
     auto freeSubscriber = journal->GetSegmentFreeSubscriber();
-    auto segmentCtx = allocator->GetISegmentCtx();
     segmentCtx->AddSegmentFreeSubscriber(freeSubscriber);    
 
     return result;

--- a/test/integration-tests/journal/fake/i_context_manager_fake.h
+++ b/test/integration-tests/journal/fake/i_context_manager_fake.h
@@ -26,6 +26,7 @@ public:
     virtual uint64_t GetStoredContextVersion(int owner) override;
     virtual SegmentCtx* GetSegmentCtx(void) override;
 
+    virtual int FlushContext(EventSmartPtr callback, ContextSectionBuffer buffer) { return 0; }
     virtual int FlushContexts(EventSmartPtr callback, bool sync) { return 0; }
     virtual SegmentId AllocateFreeSegment(void) { return 0; }
     virtual SegmentId AllocateGCVictimSegment(void) { return 0; }

--- a/test/integration-tests/journal/fixture/replay_test_fixture.cpp
+++ b/test/integration-tests/journal/fixture/replay_test_fixture.cpp
@@ -158,7 +158,7 @@ ReplayTestFixture::ExpectReplayOverwrittenBlockLog(StripeTestFixture stripe)
         for (uint32_t blockOffset = 0; blockOffset < (*vsa).second.numBlks; blockOffset++)
         {
             VirtualBlks blks = _GetBlock((*vsa).second, blockOffset);
-            EXPECT_CALL(*(allocator->GetSegmentCtxFake()), InvalidateBlks(blks, true));
+            EXPECT_CALL(*(allocator->GetSegmentCtxFake()), InvalidateBlks(blks, false));
         }
     }
 }

--- a/test/integration-tests/segmentCtx/segment_ctx_tester.h
+++ b/test/integration-tests/segmentCtx/segment_ctx_tester.h
@@ -49,8 +49,8 @@ public:
     MOCK_METHOD(int, GetAllocatedSegmentCount, (), (override));
     MOCK_METHOD(void, ValidateBlks, (VirtualBlks blks), (override));
     MOCK_METHOD(bool, InvalidateBlks, (VirtualBlks blks, bool allowVictimSegRelease), (override));
-    MOCK_METHOD(uint32_t, GetValidBlockCount, (SegmentId segId), (override));
-    MOCK_METHOD(uint32_t, GetOccupiedStripeCount, (SegmentId segId), (override));
+    MOCK_METHOD(int, GetValidBlockCount, (SegmentId segId), (override));
+    MOCK_METHOD(int, GetOccupiedStripeCount, (SegmentId segId), (override));
     MOCK_METHOD(bool, UpdateOccupiedStripeCount, (StripeId lsid), (override));
     MOCK_METHOD(SegmentInfoData*, GetSegmentInfoDataArray, (), (override));
 

--- a/test/unit-tests/allocator/context_manager/rebuild_ctx/rebuild_ctx_test.cpp
+++ b/test/unit-tests/allocator/context_manager/rebuild_ctx/rebuild_ctx_test.cpp
@@ -92,7 +92,7 @@ TEST(RebuildCtx, AfterFlush_TestSimpleSetter)
     NiceMock<MockAllocatorAddressInfo> addrInfo;
     RebuildCtx rebuildCtx(nullptr, &addrInfo);
     AsyncMetaFileIoCtx ctx;
-    char buf[sizeof(RebuildCtxHeader)];
+    char buf[rebuildCtx.GetTotalDataSize()];
     InitializeRebuildCtxHeader(buf);
     ctx.SetIoInfo(MetaFsIoOpcode::Write, 0, sizeof(buf), buf);
     // when
@@ -164,7 +164,7 @@ TEST(RebuildCtx, AfterLoad_testIfSegmentSignatureSuccessAndSetBuf)
     RebuildCtx rebuildCtx(nullptr, &header, &addrInfo);
     rebuildCtx.Init();
 
-    char buf[sizeof(RebuildCtxHeader) + 3 * sizeof(int)];
+    char buf[rebuildCtx.GetTotalDataSize()];
     InitializeRebuildCtxHeader(buf, 3);
 
     // when 1.
@@ -184,7 +184,7 @@ TEST(RebuildCtx, AfterLoad_testIfStoredVersionIsUpdated)
     RebuildCtx rebuildCtx(nullptr, &header, &addrInfo);
     rebuildCtx.Init();
 
-    char buf[sizeof(RebuildCtxHeader) + 3 * sizeof(int)];
+    char buf[rebuildCtx.GetTotalDataSize()];
     InitializeRebuildCtxHeader(buf, 3, header.ctxVersion + 1);
 
     // when 1.

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_mock.h
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_mock.h
@@ -23,8 +23,8 @@ public:
     MOCK_METHOD(int, GetNumSections, (), (override));
     MOCK_METHOD(uint64_t, GetTotalDataSize, (), (override));
     MOCK_METHOD(bool, MoveToFreeState, (SegmentId segId), (override));
-    MOCK_METHOD(uint32_t, GetValidBlockCount, (SegmentId segId), (override));
-    MOCK_METHOD(uint32_t, GetOccupiedStripeCount, (SegmentId segId), (override));
+    MOCK_METHOD(int, GetValidBlockCount, (SegmentId segId), (override));
+    MOCK_METHOD(int, GetOccupiedStripeCount, (SegmentId segId), (override));
     MOCK_METHOD(SegmentState, GetSegmentState, (SegmentId segId), (override));
     MOCK_METHOD(void, ResetSegmentsStates, (), (override));
     MOCK_METHOD(void, AllocateSegment, (SegmentId segId), (override));

--- a/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_mock.h
+++ b/test/unit-tests/allocator/context_manager/segment_ctx/segment_info_mock.h
@@ -12,18 +12,18 @@ class MockSegmentInfo : public SegmentInfo
 public:
     using SegmentInfo::SegmentInfo;
     MOCK_METHOD(void, AllocateAndInitSegmentInfoData, (SegmentInfoData* segmentInfoData), (override));
-    MOCK_METHOD(uint32_t, GetValidBlockCount, (), (override));
-    MOCK_METHOD(void, SetValidBlockCount, (uint32_t cnt), (override));
-    MOCK_METHOD(uint32_t, IncreaseValidBlockCount, (uint32_t inc), (override));
-    MOCK_METHOD((std::pair<bool, SegmentState>), DecreaseValidBlockCount, (uint32_t dec, bool allowVictimSegRelease), (override));
-    MOCK_METHOD(void, SetOccupiedStripeCount, (uint32_t cnt), (override));
-    MOCK_METHOD(uint32_t, GetOccupiedStripeCount, (), (override));
-    MOCK_METHOD(uint32_t, IncreaseOccupiedStripeCount, (), (override));
+    MOCK_METHOD(int, GetValidBlockCount, (), (override));
+    MOCK_METHOD(void, SetValidBlockCount, (int cnt), (override));
+    MOCK_METHOD(int, IncreaseValidBlockCount, (int inc), (override));
+    MOCK_METHOD((std::pair<bool, SegmentState>), DecreaseValidBlockCount, (int dec, bool allowVictimSegRelease), (override));
+    MOCK_METHOD(void, SetOccupiedStripeCount, (int cnt), (override));
+    MOCK_METHOD(int, GetOccupiedStripeCount, (), (override));
+    MOCK_METHOD(int, IncreaseOccupiedStripeCount, (), (override));
     MOCK_METHOD(SegmentState, GetState, (), (override));
     MOCK_METHOD(void, MoveToNvramState, (), (override));
     MOCK_METHOD(bool, MoveToSsdStateOrFreeStateIfItBecomesEmpty, (), (override));
     MOCK_METHOD(bool, MoveToVictimState, (), (override));
-    MOCK_METHOD(uint32_t, GetValidBlockCountIfSsdState, (), (override));
+    MOCK_METHOD(int, GetValidBlockCountIfSsdState, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/allocator/i_context_manager_mock.h
+++ b/test/unit-tests/allocator/i_context_manager_mock.h
@@ -12,6 +12,7 @@ public:
     using IContextManager::IContextManager;
     MOCK_METHOD(int, FlushContexts, (EventSmartPtr callback, bool sync), (override));
     MOCK_METHOD(int, FlushContexts, (EventSmartPtr callback, bool sync, ContextSectionBuffer buffer), (override));
+    MOCK_METHOD(int, FlushContext, (EventSmartPtr callback, ContextSectionBuffer buffer), (override));
     MOCK_METHOD(uint64_t, GetStoredContextVersion, (int owner), (override));
     MOCK_METHOD(SegmentId, AllocateFreeSegment, (), (override));
     MOCK_METHOD(SegmentId, AllocateGCVictimSegment, (), (override));

--- a/test/unit-tests/journal_manager/checkpoint/checkpoint_handler_mock.h
+++ b/test/unit-tests/journal_manager/checkpoint/checkpoint_handler_mock.h
@@ -14,6 +14,7 @@ public:
     using CheckpointHandler::CheckpointHandler;
     MOCK_METHOD(void, Init, (IVersionedSegmentContext* versionedSegCtx, IMapFlush * mapFlush, IContextManager* contextManager, EventScheduler* scheduler), (override));
     MOCK_METHOD(int, Start, (MapList pendingDirtyMaps, EventSmartPtr callback, int logGroupIdInProgress), (override));
+    MOCK_METHOD(int, StartSegmentCtx, (EventSmartPtr callback, VersionedSegmentInfo* versionedSegmentInfo), (override));
     MOCK_METHOD(int, FlushCompleted, (int metaId), (override));
     MOCK_METHOD(CheckpointStatus, GetStatus, (), (override));
 };

--- a/test/unit-tests/journal_manager/checkpoint/checkpoint_manager_mock.h
+++ b/test/unit-tests/journal_manager/checkpoint/checkpoint_manager_mock.h
@@ -12,7 +12,7 @@ public:
     using CheckpointManager::CheckpointManager;
     MOCK_METHOD(void, Init, (IMapFlush* mapFlush, IContextManager* ctxManager, EventScheduler* scheduler, CallbackSequenceController* seqController, DirtyMapManager* dMapManager, IVersionedSegmentContext* versionedSegCtx, TelemetryPublisher* tp), (override));
     MOCK_METHOD(int, RequestCheckpoint, (int logGroupId, EventSmartPtr callback), (override));
-    MOCK_METHOD(int, StartCheckpoint, (EventSmartPtr callback), (override));
+    MOCK_METHOD(int, StartCheckpoint, (EventSmartPtr callback, VersionedSegmentInfo* versionedSegmentInfo), (override));
     MOCK_METHOD(CheckpointStatus, GetStatus, (), (override));
     MOCK_METHOD(void, CheckpointCompleted, (), (override));
     MOCK_METHOD(void, BlockCheckpointAndWaitToBeIdle, (), (override));

--- a/test/unit-tests/journal_manager/config/journal_configuration_mock.h
+++ b/test/unit-tests/journal_manager/config/journal_configuration_mock.h
@@ -13,6 +13,7 @@ public:
     MOCK_METHOD(void, Init, (bool isWriteThroughEnabled), (override));
     MOCK_METHOD(int, SetLogBufferSize, (uint64_t loadedLogBufferSize, MetaFs* metaFs), (override));
     MOCK_METHOD(bool, IsEnabled, (), (override));
+    MOCK_METHOD(bool, IsVscEnabled, (), (override));
     MOCK_METHOD(bool, IsDebugEnabled, (), (override));
     MOCK_METHOD(bool, AreReplayWbStripesInUserArea, (), (override));
     MOCK_METHOD(bool, IsRocksdbEnabled, (), (override));

--- a/test/unit-tests/journal_manager/log_buffer/i_versioned_segment_context_mock.h
+++ b/test/unit-tests/journal_manager/log_buffer/i_versioned_segment_context_mock.h
@@ -12,7 +12,7 @@ class MockIVersionedSegmentContext : public IVersionedSegmentContext
 {
 public:
     using IVersionedSegmentContext::IVersionedSegmentContext;
-    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments), (override));
+    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments, uint32_t numStripesPerSegment), (override));
     MOCK_METHOD(void, Load, (SegmentInfoData * loadedSegmentInfos), (override));
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(void, IncreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));

--- a/test/unit-tests/journal_manager/log_buffer/i_versioned_segment_context_mock.h
+++ b/test/unit-tests/journal_manager/log_buffer/i_versioned_segment_context_mock.h
@@ -19,6 +19,7 @@ public:
     MOCK_METHOD(void, DecreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));
     MOCK_METHOD(void, IncreaseOccupiedStripeCount, (int logGroupId, SegmentId segId), (override));
     MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (int logGroupId), (override));
+    MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (VersionedSegmentInfo * info), (override));
     MOCK_METHOD(int, GetNumSegments, (), (override));
     MOCK_METHOD(int, GetNumLogGroups, (), (override));
     MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments, std::vector<std::shared_ptr<VersionedSegmentInfo>> inputVersionedSegmentInfo), (override));

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_mock.h
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_mock.h
@@ -44,7 +44,7 @@ class MockDummyVersionedSegmentCtx : public DummyVersionedSegmentCtx
 {
 public:
     using DummyVersionedSegmentCtx::DummyVersionedSegmentCtx;
-    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments), (override));
+    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments, uint32_t numStripesPerSegment), (override));
     MOCK_METHOD(void, Load, (SegmentInfoData * loadedSegmentInfos), (override));
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(void, IncreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));
@@ -63,7 +63,7 @@ class MockVersionedSegmentCtx : public VersionedSegmentCtx
 {
 public:
     using VersionedSegmentCtx::VersionedSegmentCtx;
-    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments), (override));
+    MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments, uint32_t numStripesPerSegment), (override));
     MOCK_METHOD(void, Load, (SegmentInfoData * loadedSegmentInfos), (override));
     MOCK_METHOD(void, Dispose, (), (override));
     MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments, std::vector<std::shared_ptr<VersionedSegmentInfo>> inputVersionedSegmentInfo), (override));

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_mock.h
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_ctx_mock.h
@@ -51,6 +51,7 @@ public:
     MOCK_METHOD(void, DecreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));
     MOCK_METHOD(void, IncreaseOccupiedStripeCount, (int logGroupId, SegmentId segId), (override));
     MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (int logGroupId), (override));
+    MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (VersionedSegmentInfo * info), (override));
     MOCK_METHOD(int, GetNumSegments, (), (override));
     MOCK_METHOD(int, GetNumLogGroups, (), (override));
     MOCK_METHOD(void, Init, (JournalConfiguration * journalConfiguration, uint32_t numSegments, std::vector<std::shared_ptr<VersionedSegmentInfo>> inputVersionedSegmentInfo), (override));
@@ -71,6 +72,7 @@ public:
     MOCK_METHOD(void, DecreaseValidBlockCount, (int logGroupId, SegmentId segId, uint32_t cnt), (override));
     MOCK_METHOD(void, IncreaseOccupiedStripeCount, (int logGroupId, SegmentId segId), (override));
     MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (int logGroupId), (override));
+    MOCK_METHOD(SegmentInfoData*, GetUpdatedInfoDataToFlush, (VersionedSegmentInfo * info), (override));
     MOCK_METHOD(int, GetNumSegments, (), (override));
     MOCK_METHOD(int, GetNumLogGroups, (), (override));
     MOCK_METHOD(void, LogFilled, (int logGroupId, const MapList& dirty), (override));

--- a/test/unit-tests/journal_manager/log_buffer/versioned_segment_info_test.cpp
+++ b/test/unit-tests/journal_manager/log_buffer/versioned_segment_info_test.cpp
@@ -47,7 +47,7 @@ namespace pos
 TEST(VersionedSegmentInfo, IncreaseValidBlockCount_testIfValidBlockCountIsIncreasedDecreasedAndReseted)
 {
     // Given
-    VersionedSegmentInfo versionedSegInfo;
+    VersionedSegmentInfo versionedSegInfo(1024);
 
     // When
     versionedSegInfo.IncreaseValidBlockCount(2, 3);
@@ -74,7 +74,7 @@ TEST(VersionedSegmentInfo, IncreaseValidBlockCount_testIfValidBlockCountIsIncrea
 TEST(VersionedSegmentInfo, IncreaseOccupiedStripeCount_testIfOccupiedStripeCountIsIncreasedAndReseted)
 {
     // Given
-    VersionedSegmentInfo versionedSegInfo;
+    VersionedSegmentInfo versionedSegInfo(1024);
 
     // When
     tbb::concurrent_unordered_map<SegmentId, tbb::atomic<int>> expectChangedOccupiedCount;
@@ -115,7 +115,7 @@ TEST(VersionedSegmentInfo, IncreaseValidBlockCount_testIfValidBlockCountIsIncrea
     std::vector<std::thread> threadList;
     boost::barrier barrierToWait(numThread);
 
-    VersionedSegmentInfo versionedSegInfo;
+    VersionedSegmentInfo versionedSegInfo(1024);
     SegmentId targetSegmentId = 0;
 
     // When
@@ -157,7 +157,7 @@ TEST(VersionedSegmentInfo, IncreaseValidBlockCount_testIfValidBlockCountIsIncrea
     std::vector<std::thread> threadList;
     boost::barrier barrierToWait(numThread);
 
-    VersionedSegmentInfo versionedSegInfo;
+    VersionedSegmentInfo versionedSegInfo(1024);
     SegmentId targetSegmentId = 0;
 
     // When
@@ -192,5 +192,58 @@ TEST(VersionedSegmentInfo, IncreaseValidBlockCount_testIfValidBlockCountIsIncrea
 
     // Then
     EXPECT_EQ(true, versionedSegInfo.GetChangedValidBlockCount().empty());
+}
+
+TEST(VersionedSegmentInfo, ISegmentCtx_testIfCountChangesWhenCalledByISegmentCtxInterfaces)
+{
+    // Given
+    VersionedSegmentInfo versionedSegInfo(1024);
+
+    {
+        // When 1. Update Valid Block Count
+        {
+            auto blks = VirtualBlks{
+                .startVsa = {.stripeId = 100, .offset = 0},
+                .numBlks = 5};
+            versionedSegInfo.ValidateBlks(blks);
+        }
+
+        {
+            auto blks = VirtualBlks{
+                .startVsa = {.stripeId = 2030, .offset = 0},
+                .numBlks = 10};
+            versionedSegInfo.InvalidateBlks(blks, false);
+        }
+
+        // Then
+        tbb::concurrent_unordered_map<SegmentId, tbb::atomic<int>> expectChangedValidCount;
+        expectChangedValidCount[0] = 5;
+        expectChangedValidCount[1] = -10;
+
+        auto var = versionedSegInfo.GetChangedValidBlockCount();
+
+        EXPECT_EQ(expectChangedValidCount[0], var[0]);
+        EXPECT_EQ(expectChangedValidCount[1], var[1]);
+    }
+
+    {
+        // When 2. Update Occupied Stripe Count
+        versionedSegInfo.UpdateOccupiedStripeCount(10);
+        versionedSegInfo.UpdateOccupiedStripeCount(11);
+        versionedSegInfo.UpdateOccupiedStripeCount(12);
+
+        versionedSegInfo.UpdateOccupiedStripeCount(1026);
+        versionedSegInfo.UpdateOccupiedStripeCount(1027);
+
+        // Then
+        tbb::concurrent_unordered_map<SegmentId, tbb::atomic<uint32_t>> expectChangedOccupiedStripeCount;
+        expectChangedOccupiedStripeCount[0] = 3;
+        expectChangedOccupiedStripeCount[1] = 2;
+
+        auto var = versionedSegInfo.GetChangedOccupiedStripeCount();
+
+        EXPECT_EQ(expectChangedOccupiedStripeCount[0], var[0]);
+        EXPECT_EQ(expectChangedOccupiedStripeCount[1], var[1]);
+    }
 }
 } // namespace pos

--- a/test/unit-tests/journal_manager/log_write/i_journal_volume_event_handler_mock.h
+++ b/test/unit-tests/journal_manager/log_write/i_journal_volume_event_handler_mock.h
@@ -12,6 +12,7 @@ public:
     using IJournalVolumeEventHandler::IJournalVolumeEventHandler;
     MOCK_METHOD(int, WriteVolumeDeletedLog, (int volId), (override));
     MOCK_METHOD(int, TriggerMetadataFlush, (), (override));
+    MOCK_METHOD(ISegmentCtx*, AllocateSegmentCtxToUse, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/journal_manager/log_write/journal_volume_event_handler_mock.h
+++ b/test/unit-tests/journal_manager/log_write/journal_volume_event_handler_mock.h
@@ -10,7 +10,7 @@ class MockJournalVolumeEventHandler : public JournalVolumeEventHandler
 {
 public:
     using JournalVolumeEventHandler::JournalVolumeEventHandler;
-    MOCK_METHOD(void, Init, (LogWriteContextFactory* logFactory, CheckpointManager* cpManager, DirtyMapManager* dirtyManager, LogWriteHandler* logWritter, JournalConfiguration* journalConfiguration, IContextManager* contextManager, EventScheduler* scheduler), (override));
+    MOCK_METHOD(void, Init, (LogWriteContextFactory * logFactory, CheckpointManager* cpManager, DirtyMapManager* dirtyManager, LogWriteHandler* logWritter, JournalConfiguration* journalConfiguration, IContextManager* contextManager, EventScheduler* scheduler, uint32_t numStripesPerSegment), (override));
     MOCK_METHOD(int, WriteVolumeDeletedLog, (int volId), (override));
     MOCK_METHOD(int, TriggerMetadataFlush, (), (override));
     MOCK_METHOD(void, MetaFlushed, (), (override));

--- a/test/unit-tests/journal_manager/replay/replay_block_map_update_mock.h
+++ b/test/unit-tests/journal_manager/replay/replay_block_map_update_mock.h
@@ -13,6 +13,8 @@ class MockReplayBlockMapUpdate : public ReplayBlockMapUpdate
 public:
     using ReplayBlockMapUpdate::ReplayBlockMapUpdate;
     MOCK_METHOD(int, Replay, (), (override));
+    MOCK_METHOD(ReplayEventType, GetType, (), (override));
+    MOCK_METHOD(void, MarkNotToReplayMap, (), (override));
 };
 
 } // namespace pos

--- a/test/unit-tests/journal_manager/replay/replay_block_map_update_test.cpp
+++ b/test/unit-tests/journal_manager/replay/replay_block_map_update_test.cpp
@@ -177,7 +177,7 @@ TEST(ReplayBlockMapUpdate, Replay_testIfOldBlockIsInvalidated)
                 .stripeId = 200,
                 .offset = startVsa.offset + offset},
             .numBlks = 1};
-        EXPECT_CALL(segmentCtx, InvalidateBlks(blksToInvalidate, true)).Times(1);
+        EXPECT_CALL(segmentCtx, InvalidateBlks(blksToInvalidate, false)).Times(1);
     }
     EXPECT_CALL(stripeReplayStatus, BlockInvalidated).Times(numBlks);
 

--- a/test/unit-tests/journal_manager/replay/replay_stripe_test.cpp
+++ b/test/unit-tests/journal_manager/replay/replay_stripe_test.cpp
@@ -5,6 +5,7 @@
 #include "test/unit-tests/journal_manager/replay/replay_event_factory_mock.h"
 #include "test/unit-tests/journal_manager/replay/replay_event_mock.h"
 #include "test/unit-tests/journal_manager/statistics/stripe_replay_status_mock.h"
+#include "test/unit-tests/journal_manager/replay/replay_block_map_update_mock.h"
 
 using ::testing::NiceMock;
 using ::testing::Return;
@@ -191,7 +192,7 @@ TEST(ReplayStripe, GetVolumeId_testIfExecutedSuccessfully)
     EXPECT_EQ(expected, actual);
 }
 
-TEST(ReplayStripe, DeleteBlockMapReplayEvents_testIfAllBlockEventsDeleted)
+TEST(ReplayStripe, MarkBlockMapUpdateToSkip_testIfAllBlockEventsDeleted)
 {
     // Given
     NiceMock<MockStripeReplayStatus>* status = new NiceMock<MockStripeReplayStatus>;
@@ -200,8 +201,9 @@ TEST(ReplayStripe, DeleteBlockMapReplayEvents_testIfAllBlockEventsDeleted)
 
     for (int count = 0; count < 5; count++)
     {
-        NiceMock<MockReplayEvent>* replayEvent = new NiceMock<MockReplayEvent>;
+        NiceMock<MockReplayBlockMapUpdate>* replayEvent = new NiceMock<MockReplayBlockMapUpdate>;
         EXPECT_CALL(*replayEvent, GetType).WillOnce(Return(ReplayEventType::BLOCK_MAP_UPDATE));
+        EXPECT_CALL(*replayEvent, MarkNotToReplayMap).Times(1);
         replayEvents.push_back(replayEvent);
     }
 
@@ -211,12 +213,11 @@ TEST(ReplayStripe, DeleteBlockMapReplayEvents_testIfAllBlockEventsDeleted)
 
     // When
     ReplayStripeSpy stripe(nullptr, nullptr, nullptr, nullptr, status, factory, &replayEvents);
-    stripe.DeleteBlockMapReplayEvents();
+    stripe.MarkBlockMapUpdateToSkip();
 
     // Then
     auto actual = stripe.GetReplayEventList();
-    EXPECT_EQ(actual.size(), 1);
-    EXPECT_EQ(actual.front(), stripeFlushReplayEvent);
+    EXPECT_EQ(actual.back(), stripeFlushReplayEvent);
 }
 
 TEST(ReplayStripe, _CreateSegmentAllocationEvent_testIfEventAddedToTheFront)

--- a/test/unit-tests/metadata/metadata_test.cpp
+++ b/test/unit-tests/metadata/metadata_test.cpp
@@ -14,6 +14,7 @@
 #include "test/unit-tests/metafs/include/metafs_mock.h"
 #include "test/unit-tests/state/interface/i_state_control_mock.h"
 #include "test/unit-tests/allocator/i_segment_ctx_mock.h"
+#include "test/unit-tests/allocator/context_manager/segment_ctx/segment_ctx_mock.h"
 
 using ::testing::_;
 using ::testing::InSequence;
@@ -94,12 +95,12 @@ TEST(Metadata, Init_testIfEverySequenceIsInitialized)
     NiceMock<MockMetaFs> metaFs;
     NiceMock<MockMetaService> metaService;
     NiceMock<MockIContextManager> contextManager;
-    NiceMock<MockISegmentCtx> segmentCtx;
+    NiceMock<MockSegmentCtx> segmentCtx;
 
     ON_CALL(arrayInfo, GetName).WillByDefault(Return("POSArray"));
     ON_CALL(arrayInfo, GetIndex).WillByDefault(Return(0));
     ON_CALL(*allocator, GetIContextManager).WillByDefault(Return(&contextManager));
-    ON_CALL(*allocator, GetISegmentCtx).WillByDefault(Return(&segmentCtx));
+    ON_CALL(contextManager, GetSegmentCtx).WillByDefault(Return(&segmentCtx));
 
     Metadata meta(&arrayInfo, mapper, allocator, journal, &metaFs, &metaService);
 


### PR DESCRIPTION
Volume Deletion으로 인해 발생한 segmentCtx 변경점(valid block count 감소분)을 안전하게 checkpoint 하기 위한 변경점 입니다.

코드 수정점은 다음과 같습니다.

1. Volume Deletion 시 mapper의 invalidateBlks를 segmentCtx에 직접 하지 않도록 수정
: VersionedSegmentInfo를 ISegmentCtx 상속받도록 하고, delete 용 VersionedSegmentInfo를 생성하고 이를 mapper에게 전달하여 여기에 업데이트

2. Volume Delete 으로 인한 checkpoint 시 1번에서 기록된 변경점만 반영하여 SegmentCtx flush
: Last checkpointed segment context + Volume deletion으로 인한 diff 반영한 것을 flush 함

3. Checkpoint가 일어나기 전에 Volume Delete이 발생하면 음수의 Valid Block Count가 SegmentCtx에 저장될 수 있음
: 저장되는 SegmentInfo의 uint32_t 타입을 int로 변경

4. Load 된 Segment Context 의 Valid Block Count가 음수인 상태에서 replay가 진행되면, 무조건 underflow가 발생함
: Replay 중에는 Underflow 확인하지 않도록 변경 필요, State 전환도 replay 끝나고 한 번에 업데이트(ResetSegmentState) 하도록 수정

5. Volume Deletion이 되더라도 Segment Info는 Replay 해야 함
: 기존에는 volume delete 된 경우 해당 BlockMapUpdate는 모두 skip 했는데, 지금은 segmentInfo는 Replay 해야 하는 상황 (checkpoint 되지 않았다면 그 변경점은 반영되어 있지 않기 때문) -> Map Update만 skip 하도록 수정