### PR TITLE
[AWIBOF-8218] Change swap policy for free buffer pool

### DIFF
--- a/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_ctx.cpp
@@ -705,7 +705,7 @@ SegmentCtx::_SegmentFreed(SegmentId segmentId)
         return;
     }
 
-    EventSmartPtr segmentFreedUpdateRequest(new SegmentFreedUpdateRequest(this, segmentId, addrInfo->GetArrayId()));
+    CallbackSmartPtr segmentFreedUpdateRequest(new SegmentFreedUpdateRequest(this, segmentId, addrInfo->GetArrayId()));
     eventScheduler->EnqueueEvent(segmentFreedUpdateRequest);
 }
 

--- a/src/allocator/context_manager/segment_ctx/segment_freed_update_request.cpp
+++ b/src/allocator/context_manager/segment_ctx/segment_freed_update_request.cpp
@@ -49,7 +49,8 @@ SegmentFreedUpdateRequest::SegmentFreedUpdateRequest(SegmentCtx* segmentCtx, Seg
 
 SegmentFreedUpdateRequest::SegmentFreedUpdateRequest(SegmentCtx* segmentCtx, SegmentId targetSegmentId,
     IMetaUpdater* metaUpdater)
-: segmentCtx(segmentCtx),
+: Callback(false, CallbackType_BackendLogWriteDone),
+  segmentCtx(segmentCtx),
   targetSegmentId(targetSegmentId),
   metaUpdater(metaUpdater)
 {
@@ -73,7 +74,7 @@ SegmentFreedUpdateRequest::GetTargetSegmentId(void)
 }
 
 bool
-SegmentFreedUpdateRequest::Execute(void)
+SegmentFreedUpdateRequest::_DoSpecificJob(void)
 {
     int result = metaUpdater->UpdateFreedSegmentContext(segmentCtx, targetSegmentId);
     if (result != 0)

--- a/src/allocator/context_manager/segment_ctx/segment_freed_update_request.h
+++ b/src/allocator/context_manager/segment_ctx/segment_freed_update_request.h
@@ -44,7 +44,7 @@ namespace pos
 {
 class VolumeIo;
 
-class SegmentFreedUpdateRequest : public Event
+class SegmentFreedUpdateRequest : public Callback
 {
 public:
     SegmentFreedUpdateRequest(SegmentCtx* segmentCtx, SegmentId targetSegmentId, int arrayIdInput);
@@ -56,7 +56,7 @@ public:
     SegmentId GetTargetSegmentId(void);
 
 private:
-    bool Execute(void) override;
+    virtual bool _DoSpecificJob(void) override;
 
     SegmentCtx* segmentCtx;
     SegmentId targetSegmentId;

--- a/src/resource_manager/buffer_pool.h
+++ b/src/resource_manager/buffer_pool.h
@@ -82,7 +82,7 @@ private:
     std::mutex producerLock;
     bool isAllocated = false;
     size_t swapThreshold = 0;
-    const static size_t SWAP_THRESHOLD_PERCENT = 25;
+    const static size_t SWAP_THRESHOLD_PERCENT = 0;
 };
 
 } // namespace pos


### PR DESCRIPTION
Why:
    - Fix assert error caused by buffer pool swap policy
    - Prevent abnormal termination caused by insufficient buffer pool
    
What:
    - Reduce threshold to 0 for swapping producer and consumer pools in buffer pool
    - Fix to swap unconditionally when requesting a free buffer pool if size of the consumer pool is 0 and the producer pool is at least 1
    
Trade-offs:
    - Increased swap overhead and potential performance degradation
    
Testing:
    - Conducted long-term test to verify that it works when many parity pools are needed in the GC flush
    
This commit address an assert error that occurred when allocate free buffer, when requesting a free buffer pool, if the consumer pool had no available buffers but the producer pool had also less than 25% of its total capacity available, an assert error would occur.