### PR TITLE
[SHPOS-1077] retry log is changed from error to debug

### DIFF
--- a/src/allocator/stripe_manager/stripe_manager.cpp
+++ b/src/allocator/stripe_manager/stripe_manager.cpp
@@ -93,7 +93,7 @@ StripeManager::AllocateGcDestStripe(uint32_t volumeId)
     StripeId arrayLsid = _AllocateSsdStripe();
     if (IsUnMapStripe(arrayLsid))
     {
-        POS_TRACE_ERROR(EID(ALLOCATOR_CANNOT_ALLOCATE_STRIPE), "failed to allocate gc stripe!");
+        POS_TRACE_DEBUG(EID(ALLOCATOR_CANNOT_ALLOCATE_STRIPE), "try again to allocate gc stripe");
         return nullptr;
     }
 

--- a/src/gc/flow_control/flow_control.cpp
+++ b/src/gc/flow_control/flow_control.cpp
@@ -74,11 +74,11 @@ FlowControl::FlowControl(IArrayInfo* arrayInfo,
 {
     if (arrayInfo != nullptr)
     {
-        RegisterDebugInfo("GC_FlowControl_Array" + std::to_string(arrayInfo->GetIndex()), 10000, true);
+        RegisterDebugInfo("GC_FlowControl_Array" + std::to_string(arrayInfo->GetIndex()), 50000, true);
     }
     else
     {
-        RegisterDebugInfo("GC_FlowControl", 10000, true);
+        RegisterDebugInfo("GC_FlowControl", 50000, true);
     }
 }
 


### PR DESCRIPTION
Error log indicates as standard output, which reduce the performance. To reduce this, we delete error log.