### PR TITLE
[AWIBOF-8234] fix logging issue on gc mode changing

### DIFF
--- a/src/allocator/context_manager/gc_ctx/gc_ctx.cpp
+++ b/src/allocator/context_manager/gc_ctx/gc_ctx.cpp
@@ -129,7 +129,7 @@ GcCtx::_PrintInfo(pos::GcMode newGcMode, uint32_t numFreeSegments)
     if (curGcMode != newGcMode)
     {
         POS_TRACE_INFO(EID(ALLOCATOR_CURRENT_GC_MODE),
-            "Change GC STATE from GCState:{} to {}}",
+            "Change GC STATE from GCState:{} to {}",
             (uint32_t)curGcMode, (uint32_t)newGcMode);
 
         // TODO (dh.ihm) want to print out this here...


### PR DESCRIPTION
gc mode 변경시 로깅이 되지 않는 현상 수정
'}' 기호가 오타로 2개들어가 발생함