### PR TITLE
[AWIBOF-8258] Do not acquire allocCtxLock and activeStripeTailLock in wrong seqeunce

### DIFF
--- a/src/allocator/context_manager/allocator_ctx/allocator_ctx.cpp
+++ b/src/allocator/context_manager/allocator_ctx/allocator_ctx.cpp
@@ -202,16 +202,18 @@ AllocatorCtx::AfterLoad(char* buf)
 void
 AllocatorCtx::BeforeFlush(char* buf, ContextSectionBuffer externalBuf)
 {
-    std::lock_guard<std::mutex> lock(allocCtxLock);
+    {
+        std::lock_guard<std::mutex> lock(allocCtxLock);
 
-    // AC_HEADER
-    ctxHeader.data.ctxVersion = ctxDirtyVersion++;
-    ctxHeader.data.numValidWbLsid = allocWbLsidBitmap.data->GetNumBitsSetWoLock();
+        // AC_HEADER
+        ctxHeader.data.ctxVersion = ctxDirtyVersion++;
+        ctxHeader.data.numValidWbLsid = allocWbLsidBitmap.data->GetNumBitsSetWoLock();
 
-    ctxHeader.CopyTo(buf);
+        ctxHeader.CopyTo(buf);
 
-    // AC_CURRENT_SSD_LSID
-    currentSsdLsid.CopyTo(buf);
+        // AC_CURRENT_SSD_LSID
+        currentSsdLsid.CopyTo(buf);
+    }
 
     // AC_ALLOCATE_WBLSID_BITMAP
     {


### PR DESCRIPTION

Lock allocCtxLock and then lock activeStripeTailLock may introduce deadlock as these locks can be acquired in a reverse order.

When copying data for flush(BeforeFlush), we don't have to acquire both locks at the same time, so removing this overlap