### PR TITLE
[AWIBOF-7875] Change the logic of searching RBA during bringup (#752)

### DIFF
--- a/src/event/pos_event.yaml
+++ b/src/event/pos_event.yaml
@@ -4836,6 +4836,13 @@ Root:
     Description: Protobuf has failed to serialize into byte stream.
     Cause: There may be an issue with protobuf version/usage.
     Solution: Developers must analyze the issue.
+  -
+    Id: 3252
+    Name: REVMAP_RBA_MISMATCH_BETWEEN_LOG_AND_INVMAP
+    Severity:
+    Description: Protobuf has failed to serialize into byte stream.
+    Cause:
+    Solution:
   
   # MapHeaderExtended: 3290 - 3299
   -

--- a/src/mapper/reversemap/reversemap_manager.cpp
+++ b/src/mapper/reversemap/reversemap_manager.cpp
@@ -211,30 +211,25 @@ int
 ReverseMapManager::ReconstructReverseMap(uint32_t volumeId, uint64_t totalRbaNum, uint32_t wblsid, uint32_t vsid, uint64_t blockCount, std::map<uint64_t, BlkAddr> revMapInfos, ReverseMapPack* revMapPack)
 {
     int ret = 0;
-    BlkAddr lastFoundRba = UINT64_MAX;
     POS_TRACE_INFO(EID(REVMAP_RECONSTRUCT_FOUND_RBA), "[ReconstructMap] START, volumeId:{}  wbLsid:{}  vsid:{}  blockCount:{}", volumeId, wblsid, vsid, blockCount);
 
+    // construct the map of stripe id to offset to rba
+    if (!invertedMap[volumeId].size())
+    {
+        _ConstructInvertedMap(volumeId, totalRbaNum);
+    }
+
+    // verify
+    _CheckInvertedMapValid(volumeId, vsid, revMapInfos);
+
+    // look up rba
     for (uint64_t offset = 0; offset < blockCount; offset++)
     {
-        if (revMapInfos.find(offset) == revMapInfos.end())
+        auto foundRba = _FindRba(volumeId, {vsid, offset});
+        if (foundRba.first)
         {
-            // Set the RBA to start finding
-            BlkAddr rbaStart = 0;
-            if (lastFoundRba != UINT64_MAX)
-            {
-                rbaStart = lastFoundRba + 1;
-            }
-
-            BlkAddr foundRba = INVALID_RBA;
-            bool found = _FindRba(volumeId, totalRbaNum, vsid, wblsid, offset, rbaStart, foundRba);
-            if (found == false)
-            {
-                continue;
-            }
-            revMapInfos.insert(make_pair(offset, foundRba));
-            lastFoundRba = foundRba;
+            revMapPack->SetReverseMapEntry(offset, foundRba.second, volumeId);
         }
-        revMapPack->SetReverseMapEntry(offset, revMapInfos[offset], volumeId);
     }
 
     POS_TRACE_INFO(EID(REVMAP_RECONSTRUCT_FOUND_RBA), "[ReconstructMap] {}/{} blocks are reconstructed for Stripe(wbLsid:{})", revMapInfos.size(), blockCount, wblsid);
@@ -253,45 +248,49 @@ ReverseMapManager::StoreReverseMapForWBT(uint64_t offset, uint64_t fileSize, cha
     return revMapWholefile->IssueIO(MetaFsIoOpcode::Write, offset, fileSize, buf);
 }
 
-bool
-ReverseMapManager::_FindRba(uint32_t volumeId, uint64_t totalRbaNum, StripeId vsid, StripeId wblsid, uint64_t offset, BlkAddr rbaStart, BlkAddr& foundRba)
+std::pair<bool, BlkAddr>
+ReverseMapManager::_FindRba(const uint32_t volumeId, const VirtualBlkAddr addr)
 {
-    assert(totalRbaNum > 0);
-
-    bool looped = false;
-    for (BlkAddr rbaToCheck = rbaStart; rbaToCheck <= totalRbaNum; ++rbaToCheck)
+    auto result = invertedMap[volumeId][addr.stripeId].find((uint64_t)addr.offset);
+    if (result == invertedMap[volumeId][addr.stripeId].end())
     {
-        // If rbaToCheck exceeds more than totalRbaNum, looped would be set as TRUE
-        if (rbaToCheck == totalRbaNum)
-        {
-            rbaToCheck = 0;
-            looped = true;
-        }
-
-        if ((rbaToCheck == rbaStart) && looped)
-        {
-            return false;
-        }
-
-        // Usually map is opened before, but exception exists in replay time.
-        // Map will be opened synchronously here only in replay time which is okay.
-        VirtualBlkAddr vsaToCheck = iVSAMap->GetVSAWithSyncOpen(volumeId, rbaToCheck);
-        if (vsaToCheck == UNMAP_VSA || vsaToCheck.offset != offset || vsaToCheck.stripeId != vsid)
-        {
-            continue;
-        }
-
-        StripeAddr lsaToCheck = iStripeMap->GetLSA(vsaToCheck.stripeId);
-        if (iStripeMap->IsInUserDataArea(lsaToCheck) || lsaToCheck.stripeId != wblsid)
-        {
-            continue;
-        }
-
-        foundRba = rbaToCheck;
-        return true;
+        return {false, -1};
     }
+    return {true, result->second};
+}
 
-    return false;
+void
+ReverseMapManager::_ConstructInvertedMap(const uint32_t volumeId, const uint64_t totalRbaNum)
+{
+    for (uint64_t rba = 0; rba < totalRbaNum; rba++)
+    {
+        auto vsaToCheck = iVSAMap->GetVSAWithSyncOpen(volumeId, rba);
+        if (vsaToCheck == UNMAP_VSA)
+        {
+            continue;
+        }
+        invertedMap[volumeId][vsaToCheck.stripeId].insert({(uint64_t)vsaToCheck.offset, rba});
+    }
+}
+
+void
+ReverseMapManager::_CheckInvertedMapValid(const uint32_t volumeId, const uint32_t vsid, const std::map<uint64_t, BlkAddr> revMapInfos)
+{
+    auto iter = revMapInfos.begin();
+    while (iter != revMapInfos.end())
+    {
+        auto rbaInLog = iter->second;
+        auto blockOffsetInTheStripe = iter->first;
+        auto result = invertedMap[volumeId][vsid].find(blockOffsetInTheStripe);
+        if (result != invertedMap[volumeId][vsid].end() && result->second != rbaInLog)
+        {
+            POS_TRACE_ERROR(EID(REVMAP_RBA_MISMATCH_BETWEEN_LOG_AND_INVMAP),
+                "RBA cannot be found, vsid:{}, result->second:{}, rbaInLog:{}",
+                vsid, result->second, rbaInLog);
+            assert(false);
+        }
+        ++iter;
+    }
 }
 
 void

--- a/src/mapper/reversemap/reversemap_manager.h
+++ b/src/mapper/reversemap/reversemap_manager.h
@@ -45,6 +45,8 @@
 #include "src/meta_file_intf/meta_file_include.h"
 #include "src/volume/i_volume_info_manager.h"
 
+using namespace std;
+
 namespace pos
 {
 class TelemetryPublisher;
@@ -70,6 +72,12 @@ public:
     virtual int LoadReverseMapForWBT(uint64_t offset, uint64_t fileSize, char* buf);
     virtual int StoreReverseMapForWBT(uint64_t offset, uint64_t fileSize, char* buf);
 
+    // for test
+    unordered_map<uint32_t, unordered_map<uint32_t, unordered_map<uint64_t, uint64_t>>> GetInvertedMap(void)
+    {
+        return invertedMap;
+    }
+
 private:
     struct IoCount
     {
@@ -87,6 +95,9 @@ private:
     uint64_t _GetFileOffset(StripeId vsid);
     ReverseMapIo* _CreateIoContext(ReverseMapPack* rev, EventSmartPtr cb, IoDirection dir);
     void _ReverseMapIoDone(ReverseMapIo* reverseMapIo);
+    void _ConstructInvertedMap(const uint32_t volumeId, const uint64_t totalRbaNum);
+    void _CheckInvertedMapValid(const uint32_t volumeId, const uint32_t vsid, const std::map<uint64_t, BlkAddr> revMapInfos);
+    std::pair<bool, BlkAddr> _FindRba(const uint32_t volumeId, const VirtualBlkAddr addr);
 
     uint64_t numMpagesPerStripe; // It depends on block count per a stripe
     uint64_t fileSizePerStripe;
@@ -102,6 +113,9 @@ private:
     MapperAddressInfo* addrInfo;
     TelemetryPublisher* telemetryPublisher;
     bool rocksDbEnabled;
+
+    /* { volid, { vsid, { offset in vsid, rba }}} */
+    unordered_map<uint32_t, unordered_map<uint32_t, unordered_map<uint64_t, uint64_t>>> invertedMap;
 };
 
 } // namespace pos


### PR DESCRIPTION
- steps
 = construct inverted map from the latest vsamap
 = verify revMapInfos from the log buffer
 = look up the rba