### PR TITLE
[AWIBOF-8317] Fix GC Hang Issue

### DIFF
--- a/src/gc/flow_control/flow_control.cpp
+++ b/src/gc/flow_control/flow_control.cpp
@@ -264,6 +264,13 @@ FlowControl::ReturnToken(FlowControlType type, int token)
         return;
     }
 
+    SegmentCtx* segmentCtx = iContextManager->GetSegmentCtx();
+    freeSegments = segmentCtx->GetNumOfFreeSegmentWoLock();
+    if (freeSegments > gcThreshold)
+    {
+        return;
+    }
+
     bucket[type].fetch_add(token);
 }
 

--- a/src/gc/flow_control/flow_control.cpp
+++ b/src/gc/flow_control/flow_control.cpp
@@ -211,6 +211,10 @@ FlowControl::GetToken(FlowControlType type, int token)
     }
     int oldBucket = bucket[type].load();
     int counterType = type ^ 0x1;
+    if (false == systemTimeoutChecker->IsActive())
+    {
+        systemTimeoutChecker->SetTimeout(flowControlConfiguration->GetForceResetTimeout());
+    }
     do
     {
         if (oldBucket <= 0)

--- a/src/lib/system_timeout_checker.h
+++ b/src/lib/system_timeout_checker.h
@@ -46,7 +46,7 @@ public:
     virtual bool CheckTimeout(void);
     uint64_t Elapsed(void);
     void Reset(void);
-    bool IsActive(void);
+    virtual bool IsActive(void);
 
 private:
     bool isActive = false;

--- a/test/unit-tests/gc/flow_control/flow_control_test.cpp
+++ b/test/unit-tests/gc/flow_control/flow_control_test.cpp
@@ -301,6 +301,7 @@ TEST_F(FlowControlTestFixture, GetToken_testForceRefill)
     // When: number of free segments < gc normal threshold, fails to get token
     EXPECT_CALL(*mockSegmentCtx, GetNumOfFreeSegmentWoLock()).WillRepeatedly(Return(15));
     EXPECT_CALL(*mockTokenDistributer, Distribute(15)).WillOnce(Return(std::make_tuple(0, 100)));
+    ON_CALL(*mockSystemTimeoutChecker, IsActive()).WillByDefault(Return(true));
     // Then: try to forceReset & refill token
     FlowControlType type = FlowControlType::USER;
     int expected, token, actual;

--- a/test/unit-tests/lib/system_timeout_checker_mock.h
+++ b/test/unit-tests/lib/system_timeout_checker_mock.h
@@ -14,6 +14,7 @@ public:
     using SystemTimeoutChecker::SystemTimeoutChecker;
     MOCK_METHOD(void, SetTimeout, (uint64_t nanoSecsLeftFromNow), (override));
     MOCK_METHOD(bool, CheckTimeout, (), (override));
+    MOCK_METHOD(bool, IsActive, (), (override));
 };
 
 } // namespace pos


### PR DESCRIPTION
원인은 Wite Submission에서 GetToken() 성공 후에 lock 실패 등의 이유로 다시 Return Token을 호출하여 User Bucket에 token을 add하는데, 이때 gc가 아닌 상황에도 조건없이 추가 되고 있었습니다. 
user token의 개수가 계속 많은 상태라 token refill이 trigger가 되지 않아 gc만 token을 계속 받지 못하고 있던 것으로 보입니다. 따라서 Token을 반환할 때 gc가 실행 중인지 확인하고, 실행 중일 때만 버킷에 토큰을 추가하도록 수정하였습니다.

When gc is not running, the token should not be added to user bucket, but it was added. Thus, when returning the Token, check whether the gc is running, and modify it to add token to the bucket only when it is running.