### PR TITLE
Bugfix/awibof 8317 gc hang bugfix

### DIFF
--- a/src/gc/flow_control/flow_control.cpp
+++ b/src/gc/flow_control/flow_control.cpp
@@ -207,10 +207,18 @@ FlowControl::GetToken(FlowControlType type, int token)
     freeSegments = segmentCtx->GetNumOfFreeSegmentWoLock();
     if (freeSegments > gcThreshold)
     {
+        if(true == systemTimeoutChecker->IsActive())
+        {
+            systemTimeoutChecker->Reset();
+        }
         return token;
     }
     int oldBucket = bucket[type].load();
     int counterType = type ^ 0x1;
+    if (false == systemTimeoutChecker->IsActive())
+    {
+        systemTimeoutChecker->SetTimeout(flowControlConfiguration->GetForceResetTimeout());
+    }
     do
     {
         if (oldBucket <= 0)

--- a/src/gc/flow_control/flow_control.cpp
+++ b/src/gc/flow_control/flow_control.cpp
@@ -207,7 +207,7 @@ FlowControl::GetToken(FlowControlType type, int token)
     freeSegments = segmentCtx->GetNumOfFreeSegmentWoLock();
     if (freeSegments > gcThreshold)
     {
-        if(true == systemTimeoutChecker->IsActive())
+        if (true == systemTimeoutChecker->IsActive())
         {
             systemTimeoutChecker->Reset();
         }

--- a/src/lib/system_timeout_checker.h
+++ b/src/lib/system_timeout_checker.h
@@ -46,7 +46,7 @@ public:
     virtual bool CheckTimeout(void);
     uint64_t Elapsed(void);
     void Reset(void);
-    bool IsActive(void);
+    virtual bool IsActive(void);
 
 private:
     bool isActive = false;

--- a/test/unit-tests/gc/flow_control/flow_control_test.cpp
+++ b/test/unit-tests/gc/flow_control/flow_control_test.cpp
@@ -301,6 +301,7 @@ TEST_F(FlowControlTestFixture, GetToken_testForceRefill)
     // When: number of free segments < gc normal threshold, fails to get token
     EXPECT_CALL(*mockSegmentCtx, GetNumOfFreeSegmentWoLock()).WillRepeatedly(Return(15));
     EXPECT_CALL(*mockTokenDistributer, Distribute(15)).WillOnce(Return(std::make_tuple(0, 100)));
+    ON_CALL(*mockSystemTimeoutChecker, IsActive()).WillByDefault(Return(true));
     // Then: try to forceReset & refill token
     FlowControlType type = FlowControlType::USER;
     int expected, token, actual;

--- a/test/unit-tests/lib/system_timeout_checker_mock.h
+++ b/test/unit-tests/lib/system_timeout_checker_mock.h
@@ -14,6 +14,7 @@ public:
     using SystemTimeoutChecker::SystemTimeoutChecker;
     MOCK_METHOD(void, SetTimeout, (uint64_t nanoSecsLeftFromNow), (override));
     MOCK_METHOD(bool, CheckTimeout, (), (override));
+    MOCK_METHOD(bool, IsActive, (), (override));
 };
 
 } // namespace pos


### PR DESCRIPTION
[AWIBOF-8317] Bugfix gc hang by starting token refill timer when enters gc

    Gc hang occurs when only gc token is 0 during urgent gc. The reason
    was token refill timer started only when user and gc token were
    less then 0. Thus, we changed the logic of refill trigger time to start
    timer when POS enters gc. Both user/gc token will get refilled regulary
    during gc. When it is not, token refill timer will be turned off.