### PR TITLE
[AWIBOF-8371] fix invalid memory access

### DIFF
--- a/src/main/poseidonos.cpp
+++ b/src/main/poseidonos.cpp
@@ -228,8 +228,8 @@ Poseidonos::Terminate(void)
     }
     ArrayManagerSingleton::ResetInstance();
     AccelEngineApi::Finalize();
-    DeadLockCheckerSingleton::ResetInstance();
     SpdkCallerSingleton::Instance()->SpdkBdevPosUnRegisterPoller(UNVMfCompleteHandler);
+    DeadLockCheckerSingleton::ResetInstance();
     EventFrameworkApiSingleton::ResetInstance();
     SpdkSingleton::ResetInstance();
     IoTimeoutCheckerSingleton::ResetInstance();


### PR DESCRIPTION
- deadlock checker shall be destroyed after unregistering poller