### PR TITLE
[AWIBOF-8284] stack trace with boost library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ LDFLAGS += -L$(OTEL_ROOT_DIR)/lib \
 				-lopentelemetry_resources \
 				-lopentelemetry_common \
 				-lopentelemetry_http_client_curl \
-				-lpthread -lcurl
+				-lpthread -lcurl -lbacktrace
 DEFINE += -DHAVE_ABSEIL
 
 CXXFLAGS += $(INCLUDE)

--- a/src/signal_handler/signal_handler.h
+++ b/src/signal_handler/signal_handler.h
@@ -64,15 +64,10 @@ private:
     void _BacktraceAndInvokeNextThread(int sig);
     void _Backtrace(void);
     void _ShutdownProcess(void);
-    bool _RunSystemCmdAndGetResult(char* cmdStr, char* resultStr);
     void _Log(std::string logMsg, bool printTimeStamp = true);
     std::list<long> threadList;
     std::atomic<uint32_t> pendingThreads;
     static const long ATOI_ERR = 0;
-    static const int MAX_CALL_STACK = 100;
-    static const int FILE_NAME_LINE = 300;
-    std::atomic<bool> listUpdated;
-    std::atomic<int> dominantSignal;
     FILE* btLogFilePtr;
     std::mutex signalMutex;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -498,7 +498,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(PROTOBUF REQUIRED protobuf)
 pkg_check_modules(GRPC REQUIRED grpc++)
 
-list(APPEND DEP_LIBRARIES opentelemetry_common opentelemetry_trace opentelemetry_exporter_otlp_http opentelemetry_exporter_otlp_http_client opentelemetry_otlp_recordable opentelemetry_proto opentelemetry_resources opentelemetry_http_client_curl pthread curl)
+list(APPEND DEP_LIBRARIES opentelemetry_common opentelemetry_trace opentelemetry_exporter_otlp_http opentelemetry_exporter_otlp_http_client opentelemetry_otlp_recordable opentelemetry_proto opentelemetry_resources opentelemetry_http_client_curl pthread curl backtrace)
 list(APPEND DEP_LIBRARIES ${PROTOBUF_LIBRARIES} ${GRPC_LIBRARIES})
 list(APPEND DEP_LIBRARIES grpc++_reflection)
 list(APPEND DEP_LIBRARIES boost_system boost_thread)


### PR DESCRIPTION
- previous stacktrace in pos was implemented with "glibc"
- we change from glibc to boost library. its library has high performance for printing backtrace and file linenumber