### PR TITLE
[AWIBOF-8131] Busy wait code

### DIFF
--- a/src/io/frontend_io/write_submission.cpp
+++ b/src/io/frontend_io/write_submission.cpp
@@ -117,7 +117,21 @@ WriteSubmission::Execute(void)
         {
             return false;
         }
+
         int token = flowControl->GetToken(FlowControlType::USER, blockCount);
+        auto start = std::chrono::high_resolution_clock::now();
+        while (0 >= token)
+        {
+            usleep(1);
+            token = flowControl->GetToken(FlowControlType::USER, blockCount);
+
+            auto end = std::chrono::high_resolution_clock::now();
+            auto taken = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+            if (taken > BWAIT_MAX)
+            {
+                break;
+            }
+        }
         if (0 >= token)
         {
             return false;

--- a/src/io/frontend_io/write_submission.h
+++ b/src/io/frontend_io/write_submission.h
@@ -81,6 +81,7 @@ private:
     IBlockAllocator* iBlockAllocator;
     FlowControl* flowControl;
     IVolumeInfoManager* volumeManager;
+    const uint32_t BWAIT_MAX = 10000;
 
     void _SendVolumeIo(VolumeIoSmartPtr volumeIo);
     bool _ProcessOwnedWrite(void);


### PR DESCRIPTION
Small amount of busy wait code on the write submission path to improve GC performance. Limited to 10 microseconds for now. May need to be expanded in the future to adapt to the workload.