### PR TITLE
[AWIBOF-8370] fix bug for deadlock in backtrace

### DIFF
--- a/src/lib/signal_mask.cpp
+++ b/src/lib/signal_mask.cpp
@@ -48,6 +48,7 @@ SignalMask::MaskSignal(int AllowedSignalNo, sigset_t* oldset)
     sigaddset(&set, SIGABRT);
     sigaddset(&set, SIGTERM);
     sigaddset(&set, SIGQUIT);
+    sigaddset(&set, SIGUSR1);
     sigdelset(&set, AllowedSignalNo);
     pthread_sigmask(SIG_BLOCK, &set, oldset);
 }
@@ -82,6 +83,7 @@ SignalMask::MaskSignal(sigset_t* oldset)
     sigaddset(&set, SIGABRT);
     sigaddset(&set, SIGTERM);
     sigaddset(&set, SIGQUIT);
+    sigaddset(&set, SIGUSR1);
     pthread_sigmask(SIG_BLOCK, &set, oldset);
 }
 


### PR DESCRIPTION
- when backtrace takes much time (> 10 seconds) there is possibility for nested backtrace,
- Because there is no blocking for SIGUSR1 (for deadlock checker).
- I add masking when abort / segfault / usr1 signal handling happend.