### PR TITLE
[AWIBOF-7879] Enable Versioned Segment Context by default

### DIFF
--- a/config/ibofos_for_perf_ci.conf
+++ b/config/ibofos_for_perf_ci.conf
@@ -6,7 +6,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/ibofos_for_perf_ci_single_numa.conf
+++ b/config/ibofos_for_perf_ci_single_numa.conf
@@ -6,7 +6,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/ibofos_for_perf_psd.conf
+++ b/config/ibofos_for_perf_psd.conf
@@ -6,7 +6,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/ibofos_for_perf_psd_200GB.conf
+++ b/config/ibofos_for_perf_psd_200GB.conf
@@ -6,7 +6,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/ibofos_for_psd_ci.conf
+++ b/config/ibofos_for_psd_ci.conf
@@ -6,7 +6,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/ibofos_for_psd_ci_wt.conf
+++ b/config/ibofos_for_psd_ci_wt.conf
@@ -6,7 +6,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/ibofos_for_vm_ci.conf
+++ b/config/ibofos_for_vm_ci.conf
@@ -6,7 +6,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/ibofos_for_vm_ci_wt.conf
+++ b/config/ibofos_for_vm_ci_wt.conf
@@ -6,7 +6,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/pos.conf
+++ b/config/pos.conf
@@ -5,7 +5,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/pos_for_aws.conf
+++ b/config/pos_for_aws.conf
@@ -6,7 +6,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/pos_for_ha_primary_psd.conf
+++ b/config/pos_for_ha_primary_psd.conf
@@ -5,7 +5,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/pos_for_ha_secondary_psd.conf
+++ b/config/pos_for_ha_secondary_psd.conf
@@ -5,7 +5,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/pos_for_pm_qos.conf
+++ b/config/pos_for_pm_qos.conf
@@ -6,7 +6,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/pos_multi_array_fast_sustain_perf.conf
+++ b/config/pos_multi_array_fast_sustain_perf.conf
@@ -5,7 +5,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/pos_multi_array_normal.conf
+++ b/config/pos_multi_array_normal.conf
@@ -6,7 +6,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,

--- a/config/pos_multi_array_perf.conf
+++ b/config/pos_multi_array_perf.conf
@@ -6,7 +6,7 @@
         "number_of_log_groups": 2,
         "debug_mode": false,
         "interval_in_msec_for_metric": 1000,
-        "enable_vsc": false
+        "enable_vsc": true
    },
    "flush": {
         "enable": false,


### PR DESCRIPTION
Why:
- Ensure correct replay of segment context after SPO during the checkpoint
- Prevent overflow or underflow of valid block count and occupied segment count

What:
- Modify config to enable Versioned Segment Context by default

This commit modifies the code to enable Versioned Segment Context (VSC) by default. When VSC is disabled and an SPO occurs during checkpoint, the segment context may be double replayed because the most recent SegmentContext can be flushed along with the log group being checkpointed. This can cause valid block count and occupied stripe count to overflow or underflow during replay. By enabling VSC by default, we can ensure that the correct segment context is reconstructed after an SPO checkpoint and prevent these issues from occurring